### PR TITLE
Generic Events: using Callables as event conditions, for general-purpose condition building

### DIFF
--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -800,6 +800,12 @@ class BaseComponent(lifecycle.Node):
                 self.destroy_publisher(bridge_pub)
             self.__bridge_publishers = {}
 
+        # Destroy all publishers created for event bridging
+        if hasattr(self, "_bridge_publishers"):
+            for bridge_pub in self.__bridge_publishers.values():
+                self.destroy_publisher(bridge_pub)
+            self.__bridge_publishers = {}
+
     def destroy_all_services(self):
         """
         Destroys all node services

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -155,6 +155,7 @@ class BaseComponent(lifecycle.Node):
         self.__events: Optional[List[Event]] = None
         self.__actions: Optional[List[List[Action]]] = None
         self.__event_listeners: List[Subscription] = []
+        self.__bridge_publishers: Dict[str, ROSPublisher] = {}
 
         # To manage algorithms config
         self._algorithms_config: Dict[
@@ -761,6 +762,8 @@ class BaseComponent(lifecycle.Node):
         if hasattr(self, "_execution_timer"):
             self.get_logger().info("DESTROYING MAIN TIMER")
             self.destroy_timer(self._execution_timer)
+        for timer in getattr(self, "__action_event_timers", []):
+            self.destroy_timer(timer)
 
     def destroy_all_subscribers(self):
         """
@@ -788,6 +791,12 @@ class BaseComponent(lifecycle.Node):
         for publisher in self.publishers_dict.values():
             if publisher._publisher:
                 self.destroy_publisher(publisher._publisher)
+
+        # Destroy all publishers created for event bridging
+        if hasattr(self, "_bridge_publishers"):
+            for bridge_pub in self.__bridge_publishers.values():
+                self.destroy_publisher(bridge_pub)
+            self.__bridge_publishers = {}
 
     def destroy_all_services(self):
         """
@@ -893,6 +902,38 @@ class BaseComponent(lifecycle.Node):
         return _new_client
 
     # EVENT MANAGEMENT
+    def _publish_event_signal(self, bridge_topic_name: str, **_) -> None:
+        """Publish a Bool signal on a bridge topic to notify a cross-process consequence.
+        Used internally by the Launcher for action-based events whose consequence actions
+        belong to a different component. Publishers are created lazily and cached.
+
+        :param bridge_topic_name: Name of the bridge topic to publish on
+        :type bridge_topic_name: str
+        """
+        from std_msgs.msg import Bool
+
+        if bridge_topic_name not in self.__bridge_publishers:
+            self.__bridge_publishers[bridge_topic_name] = self.create_publisher(
+                Bool, bridge_topic_name, qos_profile=1
+            )
+        msg = Bool()
+        msg.data = True
+        self.__bridge_publishers[bridge_topic_name].publish(msg)
+
+    def __start_action_based_event_timers(self) -> None:
+        """Create one periodic timer per action-based event."""
+        self.__action_event_timers = []
+        for event in self.__events:
+            if event._is_action_based:
+                rate = event.check_rate or self.config.loop_rate
+                self.__action_event_timers.append(
+                    self.create_timer(
+                        timer_period_sec=1.0 / rate,
+                        callback=event.check_action_condition,
+                        callback_group=MutuallyExclusiveCallbackGroup(),
+                    )
+                )
+
     def _turn_on_events_management(self) -> None:
         """
         Turn on event by starting a listener to the event topic
@@ -913,6 +954,9 @@ class BaseComponent(lifecycle.Node):
         unique_topics = {}
         self.__events_per_topic: Dict[str, List[Event]] = {}
         for event in self.__events:
+            # Action-based events have no monitored topics, they are polled by a timer
+            if event._is_action_based:
+                continue
             required_topics = event.get_involved_topics()
             # Ensure topic is not already there, then add to unique topics
             for topic in required_topics:
@@ -940,6 +984,8 @@ class BaseComponent(lifecycle.Node):
                 callback_group=MutuallyExclusiveCallbackGroup(),
             )
             self.__event_listeners.append(listener)
+
+        self.__start_action_based_event_timers()
 
     def _turn_on_fallbacks_subscribers(self):
         # Create ONE subscription per Topic
@@ -1188,7 +1234,19 @@ class BaseComponent(lifecycle.Node):
                     raise ValueError(
                         f"Component '{self.node_name}' does not support action '{action.action_name}'"
                     )
-            self.__events.append(Event.from_json(event_serialized))
+            event_dict = json.loads(event_serialized)
+            if "action_condition" in event_dict:
+                action_name = json.loads(event_dict["action_condition"])["action_name"]
+                if not hasattr(self, action_name):
+                    raise AttributeError(
+                        f"Component '{self.node_name}' does not contain action condition method '{action_name}'"
+                    )
+                condition_method = getattr(self, action_name)
+                self.__events.append(
+                    Event.from_json(event_serialized, deserialized_method=condition_method)
+                )
+            else:
+                self.__events.append(Event.from_json(event_serialized))
             self.__actions.append(action_set)
 
     # SERIALIZATION AND DESERIALIZATION

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -155,6 +155,7 @@ class BaseComponent(lifecycle.Node):
         self.__events: Optional[List[Event]] = None
         self.__actions: Optional[List[List[Action]]] = None
         self.__event_listeners: List[Subscription] = []
+        self.__bridge_publishers: Dict[str, ROSPublisher] = {}
 
         # To manage algorithms config
         self._algorithms_config: Dict[
@@ -761,6 +762,8 @@ class BaseComponent(lifecycle.Node):
         if hasattr(self, "_execution_timer"):
             self.get_logger().info("DESTROYING MAIN TIMER")
             self.destroy_timer(self._execution_timer)
+        for timer in getattr(self, "__action_event_timers", []):
+            self.destroy_timer(timer)
 
     def destroy_all_subscribers(self):
         """
@@ -790,6 +793,12 @@ class BaseComponent(lifecycle.Node):
             if publisher._publisher:
                 self.destroy_publisher(publisher._publisher)
                 publisher._publisher = None
+
+        # Destroy all publishers created for event bridging
+        if hasattr(self, "_bridge_publishers"):
+            for bridge_pub in self.__bridge_publishers.values():
+                self.destroy_publisher(bridge_pub)
+            self.__bridge_publishers = {}
 
     def destroy_all_services(self):
         """
@@ -895,6 +904,38 @@ class BaseComponent(lifecycle.Node):
         return _new_client
 
     # EVENT MANAGEMENT
+    def _publish_event_signal(self, bridge_topic_name: str, **_) -> None:
+        """Publish a Bool signal on a bridge topic to notify a cross-process consequence.
+        Used internally by the Launcher for action-based events whose consequence actions
+        belong to a different component. Publishers are created lazily and cached.
+
+        :param bridge_topic_name: Name of the bridge topic to publish on
+        :type bridge_topic_name: str
+        """
+        from std_msgs.msg import Bool
+
+        if bridge_topic_name not in self.__bridge_publishers:
+            self.__bridge_publishers[bridge_topic_name] = self.create_publisher(
+                Bool, bridge_topic_name, qos_profile=1
+            )
+        msg = Bool()
+        msg.data = True
+        self.__bridge_publishers[bridge_topic_name].publish(msg)
+
+    def __start_action_based_event_timers(self) -> None:
+        """Create one periodic timer per action-based event."""
+        self.__action_event_timers = []
+        for event in self.__events:
+            if event._is_action_based:
+                rate = event.check_rate or self.config.loop_rate
+                self.__action_event_timers.append(
+                    self.create_timer(
+                        timer_period_sec=1.0 / rate,
+                        callback=event.check_action_condition,
+                        callback_group=MutuallyExclusiveCallbackGroup(),
+                    )
+                )
+
     def _turn_on_events_management(self) -> None:
         """
         Turn on event by starting a listener to the event topic
@@ -915,6 +956,9 @@ class BaseComponent(lifecycle.Node):
         unique_topics = {}
         self.__events_per_topic: Dict[str, List[Event]] = {}
         for event in self.__events:
+            # Action-based events have no monitored topics, they are polled by a timer
+            if event._is_action_based:
+                continue
             required_topics = event.get_involved_topics()
             # Ensure topic is not already there, then add to unique topics
             for topic in required_topics:
@@ -942,6 +986,8 @@ class BaseComponent(lifecycle.Node):
                 callback_group=MutuallyExclusiveCallbackGroup(),
             )
             self.__event_listeners.append(listener)
+
+        self.__start_action_based_event_timers()
 
     def _turn_on_fallbacks_subscribers(self):
         # Create ONE subscription per Topic
@@ -1190,7 +1236,19 @@ class BaseComponent(lifecycle.Node):
                     raise ValueError(
                         f"Component '{self.node_name}' does not support action '{action.action_name}'"
                     )
-            self.__events.append(Event.from_json(event_serialized))
+            event_dict = json.loads(event_serialized)
+            if "action_condition" in event_dict:
+                action_name = json.loads(event_dict["action_condition"])["action_name"]
+                if not hasattr(self, action_name):
+                    raise AttributeError(
+                        f"Component '{self.node_name}' does not contain action condition method '{action_name}'"
+                    )
+                condition_method = getattr(self, action_name)
+                self.__events.append(
+                    Event.from_json(event_serialized, deserialized_method=condition_method)
+                )
+            else:
+                self.__events.append(Event.from_json(event_serialized))
             self.__actions.append(action_set)
 
     # SERIALIZATION AND DESERIALIZATION

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -155,6 +155,7 @@ class BaseComponent(lifecycle.Node):
         self.__events: Optional[List[Event]] = None
         self.__actions: Optional[List[List[Action]]] = None
         self.__event_listeners: List[Subscription] = []
+        self.__bridge_publishers: Dict[str, ROSPublisher] = {}
 
         # To manage algorithms config
         self._algorithms_config: Dict[
@@ -695,6 +696,8 @@ class BaseComponent(lifecycle.Node):
         if hasattr(self, "_execution_timer"):
             self.get_logger().info("DESTROYING MAIN TIMER")
             self.destroy_timer(self._execution_timer)
+        for timer in getattr(self, "__action_event_timers", []):
+            self.destroy_timer(timer)
 
     def destroy_all_subscribers(self):
         """
@@ -722,6 +725,12 @@ class BaseComponent(lifecycle.Node):
         for publisher in self.publishers_dict.values():
             if publisher._publisher:
                 self.destroy_publisher(publisher._publisher)
+
+        # Destroy all publishers created for event bridging
+        if hasattr(self, "_bridge_publishers"):
+            for bridge_pub in self.__bridge_publishers.values():
+                self.destroy_publisher(bridge_pub)
+            self.__bridge_publishers = {}
 
     def destroy_all_services(self):
         """
@@ -827,6 +836,38 @@ class BaseComponent(lifecycle.Node):
         return _new_client
 
     # EVENT MANAGEMENT
+    def _publish_event_signal(self, bridge_topic_name: str, **_) -> None:
+        """Publish a Bool signal on a bridge topic to notify a cross-process consequence.
+        Used internally by the Launcher for action-based events whose consequence actions
+        belong to a different component. Publishers are created lazily and cached.
+
+        :param bridge_topic_name: Name of the bridge topic to publish on
+        :type bridge_topic_name: str
+        """
+        from std_msgs.msg import Bool
+
+        if bridge_topic_name not in self.__bridge_publishers:
+            self.__bridge_publishers[bridge_topic_name] = self.create_publisher(
+                Bool, bridge_topic_name, qos_profile=1
+            )
+        msg = Bool()
+        msg.data = True
+        self.__bridge_publishers[bridge_topic_name].publish(msg)
+
+    def __start_action_based_event_timers(self) -> None:
+        """Create one periodic timer per action-based event."""
+        self.__action_event_timers = []
+        for event in self.__events:
+            if event._is_action_based:
+                rate = event.check_rate or self.config.loop_rate
+                self.__action_event_timers.append(
+                    self.create_timer(
+                        timer_period_sec=1.0 / rate,
+                        callback=event.check_action_condition,
+                        callback_group=MutuallyExclusiveCallbackGroup(),
+                    )
+                )
+
     def _turn_on_events_management(self) -> None:
         """
         Turn on event by starting a listener to the event topic
@@ -847,6 +888,9 @@ class BaseComponent(lifecycle.Node):
         unique_topics = {}
         self.__events_per_topic: Dict[str, List[Event]] = {}
         for event in self.__events:
+            # Action-based events have no monitored topics, they are polled by a timer
+            if event._is_action_based:
+                continue
             required_topics = event.get_involved_topics()
             # Ensure topic is not already there, then add to unique topics
             for topic in required_topics:
@@ -874,6 +918,8 @@ class BaseComponent(lifecycle.Node):
                 callback_group=MutuallyExclusiveCallbackGroup(),
             )
             self.__event_listeners.append(listener)
+
+        self.__start_action_based_event_timers()
 
     def _turn_on_fallbacks_subscribers(self):
         # Create ONE subscription per Topic
@@ -1122,7 +1168,19 @@ class BaseComponent(lifecycle.Node):
                     raise ValueError(
                         f"Component '{self.node_name}' does not support action '{action.action_name}'"
                     )
-            self.__events.append(Event.from_json(event_serialized))
+            event_dict = json.loads(event_serialized)
+            if "action_condition" in event_dict:
+                action_name = json.loads(event_dict["action_condition"])["action_name"]
+                if not hasattr(self, action_name):
+                    raise AttributeError(
+                        f"Component '{self.node_name}' does not contain action condition method '{action_name}'"
+                    )
+                condition_method = getattr(self, action_name)
+                self.__events.append(
+                    Event.from_json(event_serialized, deserialized_method=condition_method)
+                )
+            else:
+                self.__events.append(Event.from_json(event_serialized))
             self.__actions.append(action_set)
 
     # SERIALIZATION AND DESERIALIZATION

--- a/ros_sugar/core/event.py
+++ b/ros_sugar/core/event.py
@@ -218,10 +218,11 @@ class Event:
 
     def __init__(
         self,
-        event_condition: Union[Topic, Condition],
+        event_condition: Union[Topic, Condition, "Action"],
         on_change: bool = False,
         handle_once: bool = False,
         keep_event_delay: float = 0.0,
+        check_rate: Optional[float] = None,
     ) -> None:
         """Creates an event
 
@@ -255,8 +256,11 @@ class Event:
         # Case 1: Init from Condition Expression (topic.msg.data > 5)
         if isinstance(event_condition, Condition):
             self._condition = event_condition
+            self._action_condition: Optional[Action] = None
+            self._is_action_based: bool = False
+            self.check_rate: Optional[float] = None
 
-        # Topics are passed for on_any event
+        # Case 2: Topics are passed for on_any event
         elif isinstance(event_condition, Topic):
             self._condition = Condition(
                 topic_name=event_condition.name,
@@ -266,10 +270,22 @@ class Event:
                 operator_func=None,
                 ref_value=None,
             )
+            self._action_condition = None
+            self._is_action_based = False
+            self.check_rate = None
             self._on_any = True
+
+        # Case 3: Action-based polling: action return value is the boolean condition
+        elif isinstance(event_condition, Action):
+            self._condition = None
+            self._action_condition = event_condition
+            self._is_action_based = True
+            self.check_rate = check_rate
+
         else:
             raise AttributeError(
-                f"Cannot initialize Event class. Must provide 'event_source' as a Topic or a valid config from json or dictionary or a condition, got {type(event_condition)}"
+                f"Cannot initialize Event class. Must provide 'event_source' as a Topic, "
+                f"Condition, or Action, got {type(event_condition)}"
             )
 
         # Init trigger as False
@@ -280,9 +296,11 @@ class Event:
 
         # Required topics registry
         self.__required_topics: List[Topic] = []
-        required_topics_dict: Dict = self._condition._get_involved_topics()
-        for topic_name, topic_dict in required_topics_dict.items():
-            self.__required_topics.append(Topic(name=topic_name, **topic_dict))
+        # TODO: handle getting topics from action conditions as well (if any) and add to the required topics list
+        if not self._is_action_based:
+            required_topics_dict: Dict = self._condition._get_involved_topics()
+            for topic_name, topic_dict in required_topics_dict.items():
+                self.__required_topics.append(Topic(name=topic_name, **topic_dict))
 
         # Additional Action Topics
         self.__additional_action_topics: List[Topic] = []
@@ -343,32 +361,59 @@ class Event:
         :return: Event description dictionary
         :rtype: Dict
         """
-        event_dict = {
+        if self._is_action_based:
+            return {
+                "name": self.__id,
+                "action_condition": json.dumps(self._action_condition.dictionary),
+                "check_rate": self.check_rate,
+                "handle_once": self._handle_once,
+                "keep_event_delay": self._keep_event_delay,
+                "on_change": self._on_change,
+            }
+        return {
             "name": self.__id,
             "condition": self._condition.to_json(),
             "handle_once": self._handle_once,
             "keep_event_delay": self._keep_event_delay,
             "on_change": self._on_change,
         }
-        return event_dict
 
     @classmethod
-    def from_dict(cls, dict_obj: Dict):
+    def from_dict(cls, dict_obj: Dict, deserialized_method=None):
         """
         Setter of the event using a dictionary
 
         :param dict_obj: Event description dictionary
         :type dict_obj: Dict
+        :param deserialized_method: Required when the dict encodes an action-based event;
+            the callable to reconstruct the condition Action with.
+        :type deserialized_method: Optional[Callable]
         """
         try:
-            event_condition = Condition.from_dict(json.loads(dict_obj["condition"]))
-            event = cls(
-                event_condition=event_condition,
-                on_change=dict_obj["on_change"],
-                handle_once=dict_obj["handle_once"],
-                keep_event_delay=dict_obj["keep_event_delay"],
-            )
-            # Set the same ID to the event
+            if "action_condition" in dict_obj:
+                if deserialized_method is None:
+                    raise ValueError(
+                        "deserialized_method must be provided to reconstruct an action-based event."
+                    )
+                action_condition = Action.deserialize_action(
+                    json.loads(dict_obj["action_condition"]), deserialized_method
+                )
+                event = cls(
+                    event_condition=action_condition,
+                    on_change=dict_obj["on_change"],
+                    handle_once=dict_obj["handle_once"],
+                    keep_event_delay=dict_obj["keep_event_delay"],
+                    check_rate=dict_obj.get("check_rate"),
+                )
+            else:
+                event_condition = Condition.from_dict(json.loads(dict_obj["condition"]))
+                event = cls(
+                    event_condition=event_condition,
+                    on_change=dict_obj["on_change"],
+                    handle_once=dict_obj["handle_once"],
+                    keep_event_delay=dict_obj["keep_event_delay"],
+                )
+            # Restore the original ID
             event.__id = dict_obj["name"]
             return event
         except Exception as e:
@@ -385,15 +430,18 @@ class Event:
         return json.dumps(self.to_dict())
 
     @classmethod
-    def from_json(cls, json_obj: Union[str, bytes, bytearray]):
+    def from_json(cls, json_obj: Union[str, bytes, bytearray], deserialized_method=None):
         """
         Property to get/set the event using a json
 
         :param json_obj: Event description dictionary as json
         :type json_obj: Union[str, bytes, bytearray]
+        :param deserialized_method: Required when the JSON encodes an action-based event;
+            the callable to reconstruct the condition Action with.
+        :type deserialized_method: Optional[Callable]
         """
         dict_obj = json.loads(json_obj)
-        return cls.from_dict(dict_obj)
+        return cls.from_dict(dict_obj, deserialized_method=deserialized_method)
 
     def get_involved_topics(self) -> List[Topic]:
         """Get all the topics required for monitoring this event
@@ -457,6 +505,9 @@ class Event:
             for action in self._registered_on_trigger_actions:
                 action(topics=global_topic_cache)
 
+            if self._handle_once:
+                self._processed_once = True
+
             # Handle the blocking delay inside the thread (so main loop isn't blocked)
             if self._keep_event_delay > 0:
                 # If a delay is provided start a timer and
@@ -499,12 +550,12 @@ class Event:
         Evaluates the root Condition tree against the global cache.
         """
         topics_dict = {key: value.msg for key, value in global_topic_cache.items()}
-        self._previous_trigger = copy(self.trigger)
 
         if self._on_any:
             # Check that all involved topics has values
             topics_names = [topic.name for topic in self.get_involved_topics()]
             self.trigger = all(topics_dict.get(key, None) for key in topics_names)
+            self._previous_trigger = copy(self.trigger)
         else:
             # This assumes self.event_condition is now the root Condition object
             triggered = self._condition.evaluate(topics_dict)
@@ -528,6 +579,8 @@ class Event:
                 # then just directly update the trigger
                 self.trigger = triggered
 
+            self._previous_trigger = copy(triggered)
+
         if self.trigger:
             # If triggered update the last processed IDs
             # This prevents handling the same topic data twice in the period before its 'stale'
@@ -537,8 +590,27 @@ class Event:
             self._execute_actions(topics_dict)
         return
 
+    def check_action_condition(self) -> None:
+        """Evaluate the action-based condition and execute registered actions if triggered.
+        Called periodically by a component timer; should only be used on action-based events.
+        """
+        triggered = bool(self._action_condition())
+
+        if self._on_change and self._previous_trigger is not None:
+            self.trigger = triggered and not self._previous_trigger
+        else:
+            self.trigger = triggered
+
+        if self.trigger:
+            # TODO: handle dynamic arguments
+            self._execute_actions({})
+
+        self._previous_trigger = copy(triggered)
+
     def __str__(self) -> str:
         """
         str for Event object
         """
+        if self._is_action_based:
+            return f"Action({self._action_condition.action_name}) (ID {self.__id})"
         return f"{self._condition._readable()} (ID {self.__id})"

--- a/ros_sugar/core/event.py
+++ b/ros_sugar/core/event.py
@@ -1,5 +1,6 @@
 """Event"""
 
+import inspect
 import json
 import time
 import uuid
@@ -218,7 +219,7 @@ class Event:
 
     def __init__(
         self,
-        event_condition: Union[Topic, Condition, "Action"],
+        event_condition: Union[Topic, Condition, Callable],
         on_change: bool = False,
         handle_once: bool = False,
         keep_event_delay: float = 0.0,
@@ -276,11 +277,21 @@ class Event:
             self._on_any = True
 
         # Case 3: Action-based polling: action return value is the boolean condition
-        elif isinstance(event_condition, Action):
+        elif isinstance(event_condition, Callable):
             self._condition = None
-            self._action_condition = event_condition
+            # Verify that the method returns boolean
+            return_annotation = inspect.signature(event_condition).return_annotation
+            if return_annotation is not inspect.Parameter.empty and return_annotation is not bool:
+                raise TypeError(
+                    f"Action-based event condition must return bool, "
+                    f"but '{event_condition.__name__}' has return type '{return_annotation}'"
+                )
+
+            self._action_condition = Action(method=event_condition)
             self._is_action_based = True
             self.check_rate = check_rate
+            if not check_rate:
+                logger.warning("No 'check_rate' is provided to pool the event condition method, the default component 'loop_rate' will be used instead")
 
         else:
             raise AttributeError(

--- a/ros_sugar/core/monitor.py
+++ b/ros_sugar/core/monitor.py
@@ -1,5 +1,6 @@
 """Monitor"""
 
+import json
 import os
 from functools import partial
 import time
@@ -555,46 +556,39 @@ class Monitor(Node):
             # Pass the clean subset to the event
             event.check_condition(clean_cache_subset)
 
-    def _activate_event_monitoring(self) -> None:
-        """
-        Turn on all events
-        """
-        self.__events = []
-        if self._events_actions:
-            for serialized_event, actions in self._events_actions.items():
-                event = Event.from_json(serialized_event)
-                for action in actions:
-                    method = getattr(self, action.action_name)
-                    # register action to the event
-                    action.executable = partial(method, *action._args, **action._kwargs)
-                    event.register_actions(action)
-                self.__events.append(event)
+    def __build_events_from_actions(self) -> None:
+        """Deserialize and register events from _events_actions, skipping action-based ones."""
+        if not self._events_actions:
+            return
+        for serialized_event, actions in self._events_actions.items():
+            if "action_condition" in json.loads(serialized_event):
+                # Action-based events are polled by the owning component via timers.
+                # Condition methods live in the script, not on the Monitor, so the Monitor
+                # cannot deserialize them. Any launcher-side consequences will be triggered
+                # via InternalEvents emitted from the script.
+                continue
+            event = Event.from_json(serialized_event)
+            for action in actions:
+                method = getattr(self, action.action_name)
+                action.executable = partial(method, *action._args, **action._kwargs)
+                event.register_actions(action)
+            self.__events.append(event)
 
-        if self._internal_events:
-            # Add internal events (to emit back to launcher)
-            self.__events.extend(self._internal_events)
-
-        # TURN ON EVENTS MANAGEMENT
-        # Blackboard to store latest messages for all topics required for all event:
-        # {'topic_1_name': RosMsg, 'topic_2_name': ROSMsg, ... }
-        self._events_topics_blackboard: Dict[str, EventBlackboardEntry] = {}
-
-        # Identify all unique topics required across ALL events
+    def __build_topic_subscriptions(self) -> None:
+        """Create one subscription per unique topic required by all topic-based events."""
         unique_topics: Dict[str, Topic] = {}
         self.__events_per_topic: Dict[str, List[Event]] = {}
         for event in self.__events:
-            required_topics = event.get_involved_topics()
-            # Ensure topic is not already there, then add to unique topics
-            for topic in required_topics:
+            if event._is_action_based:
+                continue
+            for topic in event.get_involved_topics():
                 if topic.name not in unique_topics:
                     unique_topics[topic.name] = topic
-                # update to keep a record of the events to check for each topic
                 if topic.name not in self.__events_per_topic:
                     self.__events_per_topic[topic.name] = [event]
                 else:
                     self.__events_per_topic[topic.name].append(event)
 
-        # Create ONE subscription per Topic
         self.__event_listeners = []
         for name, topic_obj in unique_topics.items():
             listener = self.create_subscription(
@@ -605,6 +599,43 @@ class Monitor(Node):
                 callback_group=MutuallyExclusiveCallbackGroup(),
             )
             self.__event_listeners.append(listener)
+
+    def __start_action_based_event_timers(self) -> None:
+        """Create one periodic timer per action-based event sourced from _internal_events.
+
+        Recipe-level action-based events are passed as live Event objects (with the
+        condition callable intact) via _internal_events. The Monitor polls them here.
+        """
+        self.__action_event_timers = []
+        for event in self.__events:
+            if event._is_action_based:
+                rate = event.check_rate or self.config.loop_rate
+                self.__action_event_timers.append(
+                    self.create_timer(
+                        timer_period_sec=1.0 / rate,
+                        callback=event.check_action_condition,
+                        callback_group=MutuallyExclusiveCallbackGroup(),
+                    )
+                )
+
+    def _activate_event_monitoring(self) -> None:
+        """
+        Turn on all events
+        """
+        self.__events = []
+
+        self.__build_events_from_actions()
+
+        if self._internal_events:
+            # Add internal events (to emit back to launcher)
+            self.__events.extend(self._internal_events)
+
+        # Blackboard to store latest messages for all topics required for all events:
+        # {'topic_1_name': RosMsg, 'topic_2_name': ROSMsg, ... }
+        self._events_topics_blackboard: Dict[str, EventBlackboardEntry] = {}
+
+        self.__build_topic_subscriptions()
+        self.__start_action_based_event_timers()
 
     def _create_status_subscribers(self) -> None:
         """

--- a/ros_sugar/core/monitor.py
+++ b/ros_sugar/core/monitor.py
@@ -1,6 +1,5 @@
 """Monitor"""
 
-import json
 import os
 from functools import partial
 import time

--- a/ros_sugar/core/monitor.py
+++ b/ros_sugar/core/monitor.py
@@ -1,5 +1,6 @@
 """Monitor"""
 
+import json
 import os
 from functools import partial
 import time
@@ -679,46 +680,39 @@ class Monitor(Node):
             # Pass the clean subset to the event
             event.check_condition(clean_cache_subset)
 
-    def _activate_event_monitoring(self) -> None:
-        """
-        Turn on all events
-        """
-        self.__events = []
-        if self._monitor_events_actions:
-            for serialized_event, actions in self._monitor_events_actions.items():
-                event = Event.from_json(serialized_event)
-                for action in actions:
-                    method = getattr(self, action.action_name)
-                    # register action to the event
-                    action.executable = partial(method, *action._args, **action._kwargs)
-                    event.register_actions(action)
-                self.__events.append(event)
+    def __build_events_from_actions(self) -> None:
+        """Deserialize and register events from _events_actions, skipping action-based ones."""
+        if not self._monitor_events_actions:
+            return
+        for serialized_event, actions in self._monitor_events_actions.items():
+            if "action_condition" in json.loads(serialized_event):
+                # Action-based events are polled by the owning component via timers.
+                # Condition methods live in the script, not on the Monitor, so the Monitor
+                # cannot deserialize them. Any launcher-side consequences will be triggered
+                # via InternalEvents emitted from the script.
+                continue
+            event = Event.from_json(serialized_event)
+            for action in actions:
+                method = getattr(self, action.action_name)
+                action.executable = partial(method, *action._args, **action._kwargs)
+                event.register_actions(action)
+            self.__events.append(event)
 
-        if self._internal_events:
-            # Add internal events (to emit back to launcher)
-            self.__events.extend(self._internal_events)
-
-        # TURN ON EVENTS MANAGEMENT
-        # Blackboard to store latest messages for all topics required for all event:
-        # {'topic_1_name': RosMsg, 'topic_2_name': ROSMsg, ... }
-        self._events_topics_blackboard: Dict[str, EventBlackboardEntry] = {}
-
-        # Identify all unique topics required across ALL events
+    def __build_topic_subscriptions(self) -> None:
+        """Create one subscription per unique topic required by all topic-based events."""
         unique_topics: Dict[str, Topic] = {}
         self.__events_per_topic: Dict[str, List[Event]] = {}
         for event in self.__events:
-            required_topics = event.get_involved_topics()
-            # Ensure topic is not already there, then add to unique topics
-            for topic in required_topics:
+            if event._is_action_based:
+                continue
+            for topic in event.get_involved_topics():
                 if topic.name not in unique_topics:
                     unique_topics[topic.name] = topic
-                # update to keep a record of the events to check for each topic
                 if topic.name not in self.__events_per_topic:
                     self.__events_per_topic[topic.name] = [event]
                 else:
                     self.__events_per_topic[topic.name].append(event)
 
-        # Create ONE subscription per Topic
         self.__event_listeners = []
         for name, topic_obj in unique_topics.items():
             listener = self.create_subscription(
@@ -729,6 +723,43 @@ class Monitor(Node):
                 callback_group=MutuallyExclusiveCallbackGroup(),
             )
             self.__event_listeners.append(listener)
+
+    def __start_action_based_event_timers(self) -> None:
+        """Create one periodic timer per action-based event sourced from _internal_events.
+
+        Recipe-level action-based events are passed as live Event objects (with the
+        condition callable intact) via _internal_events. The Monitor polls them here.
+        """
+        self.__action_event_timers = []
+        for event in self.__events:
+            if event._is_action_based:
+                rate = event.check_rate or self.config.loop_rate
+                self.__action_event_timers.append(
+                    self.create_timer(
+                        timer_period_sec=1.0 / rate,
+                        callback=event.check_action_condition,
+                        callback_group=MutuallyExclusiveCallbackGroup(),
+                    )
+                )
+
+    def _activate_event_monitoring(self) -> None:
+        """
+        Turn on all events
+        """
+        self.__events = []
+
+        self.__build_events_from_actions()
+
+        if self._internal_events:
+            # Add internal events (to emit back to launcher)
+            self.__events.extend(self._internal_events)
+
+        # Blackboard to store latest messages for all topics required for all events:
+        # {'topic_1_name': RosMsg, 'topic_2_name': ROSMsg, ... }
+        self._events_topics_blackboard: Dict[str, EventBlackboardEntry] = {}
+
+        self.__build_topic_subscriptions()
+        self.__start_action_based_event_timers()
 
     def _create_status_subscribers(self) -> None:
         """

--- a/ros_sugar/core/monitor.py
+++ b/ros_sugar/core/monitor.py
@@ -738,6 +738,24 @@ class Monitor(Node):
                     )
                 )
 
+    def __build_events_from_actions(self) -> None:
+        """Deserialize and register events from _events_actions, skipping action-based ones."""
+        if not self._monitor_events_actions:
+            return
+        for serialized_event, actions in self._monitor_events_actions.items():
+            if "action_condition" in json.loads(serialized_event):
+                # Action-based events are polled by the owning component via timers.
+                # Condition methods live in the script, not on the Monitor, so the Monitor
+                # cannot deserialize them. Any launcher-side consequences will be triggered
+                # via InternalEvents emitted from the script.
+                continue
+            event = Event.from_json(serialized_event)
+            for action in actions:
+                method = getattr(self, action.action_name)
+                action.executable = partial(method, *action._args, **action._kwargs)
+                event.register_actions(action)
+            self.__events.append(event)
+
     def _activate_event_monitoring(self) -> None:
         """
         Turn on all events

--- a/ros_sugar/core/monitor.py
+++ b/ros_sugar/core/monitor.py
@@ -741,6 +741,24 @@ class Monitor(Node):
                     )
                 )
 
+    def __build_events_from_actions(self) -> None:
+        """Deserialize and register events from _events_actions, skipping action-based ones."""
+        if not self._monitor_events_actions:
+            return
+        for serialized_event, actions in self._monitor_events_actions.items():
+            if "action_condition" in json.loads(serialized_event):
+                # Action-based events are polled by the owning component via timers.
+                # Condition methods live in the script, not on the Monitor, so the Monitor
+                # cannot deserialize them. Any launcher-side consequences will be triggered
+                # via InternalEvents emitted from the script.
+                continue
+            event = Event.from_json(serialized_event)
+            for action in actions:
+                method = getattr(self, action.action_name)
+                action.executable = partial(method, *action._args, **action._kwargs)
+                event.register_actions(action)
+            self.__events.append(event)
+
     def _activate_event_monitoring(self) -> None:
         """
         Turn on all events

--- a/ros_sugar/launch/launcher.py
+++ b/ros_sugar/launch/launcher.py
@@ -606,7 +606,7 @@ class Launcher:
             self._update_ros_events_actions(event, action)
             return
 
-        # Case 3: Same component owns condition and action
+        # Case 2: Same component owns condition and action
         if condition_owner and condition_owner == consequence_owner:
             logger.debug(
                 f"Action-based event '{event}': Component-condition + same-component-action,"
@@ -617,7 +617,7 @@ class Launcher:
             )
             return
 
-        # Cases 2 and 4 require a Bool bridge topic so the condition owner can signal
+        # Cases 3: Different owners -> Add a Bool bridge topic so the condition owner can signal
         # the consequence owner across process boundaries.
         event_id_safe = event.id.replace("-", "_")
         bridge_topic_name = (
@@ -632,7 +632,7 @@ class Launcher:
             bridge_events_per_target[consequence_owner] = bridge_event
         bridge_serialized: str = bridge_event.to_json()
 
-        # Case 2: Recipe-level condition + component-owned consequence.
+        # Case 3.a: Recipe-level condition + component-owned consequence.
         # The Monitor polls the condition via a timer and, when it fires, publishes
         # Bool(True) on the bridge topic (via the _on_internal_event → OnInternalEvent
         # → publish_message path). The consequence component subscribes to the bridge.
@@ -651,7 +651,7 @@ class Launcher:
             )
             return
 
-        # Case 4: Different components own condition and action
+        # Case 3.b: Different components own condition and action
         logger.debug(
             f"Action-based event '{event}': Component-condition '{condition_owner}'"
             f" + Component-action '{consequence_owner}', bridge topic '{bridge_topic_name}'"

--- a/ros_sugar/launch/launcher.py
+++ b/ros_sugar/launch/launcher.py
@@ -48,6 +48,7 @@ from ..io.supported_types import _additional_types
 from ..core.action import LogInfo
 from ..config.base_config import ComponentRunType
 from ..core.action import Action
+from ..actions import publish_message
 from ..core.component import BaseComponent
 from ..core.monitor import Monitor
 from ..core.event import OnInternalEvent, Event
@@ -516,10 +517,17 @@ class Launcher:
         """
         self.__events_names.extend(event.id for event in events_actions_dict)
         for event, action_set in events_actions_dict.items():
+            bridge_events_per_target: Dict[str, Event] = {}
             for action in action_set:
                 # Verify that the action inputs are available from the event topic(s)
                 if isinstance(action, Action):
                     event.verify_required_action_topics(action)
+                # Action-based events have their own routing logic
+                if event._is_action_based and isinstance(action, Action) and not action._is_lifecycle_action:
+                    self.__route_action_based_event(
+                        event, action, components_list, bridge_events_per_target
+                    )
+                    continue
                 # Check if it is a component action:
                 if isinstance(action, Action) and action.component_action:
                     action_object = action.executable.__self__
@@ -550,6 +558,122 @@ class Launcher:
                 elif isinstance(action, Action) or isinstance(action, ROSLaunchAction):
                     # If it is a valid ROS launch action -> nothing is required
                     self._update_ros_events_actions(event, action)
+
+    def __route_action_based_event(
+        self,
+        event: Event,
+        action: Action,
+        components_list: List[BaseComponent],
+        bridge_events_per_target: Dict[str, Event],
+    ) -> None:
+        """Route an action-based event to the appropriate owner(s).
+
+        Four cases based on who owns the condition Action and who owns the consequence Action:
+
+        1. Monitor-condition + Monitor-action: route both directly to _monitor_events_actions.
+        2. Monitor-condition + Component-action: Monitor publishes a Bool bridge topic when the
+           condition fires; the consequence component monitors that bridge topic.
+        3. Component-condition + same-component-action: route both directly to
+           _components_events_actions.
+        4. Component-condition + different-component-action: condition owner publishes a Bool
+           bridge topic; consequence owner monitors that bridge topic.
+
+        :param event: The action-based event
+        :type event: Event
+        :param action: The consequence action
+        :type action: Action
+        :param components_list: All components registered in the launcher
+        :type components_list: List[BaseComponent]
+        :param bridge_events_per_target: Cache of already-created bridge events keyed by
+            consequence owner name, shared across actions of the same event
+        :type bridge_events_per_target: Dict[str, Event]
+        """
+        from std_msgs.msg import Bool
+
+        condition_owner: Optional[str] = event._action_condition.parent_component
+        consequence_owner: Optional[str] = action.parent_component
+        serialized_event: str = event.to_json()
+
+        # Case 1: Recipe-level condition + non-component consequence.
+        # The condition callable lives in the launch process; route the event via
+        # _internal_events so ComponentLaunchAction registers _on_internal_event on it
+        # and the Monitor creates a polling timer for it.
+        if not condition_owner and not action.component_action:
+            logger.debug(
+                f"Action-based event '{event}': recipe-level condition + launch-level"
+                f" action, routing via internal event"
+            )
+            self._update_ros_events_actions(event, action)
+            return
+
+        # Case 3: Same component owns condition and action
+        if condition_owner and condition_owner == consequence_owner:
+            logger.debug(
+                f"Action-based event '{event}': Component-condition + same-component-action,"
+                f" routing to '{condition_owner}'"
+            )
+            self.__update_dict_list(
+                self._components_events_actions, serialized_event, action
+            )
+            return
+
+        # Cases 2 and 4 require a Bool bridge topic so the condition owner can signal
+        # the consequence owner across process boundaries.
+        event_id_safe = event.id.replace("-", "_")
+        bridge_topic_name = (
+            f"/_event_bridge/e_{event_id_safe}_{consequence_owner or 'monitor'}"
+        )
+
+        # Reuse an already-created bridge event for this (event, consequence_owner) pair
+        bridge_event = bridge_events_per_target.get(consequence_owner)
+        if bridge_event is None:
+            bridge_topic = Topic(name=bridge_topic_name, msg_type="Bool")
+            bridge_event = Event(event_condition=bridge_topic)
+            bridge_events_per_target[consequence_owner] = bridge_event
+        bridge_serialized: str = bridge_event.to_json()
+
+        # Case 2: Recipe-level condition + component-owned consequence.
+        # The Monitor polls the condition via a timer and, when it fires, publishes
+        # Bool(True) on the bridge topic (via the _on_internal_event → OnInternalEvent
+        # → publish_message path). The consequence component subscribes to the bridge.
+        if not condition_owner:
+            logger.debug(
+                f"Action-based event '{event}': recipe-level condition + component-action"
+                f" '{consequence_owner}', bridge topic '{bridge_topic_name}'"
+            )
+            bridge_publish_action = publish_message(
+                topic=Topic(name=bridge_topic_name, msg_type="Bool"),
+                msg=Bool(data=True),
+            )
+            self._update_ros_events_actions(event, bridge_publish_action)
+            self.__update_dict_list(
+                self._components_events_actions, bridge_serialized, action
+            )
+            return
+
+        # Case 4: Different components own condition and action
+        logger.debug(
+            f"Action-based event '{event}': Component-condition '{condition_owner}'"
+            f" + Component-action '{consequence_owner}', bridge topic '{bridge_topic_name}'"
+        )
+        condition_component = next(
+            (c for c in components_list if c.node_name == condition_owner), None
+        )
+        if condition_component is None:
+            raise InvalidAction(
+                f"Action-based event '{event}': condition owner '{condition_owner}'"
+                f" is unknown or not added to Launcher"
+            )
+        bridge_publish_action = Action(
+            method=condition_component._publish_event_signal,
+            kwargs={"bridge_topic_name": bridge_topic_name},
+        )
+        self.__update_dict_list(
+            self._components_events_actions, serialized_event, bridge_publish_action
+        )
+        self.__update_dict_list(
+            self._components_events_actions, bridge_serialized, action
+        )
 
     def _activate_components_action(self) -> SomeEntitiesType:
         """

--- a/ros_sugar/launch/launcher.py
+++ b/ros_sugar/launch/launcher.py
@@ -48,6 +48,7 @@ from ..io.supported_types import _additional_types
 from ..core.action import LogInfo
 from ..config.base_config import ComponentRunType
 from ..core.action import Action
+from ..actions import publish_message
 from ..core.component import BaseComponent
 from ..core.monitor import Monitor
 from ..core.event import OnInternalEvent, Event
@@ -420,10 +421,17 @@ class Launcher:
         """
         self.__events_names.extend(event.id for event in events_actions_dict)
         for event, action_set in events_actions_dict.items():
+            bridge_events_per_target: Dict[str, Event] = {}
             for action in action_set:
                 # Verify that the action inputs are available from the event topic(s)
                 if isinstance(action, Action):
                     event.verify_required_action_topics(action)
+                # Action-based events have their own routing logic
+                if event._is_action_based and isinstance(action, Action) and not action._is_lifecycle_action:
+                    self.__route_action_based_event(
+                        event, action, components_list, bridge_events_per_target
+                    )
+                    continue
                 # Check if it is a component action:
                 if isinstance(action, Action) and action.component_action:
                     action_object = action.executable.__self__
@@ -454,6 +462,122 @@ class Launcher:
                 elif isinstance(action, Action) or isinstance(action, ROSLaunchAction):
                     # If it is a valid ROS launch action -> nothing is required
                     self._update_ros_events_actions(event, action)
+
+    def __route_action_based_event(
+        self,
+        event: Event,
+        action: Action,
+        components_list: List[BaseComponent],
+        bridge_events_per_target: Dict[str, Event],
+    ) -> None:
+        """Route an action-based event to the appropriate owner(s).
+
+        Four cases based on who owns the condition Action and who owns the consequence Action:
+
+        1. Monitor-condition + Monitor-action: route both directly to _monitor_events_actions.
+        2. Monitor-condition + Component-action: Monitor publishes a Bool bridge topic when the
+           condition fires; the consequence component monitors that bridge topic.
+        3. Component-condition + same-component-action: route both directly to
+           _components_events_actions.
+        4. Component-condition + different-component-action: condition owner publishes a Bool
+           bridge topic; consequence owner monitors that bridge topic.
+
+        :param event: The action-based event
+        :type event: Event
+        :param action: The consequence action
+        :type action: Action
+        :param components_list: All components registered in the launcher
+        :type components_list: List[BaseComponent]
+        :param bridge_events_per_target: Cache of already-created bridge events keyed by
+            consequence owner name, shared across actions of the same event
+        :type bridge_events_per_target: Dict[str, Event]
+        """
+        from std_msgs.msg import Bool
+
+        condition_owner: Optional[str] = event._action_condition.parent_component
+        consequence_owner: Optional[str] = action.parent_component
+        serialized_event: str = event.to_json()
+
+        # Case 1: Recipe-level condition + non-component consequence.
+        # The condition callable lives in the launch process; route the event via
+        # _internal_events so ComponentLaunchAction registers _on_internal_event on it
+        # and the Monitor creates a polling timer for it.
+        if not condition_owner and not action.component_action:
+            logger.debug(
+                f"Action-based event '{event}': recipe-level condition + launch-level"
+                f" action, routing via internal event"
+            )
+            self._update_ros_events_actions(event, action)
+            return
+
+        # Case 3: Same component owns condition and action
+        if condition_owner and condition_owner == consequence_owner:
+            logger.debug(
+                f"Action-based event '{event}': Component-condition + same-component-action,"
+                f" routing to '{condition_owner}'"
+            )
+            self.__update_dict_list(
+                self._components_events_actions, serialized_event, action
+            )
+            return
+
+        # Cases 2 and 4 require a Bool bridge topic so the condition owner can signal
+        # the consequence owner across process boundaries.
+        event_id_safe = event.id.replace("-", "_")
+        bridge_topic_name = (
+            f"/_event_bridge/e_{event_id_safe}_{consequence_owner or 'monitor'}"
+        )
+
+        # Reuse an already-created bridge event for this (event, consequence_owner) pair
+        bridge_event = bridge_events_per_target.get(consequence_owner)
+        if bridge_event is None:
+            bridge_topic = Topic(name=bridge_topic_name, msg_type="Bool")
+            bridge_event = Event(event_condition=bridge_topic)
+            bridge_events_per_target[consequence_owner] = bridge_event
+        bridge_serialized: str = bridge_event.to_json()
+
+        # Case 2: Recipe-level condition + component-owned consequence.
+        # The Monitor polls the condition via a timer and, when it fires, publishes
+        # Bool(True) on the bridge topic (via the _on_internal_event → OnInternalEvent
+        # → publish_message path). The consequence component subscribes to the bridge.
+        if not condition_owner:
+            logger.debug(
+                f"Action-based event '{event}': recipe-level condition + component-action"
+                f" '{consequence_owner}', bridge topic '{bridge_topic_name}'"
+            )
+            bridge_publish_action = publish_message(
+                topic=Topic(name=bridge_topic_name, msg_type="Bool"),
+                msg=Bool(data=True),
+            )
+            self._update_ros_events_actions(event, bridge_publish_action)
+            self.__update_dict_list(
+                self._components_events_actions, bridge_serialized, action
+            )
+            return
+
+        # Case 4: Different components own condition and action
+        logger.debug(
+            f"Action-based event '{event}': Component-condition '{condition_owner}'"
+            f" + Component-action '{consequence_owner}', bridge topic '{bridge_topic_name}'"
+        )
+        condition_component = next(
+            (c for c in components_list if c.node_name == condition_owner), None
+        )
+        if condition_component is None:
+            raise InvalidAction(
+                f"Action-based event '{event}': condition owner '{condition_owner}'"
+                f" is unknown or not added to Launcher"
+            )
+        bridge_publish_action = Action(
+            method=condition_component._publish_event_signal,
+            kwargs={"bridge_topic_name": bridge_topic_name},
+        )
+        self.__update_dict_list(
+            self._components_events_actions, serialized_event, bridge_publish_action
+        )
+        self.__update_dict_list(
+            self._components_events_actions, bridge_serialized, action
+        )
 
     def _activate_components_action(self) -> SomeEntitiesType:
         """

--- a/ros_sugar/utils.py
+++ b/ros_sugar/utils.py
@@ -9,7 +9,7 @@ from rclpy.lifecycle import Node as LifecycleNode
 from launch import LaunchContext
 from launch.actions import OpaqueFunction
 import os
-import logging
+from rclpy.logging import get_logger
 
 
 # Get ROS distro
@@ -28,7 +28,7 @@ except ModuleNotFoundError as e:
 
 
 # logger for utils
-logger = logging.getLogger("Sugarcoat")
+logger = get_logger("Sugarcoat")
 
 
 # Define a generic type variable for topic message types

--- a/test/action_based_events_test.py
+++ b/test/action_based_events_test.py
@@ -1,0 +1,211 @@
+import time
+import unittest
+from threading import Event as ThreadingEvent
+import launch_testing
+import launch_testing.actions
+import launch_testing.markers
+import pytest
+
+from ros_sugar.core import BaseComponent, Event
+from ros_sugar import Launcher
+from ros_sugar.actions import Action, LogInfo
+
+# ------------------------------------------------------------------
+# Threading events used to signal that consequence actions fired
+# ------------------------------------------------------------------
+
+# Case 3a: same-component, basic trigger
+basic_trigger_py_event = ThreadingEvent()
+# Case 3b: same-component, on_change
+on_change_py_event = ThreadingEvent()
+# Case 3c: same-component, handle_once
+handle_once_first_py_event = ThreadingEvent()
+# Case 4: cross-component bridge
+cross_trigger_py_event = ThreadingEvent()
+
+# Mutable counter for handle_once; using a list for thread-safe appends
+handle_once_invocations = []
+
+
+# ------------------------------------------------------------------
+# Components
+# ------------------------------------------------------------------
+
+class ComponentA(BaseComponent):
+    """Owns all condition methods and the same-component consequence methods (Case 3)."""
+
+    def __init__(self, component_name, inputs=None, outputs=None, **kwargs):
+        super().__init__(component_name, inputs, outputs, **kwargs)
+        self._counter = 0
+        self._toggle_state = False
+
+    def _execution_step(self):
+        self._counter += 1
+
+    # --- Condition methods ---
+
+    def becomes_true_condition(self, **_) -> bool:
+        """Returns False initially, True once the execution counter exceeds 5."""
+        return self._counter > 5
+
+    def toggling_condition(self, **_) -> bool:
+        """Alternates between False and True on each call."""
+        self._toggle_state = not self._toggle_state
+        return self._toggle_state
+
+    def always_true_condition(self, **_) -> bool:
+        return True
+
+    def cross_condition(self, **_) -> bool:
+        """Used as the condition for the cross-component bridge test (Case 4)."""
+        return self._counter > 5
+
+    # --- Same-component consequence methods ---
+
+    def on_basic_trigger(self, **_) -> None:
+        global basic_trigger_py_event
+        basic_trigger_py_event.set()
+
+    def on_change_trigger(self, **_) -> None:
+        global on_change_py_event
+        on_change_py_event.set()
+
+    def on_handle_once_trigger(self, **_) -> None:
+        global handle_once_invocations, handle_once_first_py_event
+        handle_once_invocations.append(1)
+        handle_once_first_py_event.set()
+
+
+class ComponentB(BaseComponent):
+    """Owns the cross-component consequence method (Case 4).
+
+    The condition lives on ComponentA; when it fires, the Launcher routes
+    the signal via a Bool bridge topic to ComponentB.
+    """
+
+    def _execution_step(self):
+        pass  # No internal state needed for this test
+
+    # --- Cross-component consequence method ---
+
+    def on_cross_trigger(self, **_) -> None:
+        global cross_trigger_py_event
+        cross_trigger_py_event.set()
+
+
+# ------------------------------------------------------------------
+# Launch description
+# ------------------------------------------------------------------
+
+@pytest.mark.launch_test
+@launch_testing.markers.keep_alive
+def generate_test_description():
+    component_a = ComponentA(component_name="component_a")
+    component_b = ComponentB(component_name="component_b")
+
+    # --- Case 3a: same-component, basic trigger ---
+    # Condition starts False, becomes True after execution counter exceeds 5
+    event_basic = Event(
+        Action(method=component_a.becomes_true_condition),
+        check_rate=10.0,
+    )
+
+    # --- Case 3b: same-component, on_change ---
+    # Toggling condition with on_change=True fires only on False-to-True transition
+    event_on_change = Event(
+        Action(method=component_a.toggling_condition),
+        check_rate=10.0,
+        on_change=True,
+    )
+
+    # --- Case 3c: same-component, handle_once ---
+    # Always-True condition fires exactly once
+    event_handle_once = Event(
+        Action(method=component_a.always_true_condition),
+        check_rate=10.0,
+        handle_once=True,
+    )
+
+    # --- Case 4: cross-component bridge ---
+    # Condition is on ComponentA; consequence is on ComponentB.
+    # The Launcher creates a Bool bridge topic: ComponentA publishes True when
+    # the condition fires, ComponentB monitors the bridge topic and runs the action.
+    event_cross = Event(
+        Action(method=component_a.cross_condition),
+        check_rate=10.0,
+    )
+
+    launcher = Launcher()
+    launcher.add_pkg(
+        components=[component_a, component_b],
+        events_actions={
+            event_basic: [
+                LogInfo(msg="[Case 3a] action-based event triggered"),
+                Action(method=component_a.on_basic_trigger),
+            ],
+            event_on_change: [
+                LogInfo(msg="[Case 3b] on_change action-based event triggered"),
+                Action(method=component_a.on_change_trigger),
+            ],
+            event_handle_once: [
+                Action(method=component_a.on_handle_once_trigger),
+            ],
+            event_cross: [
+                LogInfo(msg="[Case 4] cross-component bridge event triggered"),
+                Action(method=component_b.on_cross_trigger),
+            ],
+        },
+    )
+
+    launcher.setup_launch_description()
+    launcher._description.add_action(launch_testing.actions.ReadyToTest())
+    return launcher._description
+
+
+# ------------------------------------------------------------------
+# Tests
+# ------------------------------------------------------------------
+
+class TestActionBasedEvents(unittest.TestCase):
+    """Tests for the action-based event polling mechanism (Event with Action condition)."""
+
+    wait_time = 15.0  # seconds
+
+    # --- Case 3: same-component condition + same-component action ---
+
+    def test_basic_action_based_trigger(cls):
+        """[Case 3a] Consequence fires once the condition Action starts returning True."""
+        assert basic_trigger_py_event.wait(cls.wait_time), (
+            "Action-based event failed to trigger when condition became True"
+        )
+
+    def test_on_change_action_based_trigger(cls):
+        """[Case 3b] Consequence fires on a False-to-True transition when on_change=True."""
+        assert on_change_py_event.wait(cls.wait_time), (
+            "Action-based event with on_change=True failed to trigger on False-to-True transition"
+        )
+
+    def test_handle_once(cls):
+        """[Case 3c] Consequence fires exactly once even when the condition stays True."""
+        assert handle_once_first_py_event.wait(cls.wait_time), (
+            "handle_once action-based event never fired"
+        )
+        # Wait several more check periods (10 Hz -> 0.5 s covers ~5 additional checks)
+        time.sleep(0.5)
+        assert len(handle_once_invocations) == 1, (
+            f"handle_once action-based event fired {len(handle_once_invocations)} "
+            f"time(s), expected exactly 1"
+        )
+
+    # --- Case 4: cross-component bridge ---
+
+    def test_cross_component_bridge_trigger(cls):
+        """[Case 4] Consequence on ComponentB fires when the condition on ComponentA becomes True.
+
+        The Launcher routes the signal via a Bool bridge topic: ComponentA polls the
+        condition and publishes True on the bridge topic, ComponentB subscribes to it
+        and fires the consequence action.
+        """
+        assert cross_trigger_py_event.wait(cls.wait_time), (
+            "Cross-component action-based event failed to trigger via Bool bridge topic"
+        )

--- a/test/action_based_events_test.py
+++ b/test/action_based_events_test.py
@@ -106,14 +106,14 @@ def generate_test_description():
     # --- Case 3a: same-component, basic trigger ---
     # Condition starts False, becomes True after execution counter exceeds 5
     event_basic = Event(
-        Action(method=component_a.becomes_true_condition),
+        component_a.becomes_true_condition,
         check_rate=10.0,
     )
 
     # --- Case 3b: same-component, on_change ---
     # Toggling condition with on_change=True fires only on False-to-True transition
     event_on_change = Event(
-        Action(method=component_a.toggling_condition),
+        component_a.toggling_condition,
         check_rate=10.0,
         on_change=True,
     )
@@ -121,7 +121,7 @@ def generate_test_description():
     # --- Case 3c: same-component, handle_once ---
     # Always-True condition fires exactly once
     event_handle_once = Event(
-        Action(method=component_a.always_true_condition),
+        component_a.always_true_condition,
         check_rate=10.0,
         handle_once=True,
     )
@@ -131,7 +131,7 @@ def generate_test_description():
     # The Launcher creates a Bool bridge topic: ComponentA publishes True when
     # the condition fires, ComponentB monitors the bridge topic and runs the action.
     event_cross = Event(
-        Action(method=component_a.cross_condition),
+        component_a.cross_condition,
         check_rate=10.0,
     )
 


### PR DESCRIPTION
## Summary

This PR allows constructing events based on more general-purpose definitions for the triggering condition.  The `Event` class now accepts a plain `Callable` (python method or any component action method) as a condition. This method is polled at runtime using a configurable `check_rate` via timers, and the event is triggered when the method returns `True`. This allows triggering events based on low-level system checks, or external API calls outside the ROS2 network, with no topic subscription needed.

Support is guaranteed internally for cross-component routing: When the condition method owner and the consequence `Action` owner are different components, the `Launcher` automatically creates a `Bool` bridge topic so events can cross process boundaries.

Additionally, the `utils` main logger is switched to rclpy logger for consistency.

## Tests
 - [x] Verify `test/action_based_events_test.py` passes: basic trigger, `on_change`, `handle_once`, and cross-component bridge
 - [x] Run existing event-based tests to confirm no regressions in topic-based event handling
 
