### PR TITLE
Generic Events: using Callables as event conditions, for general-purpose condition building

### DIFF
--- a/docs/advanced/events_architecture.html
+++ b/docs/advanced/events_architecture.html
@@ -1,0 +1,1028 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Sugarcoat — Event-Driven Architecture</title>
+<style>
+  :root {
+    --bg: #0f1117;
+    --surface: #181b24;
+    --surface2: #1e2130;
+    --border: #2a2e3a;
+    --border-hover: #3d4255;
+    --text: #e1e4eb;
+    --text-dim: #8b90a0;
+    --accent: #6c8cff;
+    --accent-dim: #3a4d8c;
+    --green: #4ade80;
+    --green-dim: #1a4d30;
+    --orange: #fb923c;
+    --orange-dim: #5c3a18;
+    --pink: #f472b6;
+    --pink-dim: #5c2248;
+    --cyan: #22d3ee;
+    --cyan-dim: #134044;
+    --red: #f87171;
+    --yellow: #facc15;
+    --yellow-dim: rgba(250,204,21,0.2);
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.7;
+    padding: 2.5rem 3rem;
+    max-width: 1200px;
+    margin: 0 auto;
+  }
+
+  h1 { font-size: 2.2rem; font-weight: 700; margin-bottom: 0.3rem; color: #fff; }
+  h1 span { color: var(--accent); }
+
+  .subtitle { color: var(--text-dim); font-size: 1.1rem; margin-bottom: 2.5rem; }
+
+  h2 {
+    font-size: 1.45rem; font-weight: 600; margin: 3rem 0 0.6rem; color: #fff;
+    display: flex; align-items: center; gap: 0.6rem;
+  }
+
+  .section-desc { color: var(--text-dim); font-size: 1rem; margin-bottom: 1.4rem; max-width: 760px; line-height: 1.7; }
+
+  code {
+    font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
+    font-size: 0.88em;
+    background: rgba(108,140,255,0.1);
+    padding: 1px 5px;
+    border-radius: 4px;
+    color: var(--accent);
+  }
+
+  /* ── Architecture Diagram ── */
+  .arch-container { display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; margin-bottom: 1rem; }
+
+  .process-box {
+    border: 1.5px solid var(--border); border-radius: 14px; padding: 1.4rem;
+    background: var(--surface); position: relative; transition: border-color 0.3s, box-shadow 0.3s;
+  }
+  .process-box.main { grid-column: 1 / -1; }
+  .process-box.highlight { border-color: var(--accent); box-shadow: 0 0 20px rgba(108,140,255,0.1); }
+
+  .process-label {
+    font-size: 0.82rem; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.08em; color: var(--text-dim); margin-bottom: 0.9rem;
+    display: flex; align-items: center; gap: 0.5rem;
+  }
+  .process-label .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+
+  .node-card {
+    border: 1px solid var(--border); border-radius: 10px; padding: 1rem 1.2rem;
+    background: rgba(255,255,255,0.02); margin-bottom: 0.7rem; transition: all 0.3s;
+  }
+  .node-card:last-child { margin-bottom: 0; }
+  .node-card.highlight { border-color: var(--accent); background: rgba(108,140,255,0.05); }
+  .node-card.highlight-green { border-color: var(--green); background: rgba(74,222,128,0.05); }
+  .node-card.highlight-pink { border-color: var(--pink); background: rgba(244,114,182,0.05); }
+
+  .node-name {
+    font-weight: 600; font-size: 1.05rem; margin-bottom: 0.5rem;
+    display: flex; align-items: center; gap: 0.5rem;
+  }
+  .node-name .icon {
+    width: 22px; height: 22px; border-radius: 5px;
+    display: inline-flex; align-items: center; justify-content: center;
+    font-size: 0.72rem; font-weight: 700; flex-shrink: 0;
+  }
+  .node-name .type-label { font-size: 0.8rem; color: var(--text-dim); font-weight: 400; }
+
+  .cap-list { list-style: none; font-size: 0.92rem; color: var(--text-dim); }
+  .cap-list li { padding: 3px 0 3px 1.2rem; position: relative; transition: color 0.2s; }
+  .cap-list li::before { content: '›'; position: absolute; left: 0.3rem; color: var(--accent); font-weight: 700; transition: color 0.2s; }
+  .cap-list li.active { color: var(--text); }
+  .cap-list li.active::before { color: var(--green); }
+
+  /* ── Flow Selector ── */
+  .flow-selector { display: flex; flex-wrap: wrap; gap: 0.6rem; margin: 1.2rem 0 1.8rem; }
+
+  .flow-btn {
+    padding: 0.55rem 1.2rem; border-radius: 8px; border: 1.5px solid var(--border);
+    background: var(--surface); color: var(--text-dim); font-size: 0.95rem;
+    font-weight: 500; cursor: pointer; transition: all 0.25s; font-family: inherit;
+    display: flex; align-items: center; gap: 0.5rem;
+  }
+  .flow-btn:hover { border-color: var(--border-hover); color: var(--text); background: var(--surface2); }
+  .flow-btn.active { border-color: var(--accent); color: #fff; background: var(--accent-dim); }
+  .flow-btn .flow-dot { width: 8px; height: 8px; border-radius: 50%; }
+
+  /* ── Flow Detail Panel ── */
+  .flow-detail {
+    border: 1.5px solid var(--border); border-radius: 14px; background: var(--surface);
+    overflow: hidden; transition: max-height 0.4s ease, opacity 0.3s ease, margin 0.3s ease;
+    max-height: 0; opacity: 0; margin-bottom: 0;
+  }
+  .flow-detail.visible { max-height: 900px; opacity: 1; margin-bottom: 1.5rem; }
+
+  .flow-svg-wrap { width: 100%; overflow-x: auto; margin-top: 1rem; }
+  .flow-svg-wrap svg { display: block; margin: 0 auto; }
+
+  .flow-detail-inner { padding: 1.8rem 2rem; }
+
+  .flow-detail h3 {
+    font-size: 1.2rem; font-weight: 600; color: #fff; margin-bottom: 0.4rem;
+    display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap;
+  }
+
+  .flow-detail .flow-desc { color: var(--text-dim); font-size: 0.98rem; margin-bottom: 1rem; max-width: 750px; }
+
+  /* ── Routing Decision Tree ── */
+  .routing-container {
+    border: 1.5px solid var(--border); border-radius: 14px;
+    background: var(--surface); padding: 2rem; overflow-x: auto;
+  }
+  .routing-container svg { display: block; margin: 0 auto; }
+
+  /* ── Blackboard Section ── */
+  .bb-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; }
+
+  .bb-card {
+    border: 1.5px solid var(--border); border-radius: 14px;
+    background: var(--surface); padding: 1.5rem;
+  }
+  .bb-card h3 { font-size: 1.15rem; font-weight: 600; color: #fff; margin-bottom: 0.8rem; }
+
+  .bb-entry {
+    border: 1px solid var(--border); border-radius: 8px; padding: 0.9rem 1.1rem;
+    margin-bottom: 0.6rem; background: rgba(255,255,255,0.02);
+    cursor: pointer; transition: all 0.2s;
+  }
+  .bb-entry:hover { border-color: var(--border-hover); background: rgba(255,255,255,0.04); }
+  .bb-entry:last-child { margin-bottom: 0; }
+  .bb-entry .bb-topic { font-weight: 500; font-size: 1rem; }
+  .bb-entry .bb-meta { font-size: 0.88rem; color: var(--text-dim); margin-top: 3px; }
+
+  .bb-entry .bb-status {
+    float: right; font-size: 0.82rem; font-weight: 500; padding: 2px 9px; border-radius: 5px;
+  }
+  .bb-status.fresh { color: var(--green); background: rgba(74,222,128,0.1); }
+  .bb-status.expired { color: var(--red); background: rgba(248,113,113,0.1); }
+  .bb-status.stale { color: var(--orange); background: rgba(251,146,60,0.1); }
+
+  .bb-expand-detail {
+    margin-top: 0.7rem; padding-top: 0.7rem; border-top: 1px solid var(--border);
+    font-size: 0.92rem; line-height: 1.6;
+  }
+
+  .pipeline-step {
+    display: flex; align-items: flex-start; gap: 0.9rem;
+    padding: 0.75rem 0; border-bottom: 1px solid rgba(255,255,255,0.04);
+  }
+  .pipeline-step:last-child { border-bottom: none; }
+  .pipeline-num {
+    width: 28px; height: 28px; border-radius: 6px; display: flex;
+    align-items: center; justify-content: center; font-size: 0.88rem;
+    font-weight: 700; flex-shrink: 0; margin-top: 2px;
+  }
+  .pipeline-text { font-size: 1rem; }
+  .pipeline-text strong { color: #fff; font-weight: 600; }
+  .pipeline-text .dim { color: var(--text-dim); font-size: 0.92rem; }
+
+  /* ── Tags ── */
+  .tag {
+    font-size: 0.82rem; padding: 2px 10px; border-radius: 5px;
+    font-weight: 500; border: 1px solid; display: inline-block;
+  }
+  .tag-topic    { color: var(--cyan);   border-color: var(--cyan-dim);   background: rgba(34,211,238,0.08); }
+  .tag-callable { color: var(--orange); border-color: var(--orange-dim); background: rgba(251,146,60,0.08); }
+  .tag-monitor  { color: var(--accent); border-color: var(--accent-dim); background: rgba(108,140,255,0.08); }
+  .tag-component{ color: var(--green);  border-color: var(--green-dim);  background: rgba(74,222,128,0.08); }
+  .tag-launcher { color: var(--pink);   border-color: var(--pink-dim);   background: rgba(244,114,182,0.08); }
+  .tag-bridge   { color: var(--yellow); border-color: var(--yellow-dim); background: rgba(250,204,21,0.08); }
+
+  /* ── Tooltip ── */
+  .tooltip {
+    position: fixed; padding: 0.7rem 1rem; border-radius: 8px;
+    background: #252836; border: 1px solid var(--border-hover);
+    color: var(--text); font-size: 0.92rem; pointer-events: none;
+    opacity: 0; transition: opacity 0.15s; z-index: 100;
+    max-width: 360px; box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+  }
+  .tooltip.show { opacity: 1; }
+  .tooltip .tt-file { color: var(--accent); font-size: 0.85rem; font-family: 'JetBrains Mono', monospace; }
+
+  /* ── Responsive ── */
+  @media (max-width: 900px) {
+    body { padding: 1.2rem; }
+    .arch-container, .bb-grid { grid-template-columns: 1fr; }
+    .process-box.main > div { grid-template-columns: 1fr !important; }
+    .flow-svg-wrap { overflow-x: scroll; }
+  }
+</style>
+</head>
+<body>
+
+<h1>Sugarcoat <span>Event-Driven Architecture</span></h1>
+<p class="subtitle">Interactive visual reference for event routing and execution flows</p>
+
+<!-- ══════════════════════════════════════════════════════════════════ -->
+<!-- SECTION 1: SYSTEM ARCHITECTURE                                    -->
+<!-- ══════════════════════════════════════════════════════════════════ -->
+<h2>System Architecture</h2>
+<p class="section-desc">
+  A Sugarcoat application runs across two kinds of processes: the <strong>main process</strong>
+  (hosting the Launcher and Monitor node) and one or more <strong>component processes</strong>.
+  Select a flow below to highlight which parts of the architecture are involved.
+</p>
+
+<div class="arch-container" id="arch">
+  <!-- Main Process -->
+  <div class="process-box main" id="proc-main">
+    <div class="process-label"><span class="dot" style="background:var(--pink)"></span> Main Process</div>
+    <div style="display:grid; grid-template-columns:1fr 1fr; gap:1rem;">
+      <div class="node-card" id="node-launcher">
+        <div class="node-name">
+          <span class="icon" style="background:var(--pink-dim);color:var(--pink);">L</span>
+          Launcher
+        </div>
+        <ul class="cap-list">
+          <li data-flow="all">Orchestrates the ROS2 launch system</li>
+          <li data-flow="all">Routes event/action pairs by ownership</li>
+          <li data-flow="3,6">Registers <code>OnInternalEvent</code> handlers</li>
+          <li data-flow="3,6">Executes inline recipe methods &amp; ROS launch actions</li>
+          <li data-flow="5">Creates bridge topics for callable → component flows</li>
+        </ul>
+      </div>
+      <div class="node-card" id="node-monitor">
+        <div class="node-name">
+          <span class="icon" style="background:var(--accent-dim);color:var(--accent);">M</span>
+          Monitor
+          <span class="type-label">(ROS2 Node)</span>
+        </div>
+        <ul class="cap-list">
+          <li data-flow="1,3">Subscribes to event topics</li>
+          <li data-flow="1,3,4,5,6">Maintains the event blackboard</li>
+          <li data-flow="1,3">Evaluates topic-based conditions</li>
+          <li data-flow="4,5,6">Polls callable conditions via timers</li>
+          <li data-flow="1,4">Executes system-level actions (publish, srv, action goal)</li>
+          <li data-flow="3,6">Emits <code>InternalEvent</code> back to Launcher context</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <!-- Component Processes -->
+  <div class="process-box" id="proc-comp-a">
+    <div class="process-label"><span class="dot" style="background:var(--green)"></span> Component Process</div>
+    <div class="node-card" id="node-comp-a">
+      <div class="node-name">
+        <span class="icon" style="background:var(--green-dim);color:var(--green);">C</span>
+        Component Node
+        <span class="type-label">(LifecycleNode)</span>
+      </div>
+      <ul class="cap-list">
+        <li data-flow="2">Subscribes to its routed event topics</li>
+        <li data-flow="5">Subscribes to bridge topics (<code>/event_bridge/...</code>)</li>
+        <li data-flow="2,5">Maintains its own event blackboard</li>
+        <li data-flow="2,5">Evaluates topic-based conditions</li>
+        <li data-flow="2,5">Executes <code>@component_action</code> methods</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="process-box" id="proc-comp-b">
+    <div class="process-label"><span class="dot" style="background:var(--green)"></span> Component Process</div>
+    <div class="node-card" id="node-comp-b">
+      <div class="node-name">
+        <span class="icon" style="background:var(--green-dim);color:var(--green);">C</span>
+        Component Node
+        <span class="type-label">(LifecycleNode)</span>
+      </div>
+      <ul class="cap-list">
+        <li>Same event infrastructure as any component</li>
+        <li>Independent blackboard and subscriptions</li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════════════════════════════ -->
+<!-- SECTION 2: INTERACTIVE FLOW EXPLORER                              -->
+<!-- ══════════════════════════════════════════════════════════════════ -->
+<h2>Execution Flows</h2>
+<p class="section-desc">
+  Select a flow to see the step-by-step execution path and highlight the involved architecture components above.
+</p>
+
+<div class="flow-selector" id="flowSelector">
+  <button class="flow-btn" data-flow="1" onclick="selectFlow(1)">
+    <span class="flow-dot" style="background:var(--accent);"></span>
+    1 &middot; Topic → Monitor
+  </button>
+  <button class="flow-btn" data-flow="2" onclick="selectFlow(2)">
+    <span class="flow-dot" style="background:var(--green);"></span>
+    2 &middot; Topic → Component
+  </button>
+  <button class="flow-btn" data-flow="3" onclick="selectFlow(3)">
+    <span class="flow-dot" style="background:var(--pink);"></span>
+    3 &middot; Topic → Launcher
+  </button>
+  <button class="flow-btn" data-flow="4" onclick="selectFlow(4)">
+    <span class="flow-dot" style="background:var(--accent);"></span>
+    4 &middot; Callable → Monitor
+  </button>
+  <button class="flow-btn" data-flow="5" onclick="selectFlow(5)">
+    <span class="flow-dot" style="background:var(--yellow);"></span>
+    5 &middot; Callable → Component (Bridge)
+  </button>
+  <button class="flow-btn" data-flow="6" onclick="selectFlow(6)">
+    <span class="flow-dot" style="background:var(--pink);"></span>
+    6 &middot; Callable → Launcher
+  </button>
+</div>
+
+<!-- Flow 1 -->
+<div class="flow-detail" id="flow-1">
+  <div class="flow-detail-inner">
+    <h3>
+      <span class="tag tag-topic">Topic</span>
+      <span class="tag tag-monitor">Monitor</span>
+      Topic Condition → Monitor Action
+    </h3>
+    <p class="flow-desc">
+      The Monitor subscribes to the event topic, evaluates the condition on each incoming message,
+      and directly executes system-level actions (e.g. <code>publish_message</code>).
+    </p>
+    <div class="flow-svg-wrap">
+      <svg viewBox="0 0 580 130" width="580" height="130" xmlns="http://www.w3.org/2000/svg" font-family="Inter, system-ui, sans-serif">
+        <defs><marker id="f1a" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="none" stroke="#4a4e5a" stroke-width="1.2"/></marker></defs>
+        <rect x="2" y="20" width="100" height="36" rx="7" fill="rgba(34,211,238,0.1)" stroke="#134044" stroke-width="1"/>
+        <text x="52" y="38" text-anchor="middle" fill="#22d3ee" font-size="11" font-weight="500">ROS Topic</text>
+        <text x="52" y="51" text-anchor="middle" fill="#8b90a0" font-size="9">New message</text>
+        <line x1="102" y1="38" x2="118" y2="38" stroke="#4a4e5a" stroke-width="1" marker-end="url(#f1a)"/>
+        <rect x="120" y="20" width="110" height="36" rx="7" fill="rgba(108,140,255,0.1)" stroke="#3a4d8c" stroke-width="1"/>
+        <text x="175" y="38" text-anchor="middle" fill="#6c8cff" font-size="11" font-weight="500">Monitor Sub</text>
+        <text x="175" y="51" text-anchor="middle" fill="#8b90a0" font-size="9">__event_topic_callback</text>
+        <line x1="230" y1="38" x2="246" y2="38" stroke="#4a4e5a" stroke-width="1" marker-end="url(#f1a)"/>
+        <rect x="248" y="20" width="100" height="36" rx="7" fill="rgba(108,140,255,0.1)" stroke="#3a4d8c" stroke-width="1"/>
+        <text x="298" y="35" text-anchor="middle" fill="#6c8cff" font-size="11" font-weight="500">Blackboard</text>
+        <text x="298" y="51" text-anchor="middle" fill="#8b90a0" font-size="8.5">+ lazy expiration</text>
+        <line x1="298" y1="56" x2="298" y2="72" stroke="#4a4e5a" stroke-width="1" marker-end="url(#f1a)"/>
+        <rect x="228" y="74" width="140" height="36" rx="7" fill="rgba(108,140,255,0.1)" stroke="#3a4d8c" stroke-width="1"/>
+        <text x="298" y="90" text-anchor="middle" fill="#6c8cff" font-size="11" font-weight="500">check_condition()</text>
+        <text x="298" y="104" text-anchor="middle" fill="#8b90a0" font-size="9">Evaluate expression</text>
+        <line x1="368" y1="92" x2="398" y2="92" stroke="#4a4e5a" stroke-width="1" marker-end="url(#f1a)"/>
+        <rect x="400" y="74" width="170" height="42" rx="7" fill="rgba(108,140,255,0.15)" stroke="#6c8cff" stroke-width="1.5"/>
+        <text x="485" y="92" text-anchor="middle" fill="#6c8cff" font-size="12" font-weight="600">ThreadPoolExecutor</text>
+        <text x="485" y="107" text-anchor="middle" fill="#8b90a0" font-size="9">publish_message / srv / action goal</text>
+      </svg>
+    </div>
+  </div>
+</div>
+
+<!-- Flow 2 -->
+<div class="flow-detail" id="flow-2">
+  <div class="flow-detail-inner">
+    <h3>
+      <span class="tag tag-topic">Topic</span>
+      <span class="tag tag-component">Component</span>
+      Topic Condition → Component Action
+    </h3>
+    <p class="flow-desc">
+      The event is routed directly to the component. The component subscribes to the topic itself,
+      evaluates the condition, and executes the <code>@component_action</code> method.
+    </p>
+    <div class="flow-svg-wrap">
+      <svg viewBox="0 0 580 130" width="580" height="130" xmlns="http://www.w3.org/2000/svg" font-family="Inter, system-ui, sans-serif">
+        <defs><marker id="f2a" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="none" stroke="#4a4e5a" stroke-width="1.2"/></marker></defs>
+        <rect x="2" y="20" width="100" height="36" rx="7" fill="rgba(34,211,238,0.1)" stroke="#134044" stroke-width="1"/>
+        <text x="52" y="38" text-anchor="middle" fill="#22d3ee" font-size="11" font-weight="500">ROS Topic</text>
+        <text x="52" y="51" text-anchor="middle" fill="#8b90a0" font-size="9">New message</text>
+        <line x1="102" y1="38" x2="118" y2="38" stroke="#4a4e5a" stroke-width="1" marker-end="url(#f2a)"/>
+        <rect x="120" y="20" width="120" height="36" rx="7" fill="rgba(74,222,128,0.1)" stroke="#1a4d30" stroke-width="1"/>
+        <text x="180" y="38" text-anchor="middle" fill="#4ade80" font-size="11" font-weight="500">Component Sub</text>
+        <text x="180" y="51" text-anchor="middle" fill="#8b90a0" font-size="9">__event_topic_callback</text>
+        <line x1="240" y1="38" x2="256" y2="38" stroke="#4a4e5a" stroke-width="1" marker-end="url(#f2a)"/>
+        <rect x="258" y="20" width="100" height="36" rx="7" fill="rgba(74,222,128,0.1)" stroke="#1a4d30" stroke-width="1"/>
+        <text x="308" y="35" text-anchor="middle" fill="#4ade80" font-size="11" font-weight="500">Blackboard</text>
+        <text x="308" y="51" text-anchor="middle" fill="#8b90a0" font-size="8.5">+ lazy expiration</text>
+        <line x1="308" y1="56" x2="308" y2="72" stroke="#4a4e5a" stroke-width="1" marker-end="url(#f2a)"/>
+        <rect x="238" y="74" width="140" height="36" rx="7" fill="rgba(74,222,128,0.1)" stroke="#1a4d30" stroke-width="1"/>
+        <text x="308" y="90" text-anchor="middle" fill="#4ade80" font-size="11" font-weight="500">check_condition()</text>
+        <text x="308" y="104" text-anchor="middle" fill="#8b90a0" font-size="9">Evaluate expression</text>
+        <line x1="378" y1="92" x2="398" y2="92" stroke="#4a4e5a" stroke-width="1" marker-end="url(#f2a)"/>
+        <rect x="400" y="74" width="170" height="42" rx="7" fill="rgba(74,222,128,0.15)" stroke="#4ade80" stroke-width="1.5"/>
+        <text x="485" y="92" text-anchor="middle" fill="#4ade80" font-size="12" font-weight="600">ThreadPoolExecutor</text>
+        <text x="485" y="107" text-anchor="middle" fill="#8b90a0" font-size="9">@component_action method</text>
+      </svg>
+    </div>
+  </div>
+</div>
+
+<!-- Flow 3 -->
+<div class="flow-detail" id="flow-3">
+  <div class="flow-detail-inner">
+    <h3>
+      <span class="tag tag-topic">Topic</span>
+      <span class="tag tag-launcher">Launcher</span>
+      Topic Condition → Launcher Action
+    </h3>
+    <p class="flow-desc">
+      The Monitor subscribes to the event topic and evaluates the condition. On trigger, it emits an
+      <code>InternalEvent</code> to the ROS2 launch context. The Launcher's <code>OnInternalEvent</code>
+      handler matches it and executes the inline recipe method or ROS launch action.
+    </p>
+    <div class="flow-svg-wrap">
+      <svg viewBox="0 0 680 160" width="680" height="160" xmlns="http://www.w3.org/2000/svg" font-family="Inter, system-ui, sans-serif">
+        <defs>
+          <marker id="f3a" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="none" stroke="#4a4e5a" stroke-width="1.2"/></marker>
+          <marker id="f3p" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="none" stroke="#f472b6" stroke-width="1.2"/></marker>
+        </defs>
+        <rect x="2" y="10" width="100" height="36" rx="7" fill="rgba(34,211,238,0.1)" stroke="#134044" stroke-width="1"/>
+        <text x="52" y="28" text-anchor="middle" fill="#22d3ee" font-size="11" font-weight="500">ROS Topic</text>
+        <text x="52" y="41" text-anchor="middle" fill="#8b90a0" font-size="9">New message</text>
+        <line x1="102" y1="28" x2="118" y2="28" stroke="#4a4e5a" stroke-width="1" marker-end="url(#f3a)"/>
+        <rect x="120" y="10" width="120" height="36" rx="7" fill="rgba(108,140,255,0.1)" stroke="#3a4d8c" stroke-width="1"/>
+        <text x="180" y="28" text-anchor="middle" fill="#6c8cff" font-size="11" font-weight="500">Monitor Sub</text>
+        <text x="180" y="41" text-anchor="middle" fill="#8b90a0" font-size="9">check_condition()</text>
+        <line x1="240" y1="28" x2="256" y2="28" stroke="#4a4e5a" stroke-width="1" marker-end="url(#f3a)"/>
+        <rect x="258" y="10" width="150" height="36" rx="7" fill="rgba(108,140,255,0.1)" stroke="#3a4d8c" stroke-width="1"/>
+        <text x="333" y="28" text-anchor="middle" fill="#6c8cff" font-size="11" font-weight="500">_on_internal_event()</text>
+        <text x="333" y="41" text-anchor="middle" fill="#8b90a0" font-size="9">Emit to launch context</text>
+        <!-- IPC arrow -->
+        <line x1="408" y1="28" x2="430" y2="28" stroke="#f472b6" stroke-width="1.3" stroke-dasharray="5,3" marker-end="url(#f3p)"/>
+        <text x="419" y="20" text-anchor="middle" fill="#8b90a0" font-size="8">IPC</text>
+        <rect x="432" y="10" width="150" height="36" rx="7" fill="rgba(244,114,182,0.1)" stroke="#5c2248" stroke-width="1"/>
+        <text x="507" y="28" text-anchor="middle" fill="#f472b6" font-size="11" font-weight="500">OnInternalEvent</text>
+        <text x="507" y="41" text-anchor="middle" fill="#8b90a0" font-size="9">Match + inject topics</text>
+        <line x1="507" y1="46" x2="507" y2="68" stroke="#4a4e5a" stroke-width="1" marker-end="url(#f3a)"/>
+        <rect x="412" y="70" width="190" height="48" rx="7" fill="rgba(244,114,182,0.15)" stroke="#f472b6" stroke-width="1.5"/>
+        <text x="507" y="90" text-anchor="middle" fill="#f472b6" font-size="12" font-weight="600">Execute Launch Entity</text>
+        <text x="507" y="105" text-anchor="middle" fill="#8b90a0" font-size="9">OpaqueFunction (inline method)</text>
+        <text x="507" y="116" text-anchor="middle" fill="#8b90a0" font-size="9">or ROS launch action</text>
+      </svg>
+    </div>
+  </div>
+</div>
+
+<!-- Flow 4 -->
+<div class="flow-detail" id="flow-4">
+  <div class="flow-detail-inner">
+    <h3>
+      <span class="tag tag-callable">Callable</span>
+      <span class="tag tag-monitor">Monitor</span>
+      Callable Condition → Monitor Action
+    </h3>
+    <p class="flow-desc">
+      The Monitor polls the user-supplied callable at <code>check_rate</code> Hz via a timer.
+      When it returns <code>True</code>, the registered system-level action is executed directly.
+    </p>
+    <div class="flow-svg-wrap">
+      <svg viewBox="0 0 530 130" width="530" height="130" xmlns="http://www.w3.org/2000/svg" font-family="Inter, system-ui, sans-serif">
+        <defs><marker id="f4a" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="none" stroke="#4a4e5a" stroke-width="1.2"/></marker></defs>
+        <rect x="2" y="20" width="110" height="40" rx="7" fill="rgba(251,146,60,0.1)" stroke="#5c3a18" stroke-width="1"/>
+        <text x="57" y="37" text-anchor="middle" fill="#fb923c" font-size="11" font-weight="500">Timer Tick</text>
+        <text x="57" y="53" text-anchor="middle" fill="#8b90a0" font-size="9">check_rate Hz</text>
+        <line x1="112" y1="40" x2="128" y2="40" stroke="#4a4e5a" stroke-width="1" marker-end="url(#f4a)"/>
+        <rect x="130" y="20" width="100" height="40" rx="7" fill="rgba(251,146,60,0.1)" stroke="#5c3a18" stroke-width="1"/>
+        <text x="180" y="37" text-anchor="middle" fill="#fb923c" font-size="11" font-weight="500">callable()</text>
+        <text x="180" y="53" text-anchor="middle" fill="#8b90a0" font-size="9">Returns True</text>
+        <line x1="230" y1="40" x2="246" y2="40" stroke="#4a4e5a" stroke-width="1" marker-end="url(#f4a)"/>
+        <rect x="248" y="20" width="100" height="40" rx="7" fill="rgba(108,140,255,0.1)" stroke="#3a4d8c" stroke-width="1"/>
+        <text x="298" y="35" text-anchor="middle" fill="#6c8cff" font-size="10" font-weight="500">check_action</text>
+        <text x="298" y="47" text-anchor="middle" fill="#6c8cff" font-size="10" font-weight="500">_condition()</text>
+        <line x1="348" y1="40" x2="368" y2="40" stroke="#4a4e5a" stroke-width="1" marker-end="url(#f4a)"/>
+        <rect x="370" y="18" width="155" height="44" rx="7" fill="rgba(108,140,255,0.15)" stroke="#6c8cff" stroke-width="1.5"/>
+        <text x="447" y="38" text-anchor="middle" fill="#6c8cff" font-size="12" font-weight="600">ThreadPoolExecutor</text>
+        <text x="447" y="53" text-anchor="middle" fill="#8b90a0" font-size="9">publish / srv / action goal</text>
+      </svg>
+    </div>
+  </div>
+</div>
+
+<!-- Flow 5 -->
+<div class="flow-detail" id="flow-5">
+  <div class="flow-detail-inner">
+    <h3>
+      <span class="tag tag-callable">Callable</span>
+      <span class="tag tag-bridge">Bridge</span>
+      <span class="tag tag-component">Component</span>
+      Callable Condition → Component Action (Bridge)
+    </h3>
+    <p class="flow-desc">
+      The callable lives in the recipe (main process) but the action must run inside the component (separate process).
+      A <strong>bridge topic</strong> (<code>/event_bridge/e_{id}_{component}</code>) carries a <code>Bool</code>
+      message across the process boundary.
+    </p>
+    <div class="flow-svg-wrap">
+      <svg viewBox="0 0 860 200" width="860" height="200" xmlns="http://www.w3.org/2000/svg" font-family="Inter, system-ui, sans-serif">
+        <defs>
+          <marker id="f5a" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="none" stroke="#4a4e5a" stroke-width="1.2"/></marker>
+          <marker id="f5y" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="none" stroke="#facc15" stroke-width="1.2"/></marker>
+        </defs>
+        <!-- Process boundary boxes -->
+        <rect x="5" y="5" width="480" height="190" rx="12" fill="rgba(108,140,255,0.04)" stroke="#3a4d8c" stroke-width="1" stroke-dasharray="7,4"/>
+        <text x="18" y="24" fill="#6c8cff" font-size="10" font-weight="600" letter-spacing="0.06em">MONITOR (main process)</text>
+        <rect x="510" y="5" width="345" height="190" rx="12" fill="rgba(74,222,128,0.04)" stroke="#1a4d30" stroke-width="1" stroke-dasharray="7,4"/>
+        <text x="523" y="24" fill="#4ade80" font-size="10" font-weight="600" letter-spacing="0.06em">COMPONENT (separate process)</text>
+        <!-- Step 1: Timer -->
+        <rect x="18" y="42" width="115" height="34" rx="7" fill="rgba(251,146,60,0.1)" stroke="#5c3a18" stroke-width="1"/>
+        <text x="75" y="58" text-anchor="middle" fill="#fb923c" font-size="11" font-weight="500">Timer</text>
+        <text x="75" y="70" text-anchor="middle" fill="#8b90a0" font-size="9">check_rate Hz</text>
+        <line x1="133" y1="59" x2="148" y2="59" stroke="#4a4e5a" stroke-width="1" marker-end="url(#f5a)"/>
+        <!-- Step 2: Callable -->
+        <rect x="150" y="42" width="100" height="34" rx="7" fill="rgba(251,146,60,0.1)" stroke="#5c3a18" stroke-width="1"/>
+        <text x="200" y="58" text-anchor="middle" fill="#fb923c" font-size="11" font-weight="500">callable()</text>
+        <text x="200" y="70" text-anchor="middle" fill="#8b90a0" font-size="9">Returns True</text>
+        <line x1="250" y1="59" x2="268" y2="59" stroke="#4a4e5a" stroke-width="1" marker-end="url(#f5a)"/>
+        <!-- Step 3: Publish -->
+        <rect x="270" y="38" width="200" height="42" rx="7" fill="rgba(108,140,255,0.1)" stroke="#3a4d8c" stroke-width="1"/>
+        <text x="370" y="56" text-anchor="middle" fill="#6c8cff" font-size="11" font-weight="500">publish_message()</text>
+        <text x="370" y="71" text-anchor="middle" fill="#8b90a0" font-size="9">Bool(True) → /event_bridge/e_...</text>
+        <!-- Bridge arrow across process boundary -->
+        <line x1="470" y1="59" x2="528" y2="59" stroke="#facc15" stroke-width="1.8" stroke-dasharray="6,3" marker-end="url(#f5y)"/>
+        <text x="499" y="50" text-anchor="middle" fill="#facc15" font-size="9" font-weight="600">ROS Topic</text>
+        <!-- Step 4: Component subscription -->
+        <rect x="530" y="42" width="155" height="34" rx="7" fill="rgba(74,222,128,0.1)" stroke="#1a4d30" stroke-width="1"/>
+        <text x="607" y="58" text-anchor="middle" fill="#4ade80" font-size="11" font-weight="500">Subscription callback</text>
+        <text x="607" y="70" text-anchor="middle" fill="#8b90a0" font-size="9">Bridge topic listener</text>
+        <line x1="607" y1="76" x2="607" y2="96" stroke="#4a4e5a" stroke-width="1" marker-end="url(#f5a)"/>
+        <!-- Step 5: Blackboard -->
+        <rect x="530" y="98" width="155" height="34" rx="7" fill="rgba(74,222,128,0.1)" stroke="#1a4d30" stroke-width="1"/>
+        <text x="607" y="114" text-anchor="middle" fill="#4ade80" font-size="11" font-weight="500">Blackboard update</text>
+        <text x="607" y="126" text-anchor="middle" fill="#8b90a0" font-size="9">on-any → True</text>
+        <line x1="607" y1="132" x2="607" y2="148" stroke="#4a4e5a" stroke-width="1" marker-end="url(#f5a)"/>
+        <!-- Step 6: Execute -->
+        <rect x="525" y="150" width="180" height="36" rx="7" fill="rgba(74,222,128,0.15)" stroke="#4ade80" stroke-width="1.5"/>
+        <text x="615" y="166" text-anchor="middle" fill="#4ade80" font-size="12" font-weight="600">ThreadPoolExecutor</text>
+        <text x="615" y="180" text-anchor="middle" fill="#8b90a0" font-size="9">@component_action method</text>
+        <!-- Why box -->
+        <rect x="18" y="100" width="440" height="78" rx="7" fill="rgba(250,204,21,0.05)" stroke="rgba(250,204,21,0.2)" stroke-width="1"/>
+        <text x="34" y="120" fill="#facc15" font-size="10" font-weight="600">Why a bridge?</text>
+        <text x="34" y="136" fill="#8b90a0" font-size="9.5">The callable condition is a Python function defined in the recipe (main process).</text>
+        <text x="34" y="150" fill="#8b90a0" font-size="9.5">The @component_action runs inside the component's node (separate process).</text>
+        <text x="34" y="164" fill="#8b90a0" font-size="9.5">The bridge topic provides safe cross-process communication via ROS2 pub/sub.</text>
+      </svg>
+    </div>
+  </div>
+</div>
+
+<!-- Flow 6 -->
+<div class="flow-detail" id="flow-6">
+  <div class="flow-detail-inner">
+    <h3>
+      <span class="tag tag-callable">Callable</span>
+      <span class="tag tag-launcher">Launcher</span>
+      Callable Condition → Launcher Action
+    </h3>
+    <p class="flow-desc">
+      The Monitor polls the callable. On trigger, it emits an <code>InternalEvent</code> to the launch context,
+      where the Launcher executes the inline recipe method or ROS launch action.
+    </p>
+    <div class="flow-svg-wrap">
+      <svg viewBox="0 0 620 130" width="620" height="130" xmlns="http://www.w3.org/2000/svg" font-family="Inter, system-ui, sans-serif">
+        <defs>
+          <marker id="f6a" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="none" stroke="#4a4e5a" stroke-width="1.2"/></marker>
+          <marker id="f6p" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="none" stroke="#f472b6" stroke-width="1.2"/></marker>
+        </defs>
+        <rect x="2" y="20" width="100" height="36" rx="7" fill="rgba(251,146,60,0.1)" stroke="#5c3a18" stroke-width="1"/>
+        <text x="52" y="38" text-anchor="middle" fill="#fb923c" font-size="11" font-weight="500">Timer Tick</text>
+        <text x="52" y="51" text-anchor="middle" fill="#8b90a0" font-size="9">check_rate Hz</text>
+        <line x1="102" y1="38" x2="118" y2="38" stroke="#4a4e5a" stroke-width="1" marker-end="url(#f6a)"/>
+        <rect x="120" y="20" width="100" height="36" rx="7" fill="rgba(251,146,60,0.1)" stroke="#5c3a18" stroke-width="1"/>
+        <text x="170" y="38" text-anchor="middle" fill="#fb923c" font-size="11" font-weight="500">callable()</text>
+        <text x="170" y="51" text-anchor="middle" fill="#8b90a0" font-size="9">Returns True</text>
+        <line x1="220" y1="38" x2="236" y2="38" stroke="#4a4e5a" stroke-width="1" marker-end="url(#f6a)"/>
+        <rect x="238" y="20" width="150" height="36" rx="7" fill="rgba(108,140,255,0.1)" stroke="#3a4d8c" stroke-width="1"/>
+        <text x="313" y="38" text-anchor="middle" fill="#6c8cff" font-size="11" font-weight="500">_on_internal_event()</text>
+        <text x="313" y="51" text-anchor="middle" fill="#8b90a0" font-size="9">Emit to context</text>
+        <line x1="388" y1="38" x2="412" y2="38" stroke="#f472b6" stroke-width="1.3" stroke-dasharray="5,3" marker-end="url(#f6p)"/>
+        <text x="400" y="30" text-anchor="middle" fill="#8b90a0" font-size="8">IPC</text>
+        <rect x="414" y="20" width="140" height="36" rx="7" fill="rgba(244,114,182,0.1)" stroke="#5c2248" stroke-width="1"/>
+        <text x="484" y="38" text-anchor="middle" fill="#f472b6" font-size="11" font-weight="500">OnInternalEvent</text>
+        <text x="484" y="51" text-anchor="middle" fill="#8b90a0" font-size="9">Match event_name</text>
+        <line x1="484" y1="56" x2="484" y2="72" stroke="#4a4e5a" stroke-width="1" marker-end="url(#f6a)"/>
+        <rect x="404" y="74" width="160" height="42" rx="7" fill="rgba(244,114,182,0.15)" stroke="#f472b6" stroke-width="1.5"/>
+        <text x="484" y="92" text-anchor="middle" fill="#f472b6" font-size="12" font-weight="600">Execute</text>
+        <text x="484" y="107" text-anchor="middle" fill="#8b90a0" font-size="9">Inline recipe method</text>
+      </svg>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════════════════════════════ -->
+<!-- SECTION 3: ROUTING DECISION TREE                                  -->
+<!-- ══════════════════════════════════════════════════════════════════ -->
+<h2>Action Routing Decision Tree</h2>
+<p class="section-desc">
+  The Launcher inspects each action and routes it based on ownership.
+  Hover over destination boxes to see the responsible source file and method.
+</p>
+
+<div class="routing-container">
+<svg viewBox="0 0 920 460" width="920" height="460" xmlns="http://www.w3.org/2000/svg" font-family="Inter, system-ui, sans-serif">
+  <defs>
+    <marker id="a-dim" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="none" stroke="#4a4e5a" stroke-width="1.2"/></marker>
+    <marker id="a-accent" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="none" stroke="#6c8cff" stroke-width="1.2"/></marker>
+    <marker id="a-green" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="none" stroke="#4ade80" stroke-width="1.2"/></marker>
+    <marker id="a-pink" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="none" stroke="#f472b6" stroke-width="1.2"/></marker>
+    <marker id="a-yellow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="none" stroke="#facc15" stroke-width="1.2"/></marker>
+  </defs>
+
+  <!-- ROOT -->
+  <rect x="340" y="12" width="240" height="42" rx="8" fill="var(--surface2)" stroke="#4a4e5a" stroke-width="1.2"/>
+  <text x="460" y="38" text-anchor="middle" fill="#e1e4eb" font-size="14" font-weight="600">Event / Action Pair</text>
+
+  <line x1="460" y1="54" x2="460" y2="82" stroke="#4a4e5a" stroke-width="1.2" marker-end="url(#a-dim)"/>
+
+  <!-- Decision 1: Callable? -->
+  <rect x="345" y="84" width="230" height="38" rx="7" fill="rgba(251,146,60,0.1)" stroke="#5c3a18" stroke-width="1"/>
+  <text x="460" y="108" text-anchor="middle" fill="#fb923c" font-size="13" font-weight="500">Callable-based condition?</text>
+
+  <!-- NO (left) -->
+  <line x1="345" y1="103" x2="210" y2="103" stroke="#4a4e5a" stroke-width="1.2"/>
+  <line x1="210" y1="103" x2="210" y2="162" stroke="#4a4e5a" stroke-width="1.2" marker-end="url(#a-dim)"/>
+  <text x="272" y="97" text-anchor="middle" fill="#8b90a0" font-size="12">No (topic-based)</text>
+
+  <!-- YES (right) -->
+  <line x1="575" y1="103" x2="710" y2="103" stroke="#4a4e5a" stroke-width="1.2"/>
+  <line x1="710" y1="103" x2="710" y2="162" stroke="#4a4e5a" stroke-width="1.2" marker-end="url(#a-dim)"/>
+  <text x="646" y="97" text-anchor="middle" fill="#8b90a0" font-size="12">Yes (callable)</text>
+
+  <!-- LEFT: component_action? -->
+  <rect x="105" y="164" width="210" height="38" rx="7" fill="rgba(74,222,128,0.1)" stroke="#1a4d30" stroke-width="1"/>
+  <text x="210" y="188" text-anchor="middle" fill="#4ade80" font-size="13" font-weight="500">@component_action?</text>
+
+  <line x1="210" y1="202" x2="210" y2="232" stroke="#4a4e5a" stroke-width="1.2" marker-end="url(#a-dim)"/>
+  <text x="222" y="222" fill="#8b90a0" font-size="11">Yes</text>
+
+  <rect x="115" y="234" width="190" height="38" rx="7" fill="rgba(74,222,128,0.1)" stroke="#1a4d30" stroke-width="1"/>
+  <text x="210" y="258" text-anchor="middle" fill="#4ade80" font-size="13" font-weight="500">Lifecycle action?</text>
+
+  <line x1="115" y1="253" x2="40" y2="253" stroke="#4a4e5a" stroke-width="1.2"/>
+  <line x1="40" y1="253" x2="40" y2="340" stroke="#f472b6" stroke-width="1.2" marker-end="url(#a-pink)"/>
+  <text x="72" y="247" fill="#8b90a0" font-size="11">Yes</text>
+
+  <line x1="210" y1="272" x2="210" y2="340" stroke="#4ade80" stroke-width="1.2" marker-end="url(#a-green)"/>
+  <text x="222" y="305" fill="#8b90a0" font-size="11">No</text>
+
+  <!-- No component → system-level? -->
+  <line x1="315" y1="183" x2="435" y2="183" stroke="#4a4e5a" stroke-width="1.2"/>
+  <line x1="435" y1="183" x2="435" y2="232" stroke="#4a4e5a" stroke-width="1.2" marker-end="url(#a-dim)"/>
+  <text x="372" y="177" fill="#8b90a0" font-size="11">No</text>
+
+  <rect x="330" y="234" width="210" height="38" rx="7" fill="rgba(108,140,255,0.1)" stroke="#3a4d8c" stroke-width="1"/>
+  <text x="435" y="258" text-anchor="middle" fill="#6c8cff" font-size="13" font-weight="500">System-level action?</text>
+
+  <line x1="388" y1="272" x2="388" y2="340" stroke="#6c8cff" stroke-width="1.2" marker-end="url(#a-accent)"/>
+  <text x="370" y="305" fill="#8b90a0" font-size="11">Yes</text>
+
+  <line x1="482" y1="272" x2="482" y2="340" stroke="#f472b6" stroke-width="1.2" marker-end="url(#a-pink)"/>
+  <text x="498" y="305" fill="#8b90a0" font-size="11">No</text>
+
+  <!-- RIGHT: component action? -->
+  <rect x="600" y="164" width="220" height="38" rx="7" fill="rgba(74,222,128,0.1)" stroke="#1a4d30" stroke-width="1"/>
+  <text x="710" y="188" text-anchor="middle" fill="#4ade80" font-size="13" font-weight="500">Action owned by component?</text>
+
+  <line x1="660" y1="202" x2="660" y2="340" stroke="#6c8cff" stroke-width="1.2" marker-end="url(#a-accent)"/>
+  <text x="643" y="225" fill="#8b90a0" font-size="11">No</text>
+
+  <line x1="820" y1="183" x2="862" y2="183" stroke="#4a4e5a" stroke-width="1.2"/>
+  <line x1="862" y1="183" x2="862" y2="340" stroke="#facc15" stroke-width="1.2" marker-end="url(#a-yellow)"/>
+  <text x="835" y="177" fill="#8b90a0" font-size="11">Yes</text>
+
+  <!-- DESTINATION BOXES -->
+  <rect class="dest-box" x="2" y="342" width="130" height="56" rx="9" fill="rgba(244,114,182,0.1)" stroke="#f472b6" stroke-width="1.5"
+    data-tooltip="launcher.py → _setup_internal_events_handlers()\nLifecycle transitions via launch events"/>
+  <text x="67" y="366" text-anchor="middle" fill="#f472b6" font-size="13" font-weight="600">Launcher</text>
+  <text x="67" y="384" text-anchor="middle" fill="#8b90a0" font-size="10">_ros_events_actions</text>
+
+  <rect class="dest-box" x="148" y="342" width="140" height="56" rx="9" fill="rgba(74,222,128,0.1)" stroke="#4ade80" stroke-width="1.5"
+    data-tooltip="launcher.py → __rewrite_actions_for_components()\nSerialized event JSON passed to component at init"/>
+  <text x="218" y="366" text-anchor="middle" fill="#4ade80" font-size="13" font-weight="600">Component</text>
+  <text x="218" y="384" text-anchor="middle" fill="#8b90a0" font-size="10">_components_events_actions</text>
+
+  <rect class="dest-box" x="306" y="342" width="170" height="56" rx="9" fill="rgba(108,140,255,0.1)" stroke="#6c8cff" stroke-width="1.5"
+    data-tooltip="monitor.py → __reconstruct_monitor_actions()\nResolves action names to Monitor methods"/>
+  <text x="391" y="366" text-anchor="middle" fill="#6c8cff" font-size="13" font-weight="600">Monitor</text>
+  <text x="391" y="384" text-anchor="middle" fill="#8b90a0" font-size="10">_monitor_events_actions</text>
+
+  <rect class="dest-box" x="492" y="342" width="130" height="56" rx="9" fill="rgba(244,114,182,0.1)" stroke="#f472b6" stroke-width="1.5"
+    data-tooltip="launcher.py → _setup_internal_events_handlers()\nInline recipe methods wrapped as OpaqueFunction"/>
+  <text x="557" y="366" text-anchor="middle" fill="#f472b6" font-size="13" font-weight="600">Launcher</text>
+  <text x="557" y="384" text-anchor="middle" fill="#8b90a0" font-size="10">_ros_events_actions</text>
+
+  <rect class="dest-box" x="636" y="342" width="100" height="56" rx="9" fill="rgba(108,140,255,0.1)" stroke="#6c8cff" stroke-width="1.5"
+    data-tooltip="monitor.py → _activate_event_monitoring()\nDirect execution via Monitor's ThreadPoolExecutor"/>
+  <text x="686" y="366" text-anchor="middle" fill="#6c8cff" font-size="13" font-weight="600">Monitor</text>
+  <text x="686" y="384" text-anchor="middle" fill="#8b90a0" font-size="10">direct exec</text>
+
+  <rect class="dest-box" x="790" y="342" width="128" height="56" rx="9" fill="rgba(250,204,21,0.1)" stroke="#facc15" stroke-width="1.5"
+    data-tooltip="launcher.py → __route_action_based_event()\nCreates /event_bridge/e_{id}_{component} Bool topic"/>
+  <text x="854" y="362" text-anchor="middle" fill="#facc15" font-size="13" font-weight="600">Bridge</text>
+  <text x="854" y="378" text-anchor="middle" fill="#8b90a0" font-size="10">Monitor → Topic</text>
+  <text x="854" y="392" text-anchor="middle" fill="#8b90a0" font-size="10">→ Component</text>
+
+  <!-- Key files footer -->
+  <rect x="30" y="420" width="860" height="32" rx="6" fill="rgba(255,255,255,0.02)" stroke="var(--border)" stroke-width="0.8"/>
+  <text x="460" y="441" text-anchor="middle" fill="#8b90a0" font-size="11">
+    <tspan font-weight="500" fill="#6c8cff">Routing:</tspan> launcher.py → __rewrite_actions_for_components() / __route_action_based_event()
+    <tspan dx="30" font-weight="500" fill="#6c8cff">Emission:</tspan> launch_actions.py → _on_internal_event()
+  </text>
+</svg>
+</div>
+
+<!-- ══════════════════════════════════════════════════════════════════ -->
+<!-- SECTION 4: BLACKBOARD & EVALUATION                                -->
+<!-- ══════════════════════════════════════════════════════════════════ -->
+<h2>Blackboard &amp; Condition Evaluation</h2>
+<p class="section-desc">
+  Both the Monitor and each Component maintain their own event blackboard.
+  Click on a blackboard entry to see how it is handled during evaluation.
+</p>
+
+<div class="bb-grid">
+  <div class="bb-card">
+    <h3>Event Blackboard</h3>
+    <p style="font-size:0.92rem;color:var(--text-dim);margin-bottom:1rem;">
+      <code>Dict[str, EventBlackboardEntry]</code> — one entry per subscribed topic
+    </p>
+
+    <div class="bb-entry" onclick="toggleBbDetail(this)" data-detail="Valid entry. Will be included in the clean cache subset passed to check_condition(). The UUID prevents this exact message instance from triggering the same event twice.">
+      <span class="bb-status fresh">FRESH</span>
+      <div class="bb-topic" style="color:var(--cyan)">/sensor/data</div>
+      <div class="bb-meta">msg: Float32(data=7.2) &nbsp;|&nbsp; age: 0.02s &nbsp;|&nbsp; id: a3f8...</div>
+      <div class="bb-expand-detail" style="display:none;color:var(--green);"></div>
+    </div>
+
+    <div class="bb-entry" onclick="toggleBbDetail(this)" data-detail="Age exceeds topic.data_timeout → Lazy Deletion: entry is removed from the dict entirely. Returns None for this topic, so multi-topic conditions with this dependency will not fire.">
+      <span class="bb-status expired">EXPIRED</span>
+      <div class="bb-topic" style="color:var(--cyan)">/camera/image</div>
+      <div class="bb-meta">msg: Image(...) &nbsp;|&nbsp; age: 3.1s &nbsp;|&nbsp; id: c72b...</div>
+      <div class="bb-expand-detail" style="display:none;color:var(--red);"></div>
+    </div>
+
+    <div class="bb-entry" onclick="toggleBbDetail(this)" data-detail="The entry ID matches the event's last_processed_id → this message already triggered this event. Returns None for this event specifically, but the entry stays in the dict for other events that depend on the same topic.">
+      <span class="bb-status stale">ALREADY PROCESSED</span>
+      <div class="bb-topic" style="color:var(--cyan)">/odom</div>
+      <div class="bb-meta">msg: Odometry(...) &nbsp;|&nbsp; age: 0.01s &nbsp;|&nbsp; id: e91d...</div>
+      <div class="bb-expand-detail" style="display:none;color:var(--orange);"></div>
+    </div>
+  </div>
+
+  <div class="bb-card">
+    <h3>Evaluation Pipeline</h3>
+
+    <div class="pipeline-step">
+      <div class="pipeline-num" style="background:rgba(34,211,238,0.15);color:var(--cyan);">1</div>
+      <div class="pipeline-text">
+        <strong>Message arrives</strong><br>
+        <span class="dim"><code>__event_topic_callback(topic, msg)</code> updates the blackboard entry with a fresh timestamp and new UUID.</span>
+      </div>
+    </div>
+
+    <div class="pipeline-step">
+      <div class="pipeline-num" style="background:rgba(108,140,255,0.15);color:var(--accent);">2</div>
+      <div class="pipeline-text">
+        <strong>Lookup dependent events</strong><br>
+        <span class="dim"><code>__events_per_topic[topic_name]</code> returns all events that reference this topic.</span>
+      </div>
+    </div>
+
+    <div class="pipeline-step">
+      <div class="pipeline-num" style="background:rgba(108,140,255,0.15);color:var(--accent);">3</div>
+      <div class="pipeline-text">
+        <strong>Build clean cache subset</strong><br>
+        <span class="dim">For each topic the event needs: check TTL (time-to-live) and idempotency (stale ID). Only valid entries pass through.</span>
+      </div>
+    </div>
+
+    <div class="pipeline-step">
+      <div class="pipeline-num" style="background:rgba(108,140,255,0.15);color:var(--accent);">4</div>
+      <div class="pipeline-text">
+        <strong>Evaluate condition tree</strong><br>
+        <span class="dim"><code>event.check_condition(subset)</code> — applies <code>on_change</code> rising edge,
+        <code>handle_once</code> guard, and <code>keep_event_delay</code> throttle.</span>
+      </div>
+    </div>
+
+    <div class="pipeline-step" style="border-bottom:none;">
+      <div class="pipeline-num" style="background:rgba(74,222,128,0.15);color:var(--green);">5</div>
+      <div class="pipeline-text">
+        <strong>Execute actions</strong><br>
+        <span class="dim">If triggered, submit all registered actions to the shared <code>ThreadPoolExecutor</code> (10 workers).
+        The ROS callback thread is never blocked.</span>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════════════════════════════ -->
+<!-- SECTION 5: DATA FLOW SUMMARY                                      -->
+<!-- ══════════════════════════════════════════════════════════════════ -->
+<h2>Internal Data Flow Summary</h2>
+<p class="section-desc">
+  How event/action data moves through the system from user configuration to runtime execution.
+</p>
+
+<div class="routing-container">
+<svg viewBox="0 0 860 400" width="860" height="400" xmlns="http://www.w3.org/2000/svg" font-family="Inter, system-ui, sans-serif">
+  <defs>
+    <marker id="da" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="none" stroke="#4a4e5a" stroke-width="1.2"/></marker>
+    <marker id="db" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="none" stroke="#6c8cff" stroke-width="1.2"/></marker>
+    <marker id="dg" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="none" stroke="#4ade80" stroke-width="1.2"/></marker>
+    <marker id="dp" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="none" stroke="#f472b6" stroke-width="1.2"/></marker>
+    <marker id="dy" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><path d="M0,0 L8,3 L0,6" fill="none" stroke="#facc15" stroke-width="1.2"/></marker>
+  </defs>
+
+  <!-- Phase 1: Configuration -->
+  <rect x="5" y="5" width="195" height="390" rx="12" fill="rgba(244,114,182,0.04)" stroke="#5c2248" stroke-width="1"/>
+  <text x="102" y="30" text-anchor="middle" fill="#f472b6" font-size="11" font-weight="600" letter-spacing="0.06em">CONFIGURATION</text>
+
+  <rect x="18" y="48" width="170" height="38" rx="7" fill="rgba(244,114,182,0.1)" stroke="#5c2248" stroke-width="1"/>
+  <text x="103" y="65" text-anchor="middle" fill="#f472b6" font-size="11" font-weight="500">launcher.add_pkg()</text>
+  <text x="103" y="80" text-anchor="middle" fill="#8b90a0" font-size="9">events_actions={...}</text>
+
+  <line x1="103" y1="86" x2="103" y2="106" stroke="#4a4e5a" stroke-width="1" marker-end="url(#da)"/>
+
+  <rect x="18" y="108" width="170" height="56" rx="7" fill="rgba(244,114,182,0.1)" stroke="#5c2248" stroke-width="1"/>
+  <text x="103" y="128" text-anchor="middle" fill="#f472b6" font-size="11" font-weight="500">__rewrite_actions</text>
+  <text x="103" y="142" text-anchor="middle" fill="#f472b6" font-size="11" font-weight="500">_for_components()</text>
+  <text x="103" y="158" text-anchor="middle" fill="#8b90a0" font-size="9">Route by ownership</text>
+
+  <!-- Arrows to 3 destinations -->
+  <line x1="188" y1="130" x2="222" y2="68" stroke="#6c8cff" stroke-width="1.2" marker-end="url(#db)"/>
+  <line x1="188" y1="135" x2="222" y2="190" stroke="#4ade80" stroke-width="1.2" marker-end="url(#dg)"/>
+  <line x1="188" y1="140" x2="222" y2="310" stroke="#f472b6" stroke-width="1.2" marker-end="url(#dp)"/>
+
+  <!-- Phase 2: Storage -->
+  <rect x="210" y="5" width="245" height="390" rx="12" fill="rgba(255,255,255,0.02)" stroke="var(--border)" stroke-width="1"/>
+  <text x="332" y="30" text-anchor="middle" fill="#e1e4eb" font-size="11" font-weight="600" letter-spacing="0.06em">STORAGE</text>
+
+  <!-- Monitor dict -->
+  <rect x="224" y="48" width="218" height="54" rx="7" fill="rgba(108,140,255,0.1)" stroke="#3a4d8c" stroke-width="1"/>
+  <text x="333" y="66" text-anchor="middle" fill="#6c8cff" font-size="11" font-weight="500">_monitor_events_actions</text>
+  <text x="333" y="80" text-anchor="middle" fill="#8b90a0" font-size="9">Dict[Event, List[Action]]</text>
+  <text x="333" y="94" text-anchor="middle" fill="#8b90a0" font-size="9">System-level + callable bridge actions</text>
+
+  <!-- Component dict -->
+  <rect x="224" y="170" width="218" height="54" rx="7" fill="rgba(74,222,128,0.1)" stroke="#1a4d30" stroke-width="1"/>
+  <text x="333" y="188" text-anchor="middle" fill="#4ade80" font-size="11" font-weight="500">_components_events_actions</text>
+  <text x="333" y="202" text-anchor="middle" fill="#8b90a0" font-size="9">Dict[str(JSON), List[Action]]</text>
+  <text x="333" y="216" text-anchor="middle" fill="#8b90a0" font-size="9">Serialized events → component actions</text>
+
+  <!-- ROS events dict -->
+  <rect x="224" y="292" width="218" height="54" rx="7" fill="rgba(244,114,182,0.1)" stroke="#5c2248" stroke-width="1"/>
+  <text x="333" y="310" text-anchor="middle" fill="#f472b6" font-size="11" font-weight="500">_ros_events_actions</text>
+  <text x="333" y="324" text-anchor="middle" fill="#8b90a0" font-size="9">Dict[str(ID), List[LaunchEntity]]</text>
+  <text x="333" y="338" text-anchor="middle" fill="#8b90a0" font-size="9">+ _internal_events (Event objects)</text>
+
+  <!-- Phase 3: Runtime -->
+  <rect x="470" y="5" width="385" height="390" rx="12" fill="rgba(255,255,255,0.02)" stroke="var(--border)" stroke-width="1"/>
+  <text x="662" y="30" text-anchor="middle" fill="#e1e4eb" font-size="11" font-weight="600" letter-spacing="0.06em">RUNTIME</text>
+
+  <!-- Monitor runtime -->
+  <line x1="442" y1="75" x2="488" y2="75" stroke="#6c8cff" stroke-width="1.2" marker-end="url(#db)"/>
+  <rect x="490" y="48" width="350" height="78" rx="7" fill="rgba(108,140,255,0.06)" stroke="#3a4d8c" stroke-width="1"/>
+  <text x="665" y="66" text-anchor="middle" fill="#6c8cff" font-size="11" font-weight="500">Monitor Node</text>
+  <text x="665" y="82" text-anchor="middle" fill="#8b90a0" font-size="9.5">__reconstruct_monitor_actions() → resolve method refs</text>
+  <text x="665" y="96" text-anchor="middle" fill="#8b90a0" font-size="9.5">_activate_event_monitoring() → create subscriptions + timers</text>
+  <text x="665" y="110" text-anchor="middle" fill="#8b90a0" font-size="9.5">__event_topic_callback() / check_action_condition()</text>
+
+  <!-- Component runtime -->
+  <line x1="442" y1="197" x2="488" y2="197" stroke="#4ade80" stroke-width="1.2" marker-end="url(#dg)"/>
+  <rect x="490" y="170" width="350" height="64" rx="7" fill="rgba(74,222,128,0.06)" stroke="#1a4d30" stroke-width="1"/>
+  <text x="665" y="190" text-anchor="middle" fill="#4ade80" font-size="11" font-weight="500">Component Node</text>
+  <text x="665" y="206" text-anchor="middle" fill="#8b90a0" font-size="9.5">Deserialize events from JSON → Event objects</text>
+  <text x="665" y="220" text-anchor="middle" fill="#8b90a0" font-size="9.5">_turn_on_events_management() → subscriptions + register actions</text>
+
+  <!-- Launcher runtime -->
+  <line x1="442" y1="319" x2="488" y2="319" stroke="#f472b6" stroke-width="1.2" marker-end="url(#dp)"/>
+  <rect x="490" y="292" width="350" height="78" rx="7" fill="rgba(244,114,182,0.06)" stroke="#5c2248" stroke-width="1"/>
+  <text x="665" y="310" text-anchor="middle" fill="#f472b6" font-size="11" font-weight="500">Launcher (ROS Launch Context)</text>
+  <text x="665" y="326" text-anchor="middle" fill="#8b90a0" font-size="9.5">_setup_internal_events_handlers() → OnInternalEvent handlers</text>
+  <text x="665" y="340" text-anchor="middle" fill="#8b90a0" font-size="9.5">ComponentLaunchAction.execute() → register emit callbacks</text>
+  <text x="665" y="354" text-anchor="middle" fill="#8b90a0" font-size="9.5">InternalEvent emitted → handler matches → entity executes</text>
+
+  <!-- Emit arrow from monitor to launcher -->
+  <line x1="665" y1="126" x2="665" y2="148" stroke="#f472b6" stroke-width="1" stroke-dasharray="4,3"/>
+  <rect x="600" y="148" width="130" height="18" rx="4" fill="rgba(244,114,182,0.1)" stroke="#5c2248" stroke-width="0.8"/>
+  <text x="665" y="161" text-anchor="middle" fill="#f472b6" font-size="8.5">emit InternalEvent</text>
+  <line x1="665" y1="166" x2="665" y2="290" stroke="#f472b6" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#dp)"/>
+
+  <!-- Bridge arrow from monitor to component -->
+  <line x1="555" y1="126" x2="555" y2="168" stroke="#facc15" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#dy)"/>
+  <text x="535" y="150" fill="#facc15" font-size="8.5">bridge</text>
+</svg>
+</div>
+
+<!-- ══════════════════════════════════════════════════════════════════ -->
+<!-- TOOLTIP                                                           -->
+<!-- ══════════════════════════════════════════════════════════════════ -->
+<div class="tooltip" id="tooltip"></div>
+
+<script>
+// ── Flow selection & architecture highlighting ──
+let activeFlow = null;
+
+const flowHighlightMap = {
+  1: { nodes: ['node-monitor'], procs: ['proc-main'] },
+  2: { nodes: ['node-comp-a'], procs: ['proc-comp-a'] },
+  3: { nodes: ['node-monitor', 'node-launcher'], procs: ['proc-main'] },
+  4: { nodes: ['node-monitor'], procs: ['proc-main'] },
+  5: { nodes: ['node-monitor', 'node-comp-a'], procs: ['proc-main', 'proc-comp-a'] },
+  6: { nodes: ['node-monitor', 'node-launcher'], procs: ['proc-main'] },
+};
+
+function clearHighlights() {
+  document.querySelectorAll('.flow-btn').forEach(b => b.classList.remove('active'));
+  document.querySelectorAll('.flow-detail').forEach(d => d.classList.remove('visible'));
+  document.querySelectorAll('.node-card').forEach(c => c.classList.remove('highlight', 'highlight-green', 'highlight-pink'));
+  document.querySelectorAll('.process-box').forEach(p => p.classList.remove('highlight'));
+  document.querySelectorAll('.cap-list li').forEach(li => li.classList.remove('active'));
+}
+
+function selectFlow(n) {
+  const wasActive = activeFlow === n;
+  clearHighlights();
+  if (wasActive) { activeFlow = null; return; }
+
+  activeFlow = n;
+  document.querySelector('.flow-btn[data-flow="' + n + '"]').classList.add('active');
+  const detail = document.getElementById('flow-' + n);
+  detail.classList.add('visible');
+
+  // Highlight architecture nodes
+  const hl = flowHighlightMap[n];
+  hl.nodes.forEach(function(id) {
+    var el = document.getElementById(id);
+    if (id.startsWith('node-comp')) el.classList.add('highlight-green');
+    else if (id === 'node-launcher') el.classList.add('highlight-pink');
+    else el.classList.add('highlight');
+  });
+  hl.procs.forEach(function(id) { document.getElementById(id).classList.add('highlight'); });
+
+  // Highlight relevant capabilities
+  document.querySelectorAll('.cap-list li[data-flow]').forEach(function(li) {
+    var flows = li.dataset.flow.split(',');
+    if (flows.indexOf(String(n)) !== -1 || flows.indexOf('all') !== -1) {
+      li.classList.add('active');
+    }
+  });
+
+  // Scroll detail into view smoothly
+  setTimeout(function() { detail.scrollIntoView({ behavior: 'smooth', block: 'nearest' }); }, 50);
+}
+
+// ── Blackboard entry expand/collapse ──
+function toggleBbDetail(entry) {
+  var detail = entry.querySelector('.bb-expand-detail');
+  if (detail.style.display === 'none') {
+    detail.textContent = entry.dataset.detail;
+    detail.style.display = 'block';
+  } else {
+    detail.style.display = 'none';
+  }
+}
+
+// ── SVG Tooltips on destination boxes ──
+var tooltip = document.getElementById('tooltip');
+
+document.querySelectorAll('.dest-box').forEach(function(el) {
+  el.style.cursor = 'pointer';
+
+  el.addEventListener('mouseenter', function(e) {
+    var raw = el.getAttribute('data-tooltip');
+    var lines = raw.split('\\n');
+    tooltip.innerHTML = lines.map(function(l, i) {
+      return i === 0
+        ? '<div class="tt-file">' + l + '</div>'
+        : '<div style="color:var(--text-dim);font-size:0.85rem;margin-top:2px;">' + l + '</div>';
+    }).join('');
+    tooltip.classList.add('show');
+  });
+
+  el.addEventListener('mousemove', function(e) {
+    tooltip.style.left = (e.clientX + 14) + 'px';
+    tooltip.style.top = (e.clientY - 10) + 'px';
+  });
+
+  el.addEventListener('mouseleave', function() {
+    tooltip.classList.remove('show');
+  });
+});
+
+// ── Keyboard navigation ──
+document.addEventListener('keydown', function(e) {
+  if (e.key >= '1' && e.key <= '6') {
+    selectFlow(parseInt(e.key));
+  } else if (e.key === 'Escape') {
+    clearHighlights();
+    activeFlow = null;
+  }
+});
+</script>
+
+</body>
+</html>

--- a/docs/development/event_system.md
+++ b/docs/development/event_system.md
@@ -1,52 +1,38 @@
-# Event & Action System Internals
+# Event-Driven Architecture
 
-This document covers the internal mechanics of the event-action system in Sugarcoat, including event types, condition evaluation, action dispatch, and the fallback system.
+Sugarcoat provides a declarative event-driven system that lets you define **conditions** on ROS2 topics or Python callables and associate them with **actions** that execute when the conditions are met. This page covers both the user-facing API and the low-level implementation details for developers working on or extending the framework.
 
-## Event Overview
+:::{tip}
+Open the [Interactive Architecture Diagram](../advanced/events_architecture.html) for a visual version of the routing and flow diagrams below, with clickable flow selectors and architecture highlighting.
+:::
 
-An `Event` (defined in `ros_sugar.core.event`) represents a condition on ROS topic data that, when satisfied, triggers one or more `Action` instances. Events are evaluated continuously by the `Monitor` node against a shared topic cache (the "blackboard").
+---
 
-### Event Construction
+## Part 1 — Event & Action API
 
-Events are constructed from `Condition` objects, which are typically built implicitly through Python comparison operators on topic message builders:
+### Condition Types
+
+#### Condition Expression
+
+A declarative predicate on a topic message attribute. To build the condition, all the nested attributes of a ROS2 topic are accessible via the `msg` attribute. The condition is evaluated each time new data arrives on the involved topic.
 
 ```python
+from ros_sugar.core import Event
 from ros_sugar.io import Topic
-from ros_sugar.io.supported_types import Float32
 
-sensor = Topic(name="/battery_level", msg_type=Float32)
+event_topic = Topic(name="/float_input", msg_type="Float32")
 
-# This builds a Condition via MsgConditionBuilder.__gt__
-low_battery = Event(sensor.msg.data < 10.0)
+event = Event(event_condition=event_topic.msg.data > 3.0, on_change=True)
 ```
 
-The expression `sensor.msg.data` returns a `MsgConditionBuilder` that captures the attribute path `["data"]`. Applying a comparison operator (e.g., `<`) produces a `Condition` object with:
+The expression `event_topic.msg.data` returns a `MsgConditionBuilder` that captures the attribute path `["data"]`. Applying a comparison operator (e.g., `>`) produces a `Condition` object with the topic name, attribute path, operator function, and reference value.
 
-- `topic_name`: `"/battery_level"`
-- `attribute_path`: `["data"]`
-- `operator_func`: `operator.lt`
-- `ref_value`: `10.0`
-
-## Condition Tree
-
-Conditions can be composed using logical operators to form a tree:
-
-```python
-# AND: both conditions must be true
-critical = Event((sensor.msg.data < 5.0) & (motor.msg.status == 1))
-
-# OR: either condition triggers
-alert = Event((sensor.msg.data < 10.0) | (temp.msg.data > 80.0))
-```
-
-Internally, this creates a composite `Condition` with a `ConditionLogicOp` (`AND`, `OR`, or `NOT`) and a list of `sub_conditions`. Evaluation is recursive -- the `Condition.evaluate()` method walks the tree and applies each leaf condition against the topic cache.
-
-### Nested Attribute Access
+#### Nested Attribute Access
 
 `MsgConditionBuilder` supports chained attribute access to reach deeply nested fields in ROS messages:
 
 ```python
-odom = Topic(name="/odom", msg_type=Odometry)
+odom = Topic(name="/odom", msg_type="Odometry")
 
 # Access odom.pose.pose.position.x
 position_event = Event(odom.msg.pose.pose.position.x > 5.0)
@@ -54,9 +40,25 @@ position_event = Event(odom.msg.pose.pose.position.x > 5.0)
 
 Attribute paths are validated at construction time against the ROS message type hierarchy. An `AttributeError` is raised if the path is invalid.
 
-## Event Types (Condition Patterns)
+#### Condition Tree (Compound Conditions)
 
-Sugarcoat supports several event patterns, all built using `Condition` expressions:
+Conditions can be composed using logical operators to form a tree:
+
+```python
+sensor = Topic(name="/battery_level", msg_type="Float32")
+motor = Topic(name="/motor", msg_type="Int32")
+temp = Topic(name="/temperature", msg_type="Float32")
+
+# AND: both conditions must be true
+critical = Event((sensor.msg.data < 5.0) & (motor.msg.data == 1))
+
+# OR: either condition triggers
+alert = Event((sensor.msg.data < 10.0) | (temp.msg.data > 80.0))
+```
+
+Internally, this creates a composite `Condition` with a `ConditionLogicOp` (`AND`, `OR`, or `NOT`) and a list of `sub_conditions`. Evaluation is recursive — the `Condition.evaluate()` method walks the tree and applies each leaf condition against the topic cache.
+
+#### Event Patterns Summary
 
 | Pattern | Description | Example |
 |:--------|:------------|:--------|
@@ -67,17 +69,27 @@ Sugarcoat supports several event patterns, all built using `Condition` expressio
 | **OnDifferent** | Fires when value differs from reference | `Event(topic.msg.data != expected)` |
 | **OnChange** | Fires on transition from False to True | `Event(condition, on_change=True)` |
 | **OnCondition** | Fires on arbitrary compound condition | `Event((a.msg.x > 1) & (b.msg.y < 2))` |
-| **OnExternalEvent** | Fires from an `InternalEvent` emitted by the launch system | Used internally by `Launcher` |
 
-### OnAny
+#### Topic (on-any)
 
 When a `Topic` object is passed directly (rather than a `Condition`), the event fires whenever all involved topics have data present in the blackboard:
 
 ```python
-camera_ready = Event(camera_topic)
+event = Event(event_condition=event_topic)
 ```
 
-### OnChange
+#### Callable
+
+A user-supplied function polled at `check_rate` Hz. It must return `bool` and must **not** be a `@component_action` method (those are bound to Actions and Fallbacks and cannot be used as conditions).
+
+```python
+def timeout_reached() -> bool:
+    return time.time() - last_update > 5.0
+
+event = Event(event_condition=timeout_reached, check_rate=10.0)
+```
+
+#### OnChange (Edge Detection)
 
 Setting `on_change=True` adds edge-detection semantics. The event fires only on the transition from `False` to `True`, not while the condition remains true:
 
@@ -86,7 +98,7 @@ Setting `on_change=True` adds edge-detection semantics. The event fires only on 
 entered_danger = Event(sensor.msg.data < 0.5, on_change=True)
 ```
 
-## JSON Serialization
+#### JSON Serialization
 
 Events and their conditions support full serialization for multi-process execution. When components run in separate processes, events are serialized via `Event.to_json()` / `Event.from_json()`, which in turn serializes the `Condition` tree. This is used by the `Launcher` when spawning components via `ExecuteProcess`.
 
@@ -97,16 +109,20 @@ restored_event = Event.from_json(event_json)
 
 The serialization preserves the complete condition tree, operator functions (mapped by name), reference values, and topic metadata.
 
-## Action Dispatch
+---
 
-An `Action` (defined in `ros_sugar.core.action`) wraps a callable that is executed when an event triggers. Actions can wrap:
+### Action Types and Ownership
 
-- A component method (decorated with `@component_action`)
-- A plain Python function
-- An async coroutine
-- A ROS launch action (e.g., `LogInfo`)
+Every action will have an **owner**: the process/node responsible for executing it. Ownership determines how the event/action pair is routed at launch time.
 
-### Registering Actions
+| # | Action type | Example | Owner |
+|---|---|---|---|
+| 1 | Inline recipe method | A plain Python callable defined in the launch script | Main process (Launcher) |
+| 2 | Component action | A method implemented in a component class, decorated with `@component_action` | The component node |
+| 3 | System-level action | Actions available in the `actions` module, such as `publish_message`, `send_srv_request`, `send_action_goal` | Main process (Monitor) |
+| 4 | ROS launch action | Standard `ros2 launch` actions (e.g. `TimerAction`) | Main process (Launcher) |
+
+#### Registering Actions
 
 Actions are associated with events through the `Launcher.add_pkg()` method:
 
@@ -121,31 +137,13 @@ launcher.add_pkg(
 )
 ```
 
-Internally, `event.register_actions()` stores the actions on the event. When `check_condition()` evaluates to `True`, the actions are submitted to a shared `ThreadPoolExecutor` for non-blocking execution.
+#### The `@component_action` Decorator
 
-### Topic Data Injection
+Marks a component method as callable from the event system. It enforces:
 
-When an action fires, the current topic cache (a dict mapping topic names to their latest messages) is passed as a `topics` keyword argument. Actions can use this to access the data that triggered the event:
-
-```python
-def handle_collision(topics: dict = None):
-    scan = topics.get("/laser_scan")
-    # ... react to scan data ...
-```
-
-### Automatic Type Conversion
-
-If an event involves a single topic, `Action._setup_conversions()` attempts to create an automatic parser from the event's message type to the action's expected input type. This allows actions to receive converted data without manual parsing.
-
-## @component_action Decorator
-
-The `component_action` decorator (in `ros_sugar.utils`) validates action methods at call time:
-
-1. **Instance check**: Ensures the method is called on a `LifecycleNode` instance.
-2. **Return type**: Verifies the return annotation is `bool` or `None`.
-3. **Lifecycle state**: If `active=True`, the component must be in the Active state.
-
-The decorator can be used bare or with parameters:
+- The method must be a bound method on a `LifecycleNode` subclass.
+- The return type must be `bool` or `None`.
+- If `active=True` is passed, the method only executes when the component is in the `ACTIVE` lifecycle state.
 
 ```python
 from ros_sugar.utils import component_action
@@ -178,11 +176,73 @@ class Navigator(BaseComponent):
 
 When `description` is provided, it is stored on the wrapper as `_action_description` and can be used by orchestrating LLM agents to discover available tools. When omitted, the method's docstring is used instead.
 
-## Fallback System
+#### System-Level Actions
 
-The fallback system provides automatic failure recovery. It is managed by `ComponentFallbacks` (in `ros_sugar.core.fallbacks`).
+Provided by the `ros_sugar.actions` module and executed by the Monitor node:
 
-### ComponentFallbacks
+| Action | Description |
+|---|---|
+| `publish_message(topic, msg, ...)` | Publishes a message on a topic (optionally at a rate for a duration) |
+| `send_srv_request(srv_name, srv_type, srv_request_msg)` | Sends a ROS2 service request |
+| `send_action_goal(server_name, server_type, request_msg)` | Sends a ROS2 action goal |
+
+#### Dynamic Arguments from Topics
+
+Actions can receive live data from ROS topics as arguments. Instead of passing a static value, pass a `topic.msg.attribute` expression — the framework will automatically extract the value from the event's topic data at runtime and inject it into the method call.
+
+::::{tab-set}
+
+:::{tab-item} Positional args
+```python
+sensor = Topic(name="/sensor", msg_type="Float32")
+
+def handle_reading(value: float):
+    print(f"Sensor reading: {value}")
+
+event = Event(event_condition=sensor)
+action = Action(method=handle_reading, args=(sensor.msg.data,))
+```
+:::
+
+:::{tab-item} Keyword args
+```python
+odom = Topic(name="/odom", msg_type=Odometry)
+
+def navigate(x: float, y: float):
+    print(f"Going to ({x}, {y})")
+
+event = Event(event_condition=odom)
+action = Action(
+    method=navigate,
+    kwargs={
+        "x": odom.msg.pose.pose.position.x,
+        "y": odom.msg.pose.pose.position.y,
+    },
+)
+```
+:::
+
+:::{tab-item} Mixed (static + dynamic)
+```python
+def log_alert(level: str, value: float):
+    print(f"[{level}] value = {value}")
+
+# "level" is static, "value" comes from the topic at runtime
+action = Action(method=log_alert, args=("WARNING", sensor.msg.data))
+```
+:::
+
+::::
+
+These expressions (`topic.msg.data`, `odom.msg.pose.pose.position.x`, etc.) are `MsgConditionBuilder` objects — the same ones used to build conditions. When used as action arguments, they tell the framework which topic and which nested attribute to extract at execution time.
+
+---
+
+### Fallback System
+
+The fallback system provides automatic failure recovery. It is managed by `ComponentFallbacks` (defined in `ros_sugar.core.fallbacks`).
+
+#### ComponentFallbacks
 
 `ComponentFallbacks` holds a set of `Fallback` objects, one for each failure level:
 
@@ -194,9 +254,9 @@ The fallback system provides automatic failure recovery. It is managed by `Compo
 | `on_any_fail` | Any failure without a specific fallback defined |
 | `on_giveup` | All fallbacks for a failure level have been exhausted |
 
-### Fallback
+#### Defining Fallbacks
 
-Each `Fallback` (an `attrs`-defined class) wraps one or more `Action` instances and a `max_retries` count:
+Each `Fallback` wraps one or more `Action` instances and a `max_retries` count:
 
 ```python
 from ros_sugar.core import Action, ComponentFallbacks, Fallback
@@ -213,7 +273,7 @@ fallbacks = ComponentFallbacks(
 )
 ```
 
-### Failure Hierarchy
+#### Failure Hierarchy
 
 When a failure is detected, `ComponentFallbacks` follows this resolution order:
 
@@ -225,15 +285,313 @@ When a failure is detected, `ComponentFallbacks` follows this resolution order:
 
 A successful fallback execution (action returns `True`) resets the health status to `STATUS_HEALTHY`.
 
-### Default Behavior
+---
 
-By default, `BaseComponent` sets `on_any_fail` to `Action(self.broadcast_status)` with `max_retries=None` (infinite retries). This means any failure that does not have a specific fallback will cause the component to broadcast its status continuously, allowing the `Monitor` to detect the issue.
+## Part 2 — Architecture & Routing Internals
 
-## Monitor's Role in the Event-Action Loop
+### Event/Action Routing — Who keeps track of What
 
-The `Monitor` ties events, actions, and fallbacks together:
+When you associate events with actions in the launch script via `launcher.add_pkg(events_actions={...})`, the Launcher inspects each action to determine its owner, then routes the event to the appropriate process. This routing logic lives in the Launcher's `__rewrite_actions_for_components` method.
 
-1. **Event evaluation**: The `Monitor` subscribes to all topics involved in registered events. On each message, it updates the blackboard and evaluates all events.
-2. **Action dispatch**: When an event triggers, the `Monitor` either executes the action directly (for simple callables) or emits an `InternalEvent` that the `Launcher` handles (for lifecycle transitions or process-level actions).
-3. **Health monitoring**: The `Monitor` subscribes to each component's `ComponentStatus` topic. When a failure is detected, it triggers the component's fallback chain.
-4. **Staleness detection**: `EventBlackboardEntry` tracks message UUIDs and timestamps. The `Monitor` uses these to avoid re-triggering events on stale data and to perform lazy expiration of old entries.
+#### Topic-Based Conditions
+
+The event can be associated with a list of actions, and **whoever owns the action, owns the event monitoring**. If one event maps to actions with different owners, the event monitoring is duplicated: each owner subscribes to the event topic independently and triggers only its own action.
+
+**Routing rules for each action in the list:**
+
+```
+Action is a @component_action?
+├─ Yes, lifecycle action (start/stop/restart) → ROS launch event handler (Launcher)
+├─ Yes, non-lifecycle                         → Serialized to component (_components_events_actions)
+├─ No, system-level (publish_message, etc.)   → Monitor (_monitor_events_actions)
+└─ No, inline recipe method / ROS launch      → ROS launch event handler (Launcher, via _internal_events)
+```
+
+#### Callable-Based Conditions
+
+Callable-based conditions are always defined in the recipe, so they are always **owned by the main process**. The Monitor polls them via a timer. The routing then depends on who owns the consequence action:
+
+**Case 1 — Action owned by the main process (recipe method, monitor action, or ROS launch action):**
+
+The event and action stay together in the main process. The Monitor polls the callable, and on trigger either executes the action directly (monitor actions) or emits back to the Launcher context (recipe methods and ROS launch actions).
+
+**Case 2 — Action owned by a component:**
+
+The callable condition runs in the main process, but the action must execute inside the component's node. Since these live in different processes, a **bridge event** is created:
+
+1. The Launcher creates a bridge topic: `/event_bridge/e_{event_id}_{component_name}` of type `std_msgs/Bool`.
+2. The Monitor polls the callable condition at `check_rate`. When it returns `True`, the Monitor publishes `Bool(True)` to the bridge topic.
+3. The target component subscribes to the bridge topic. On receiving the message, it evaluates the (trivially true) on-any condition and executes the associated `@component_action`.
+
+```
+   Monitor (main process)                        Component (separate process)
+   ┌──────────────────────┐                      ┌──────────────────────────┐
+   │ Timer (check_rate)   │                      │                          │
+   │   ↓                  │                      │                          │
+   │ callable() == True?  │   Bool(True)         │ Subscription callback    │
+   │   ↓ yes              │ ──────────────────→  │   ↓                      │
+   │ publish to bridge    │  /event_bridge/...   │ on-any condition → True  │
+   │                      │                      │   ↓                      │
+   └──────────────────────┘                      │ execute @component_action│
+                                                 └──────────────────────────┘
+```
+
+---
+
+### Low-Level Implementation
+
+#### Key Data Structures
+
+##### `EventBlackboardEntry`
+> Defined in `ros_sugar/core/event.py`
+
+A timestamped wrapper around a ROS message. Every time a topic message is received, it is stored as a blackboard entry with:
+
+- `msg`: The raw ROS message.
+- `timestamp`: Unix time of reception.
+- `id`: A UUID4 for idempotency — prevents the same message instance from triggering the same event twice.
+
+The blackboard uses **lazy expiration**: expired or already-processed entries are cleaned up at evaluation time, not by a background sweep. This avoids lock contention and unnecessary timers.
+
+##### `Event`
+> Defined in `ros_sugar/core/event.py`
+
+The runtime trigger unit. Holds the condition (a `Condition` expression, a `Topic`, or a `Callable`), maintains trigger state, and executes registered actions. Key behavioral knobs:
+
+- `on_change`: Only fires on a rising edge (false → true transition).
+- `handle_once`: Fires at most once across the event's lifetime.
+- `keep_event_delay`: Throttles re-triggers by holding the "under processing" flag for a fixed duration after actions complete.
+
+Actions are executed via a shared `ThreadPoolExecutor` (default 10 workers) to avoid blocking the ROS callback thread.
+
+##### `InternalEvent` / `OnInternalEvent`
+> Defined in `ros_sugar/core/event.py`
+
+The bridge between the Monitor node and the ROS2 launch system. `InternalEvent` is a ROS launch event type that carries an `event_name` and `topics_value` dict. `OnInternalEvent` is a ROS launch event handler that matches by event name and injects topic data into the launch entities before execution.
+
+---
+
+:::{dropdown} The Monitor Node
+:open:
+
+> Defined in `ros_sugar/core/monitor.py`
+
+The Monitor is a ROS2 node that runs in the main process. It is responsible for:
+
+1. **Subscribing to event topics** and evaluating topic-based conditions.
+2. **Polling callable-based conditions** via timers.
+3. **Executing system-level actions** (publish_message, send_srv_request, etc.).
+4. **Emitting internal events** back to the Launcher context for actions the Launcher owns.
+5. **Health monitoring**: subscribing to each component's `ComponentStatus` topic. When a failure is detected, it triggers the component's fallback chain.
+
+**Activation Flow** (`_activate_event_monitoring`)
+
+When the Monitor activates, it:
+
+1. **Reconstructs monitor actions** (`__reconstruct_monitor_actions`): For events in `_monitor_events_actions`, it resolves each action by name to the corresponding Monitor method (e.g., `publish_message`) and registers it on the Event object.
+
+2. **Merges internal events**: Events from `_internal_events` (those that need to emit back to the Launcher) are appended to the Monitor's event list.
+
+3. **Creates the topic blackboard**: A shared `Dict[str, EventBlackboardEntry]` that caches the latest message for each topic across all events.
+
+4. **Builds a topic → events index** (`__events_per_topic`): Maps each unique topic name to the list of events that depend on it, enabling efficient lookup on message arrival.
+
+5. **Creates one ROS subscription per unique topic**: All events sharing a topic share a single subscriber. The callback `__event_topic_callback` updates the blackboard and evaluates all dependent events.
+
+6. **Creates callable-based polling timers** (`__start_callable_based_event_timers`): One timer per callable-based event, polling at `check_rate` Hz (or `config.loop_rate` if not specified).
+
+**Topic-Based Condition Evaluation** (`__event_topic_callback`)
+
+On every incoming message:
+
+1. The blackboard entry for that topic is updated with the new message, timestamp, and a fresh UUID.
+2. All events that depend on this topic are retrieved from `__events_per_topic`.
+3. For each event, a **clean cache subset** is built by checking freshness and idempotency for every topic the event needs (via `EventBlackboardEntry.get`).
+4. `event.check_condition(clean_cache_subset)` evaluates the condition tree. If triggered, actions are submitted to the thread pool.
+
+**Callable-Based Condition Evaluation**
+
+Each callable-based event gets its own timer. On each tick:
+
+1. `event.check_action_condition(blackboard)` calls the user-supplied callable directly.
+2. If it returns `True` (accounting for `on_change` rising-edge logic), the registered actions are submitted to the thread pool.
+
+:::
+
+:::{dropdown} The Launcher
+
+> Defined in `ros_sugar/launch/launcher.py`
+
+The Launcher is the entry point of a Sugarcoat application. It is **not** a ROS2 node — it orchestrates the ROS2 launch system. Its responsibilities regarding events:
+
+**Action Routing** (`__rewrite_actions_for_components`)
+
+For each event/action pair provided by the user, the Launcher classifies the action and routes it to the appropriate owner:
+
+- **Component actions** (non-lifecycle): Serialized into `_components_events_actions`. The serialized event JSON is later deserialized by the component at startup.
+- **Monitor actions**: Stored in `_monitor_events_actions`, passed directly to the Monitor node at initialization.
+- **Launcher-owned actions** (inline methods, ROS launch actions, lifecycle actions): Stored in `_ros_events_actions` and the event is added to `_internal_events`.
+
+For **callable-based events** the routing is handled by `__route_action_based_event`, which either keeps the event in the Monitor (Case 1) or creates a bridge topic (Case 2), as described above.
+
+**Internal Events Handler Setup** (`_setup_internal_events_handlers`)
+
+For events routed to `_ros_events_actions`, the Launcher:
+
+1. Converts each action into a launch entity:
+   - ROS launch actions are used directly.
+   - Lifecycle actions are converted via `_get_action_launch_entity`.
+   - Inline recipe methods are wrapped as `OpaqueFunction` via `action.launch_action(monitor_node=...)`.
+
+2. Registers an `OnInternalEvent` handler for each event name, wrapping the entities list.
+
+3. Adds the handler to the launch description.
+
+At runtime, when the Monitor detects a trigger for one of these events, it emits an `InternalEvent` to the launch context. The `OnInternalEvent` handler matches by event name, injects the topic data into the entities, and executes them.
+
+**Monitor ↔ Launcher Emission Bridge** (`ComponentLaunchAction`)
+
+> Defined in `ros_sugar/launch/launch_actions.py`
+
+When the Monitor's `ComponentLaunchAction` executes, it registers the `_on_internal_event` callback on every internal event:
+
+- **Topic-based internal events**: `event.register_actions(partial(self._on_internal_event, event.id))` — the emit callback is registered as an action on the Event object. When the event triggers, it calls the callback which emits an `InternalEvent` to the launch context.
+- **Callable-based internal events** (`_pure_internal_events`): `_register_pure_internal_event_emit_method(event_id, ...)` stores the emit callback in the Monitor's `emit_internal_event_methods` dict.
+
+The `_on_internal_event` method:
+1. Creates an `InternalEvent` with the event name.
+2. Snapshots the Monitor's topic blackboard into `topics_value`.
+3. Emits the event to the launch context via `context.emit_event_sync`, using `call_soon_threadsafe` for thread safety.
+
+:::
+
+:::{dropdown} The Component
+
+> Defined in `ros_sugar/core/component.py`
+
+Components handle events that are routed to them via `_components_events_actions`. The mechanism mirrors the Monitor's topic-based flow.
+
+**Event Setup** (`_turn_on_events_management`)
+
+Called during `on_activate()`. The component:
+
+1. Creates a topic blackboard (`_events_topics_blackboard`).
+2. Builds a topic → events index (`__events_per_topic`).
+3. Registers actions on each event via `event.register_actions(actions)`.
+4. Creates one ROS subscription per unique topic — including bridge topics for callable-based events.
+
+**Event Evaluation** (`__event_topic_callback`)
+
+Identical to the Monitor's flow: update blackboard → lazy cleanup → `event.check_condition(clean_cache_subset)` → async action execution.
+
+Components **never poll callable conditions directly**. If a callable condition needs to trigger a component action, the bridge mechanism converts it into a topic-based event from the component's perspective.
+
+:::
+
+:::{dropdown} The Action Class
+
+> Defined in `ros_sugar/core/action.py`
+
+The `Action` class wraps a callable and manages argument preparation, dynamic topic data extraction, and conversion to ROS launch entities.
+
+**Construction and Argument Classification** (`__verify_args_kwargs`)
+
+When an `Action` is constructed, its `args` and `kwargs` are scanned for `MsgConditionBuilder` objects (expressions like `topic.msg.data`). These are separated from static values:
+
+- **Static values** are stored directly in `_args` (tuple) and `_kwargs` (dict) and passed to the method on every call.
+- **Dynamic values** (`MsgConditionBuilder` instances) are stored in a separate `__input_topics` dict, keyed as `arg_{index}` for positional arguments or `kwarg_{name}` for keyword arguments. Each entry records the topic name and the attribute path to extract at runtime.
+
+**Execution** (`__call__`)
+
+When an event triggers, the `Event` object calls `action(topics=global_topic_cache)` where `global_topic_cache` is a dict mapping topic names to their latest ROS messages. The `Action.__call__` method then:
+
+1. Creates mutable copies of the static `_args` and `_kwargs`.
+2. Iterates over `__input_topics`. For each entry:
+   - Looks up the topic's message in the `topics` dict.
+   - Calls `topic_condition.get_value(object_value=message)` which walks the stored attribute path (e.g., `["pose", "pose", "position", "x"]`) to extract the nested value from the message.
+   - Inserts the value into `call_args` (by index) or `call_kwargs` (by name).
+3. Runs any registered automatic type conversions (`__prepared_events_conversions`).
+4. Calls the underlying `executable` with the fully prepared arguments.
+
+**Automatic Type Conversion** (`_setup_conversions`)
+
+When an event involves a single topic, the `Event` calls `action._setup_conversions(topic_name, msg_type)` at registration time. This uses `_create_auto_topic_parser` to attempt an automatic conversion from the event's message type to the action's expected input types, using three strategies in order:
+
+1. **Exact match**: Input and target are the same type — pass through directly.
+2. **Duck typing**: All target fields exist in the input with matching types — copy matching fields.
+3. **Type-based heuristic**: Field names differ but types match uniquely — map by type (with a warning).
+
+If a conversion is found, it is stored and applied automatically during `__call__`.
+
+**Wrapping for ROS Launch** (`launch_action`)
+
+Inline recipe methods and ROS launch actions need to execute within the Launcher's launch context. The `launch_action` method converts an `Action` into a launch-compatible entity:
+
+1. If the action is a monitor action (`_is_monitor_action`), it resolves the executable from the Monitor node by name.
+2. Wraps the executable in a new function that prepends a `LaunchContext` parameter (required by the ROS launch framework).
+3. Updates the function's `__signature__` so that ROS launch's introspection (`inspect.signature`) sees the `LaunchContext` parameter.
+4. Returns an `OpaqueFunction` (for synchronous methods) or `OpaqueCoroutine` (for async methods).
+
+At runtime, when the Launcher's `OnInternalEvent` handler fires, it injects the `topics` data into the `OpaqueFunction`'s kwargs before executing it, so the action receives the event's topic cache just as it would when called directly by the Monitor.
+
+:::
+
+---
+
+### End-to-End Flows
+
+::::{tab-set}
+
+:::{tab-item} Topic-Based Flows
+
+**Flow 1: Topic → Monitor Action**
+```
+ROS Topic → Monitor subscription → blackboard update →
+  condition evaluation → trigger → ThreadPoolExecutor →
+  Monitor method (e.g. publish_message)
+```
+
+**Flow 2: Topic → Component Action**
+```
+ROS Topic → Component subscription → blackboard update →
+  condition evaluation → trigger → ThreadPoolExecutor →
+  @component_action method
+```
+
+**Flow 3: Topic → Launcher-Owned Action**
+```
+ROS Topic → Monitor subscription → blackboard update →
+  condition evaluation → trigger → _on_internal_event →
+  emit InternalEvent to launch context →
+  OnInternalEvent handler matches → execute OpaqueFunction (inline method)
+```
+
+:::
+
+:::{tab-item} Callable-Based Flows
+
+**Flow 4: Callable → Monitor Action**
+```
+Timer (check_rate) → callable() → True →
+  trigger → ThreadPoolExecutor → Monitor method
+```
+
+**Flow 5: Callable → Component Action (Bridge)**
+```
+Timer (check_rate) → callable() → True →
+  Monitor publishes Bool(True) to /event_bridge/... →
+  Component subscription → blackboard update →
+  on-any condition → True → ThreadPoolExecutor →
+  @component_action method
+```
+
+**Flow 6: Callable → Launcher-Owned Action**
+```
+Timer (check_rate) → callable() → True →
+  _on_internal_event → emit InternalEvent to launch context →
+  OnInternalEvent handler matches → execute OpaqueFunction
+```
+
+:::
+
+::::

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -1185,12 +1185,14 @@ class BaseComponent(lifecycle.Node):
             self.__actions = []
         for event_serialized, actions in events_actions_dict.items():
             action_set = actions if isinstance(actions, list) else [actions]
+            event = Event.from_json(event_serialized)
             for action in action_set:
                 if not hasattr(self, action.action_name):
                     raise ValueError(
                         f"Component '{self.node_name}' does not support action '{action.action_name}'"
                     )
-            self.__events.append(Event.from_json(event_serialized))
+                event.verify_required_action_topics(action)
+            self.__events.append(event)
             self.__actions.append(action_set)
 
     # SERIALIZATION AND DESERIALIZATION

--- a/ros_sugar/core/event.py
+++ b/ros_sugar/core/event.py
@@ -520,6 +520,8 @@ class Event:
         finally:
             # Reset the flag only after work + delay are done
             self.under_processing = False
+            # NOTE: We set this to true even if the consequent action failed
+            # with an error
             self._processed_once = True
 
     def register_actions(
@@ -550,6 +552,10 @@ class Event:
         Replaces existing trigger logic.
         Evaluates the root Condition tree against the global cache.
         """
+        # Dont keep on checking for handle once events after they have been processed
+        if self._handle_once and self._processed_once:
+            return
+
         topics_dict = {key: value.msg for key, value in global_topic_cache.items()}
 
         if self._on_any:
@@ -596,6 +602,10 @@ class Event:
         """Evaluate the action-based condition and execute registered actions if triggered.
         Called periodically by a component timer; should only be used on action-based events.
         """
+        # Dont keep on checking for handle once events after they have been processed
+        if self._handle_once and self._processed_once:
+            return
+
         triggered = bool(self._action_condition())
 
         if self._on_change and self._previous_trigger is not None:

--- a/ros_sugar/core/event.py
+++ b/ros_sugar/core/event.py
@@ -572,13 +572,15 @@ class Event:
             # 1. the event previous value is different from the event current value (there is a change)
             # and 2. if the new_trigger is on
             # If on_change and 1 and 2 -> activate the trigger
-            if (
-                self._on_change
-                and self._previous_trigger is not None
-                and not self._previous_trigger
-                and triggered
-            ):
-                self.trigger = True
+            if self._on_change:
+                if (
+                    self._previous_trigger is not None
+                    and not self._previous_trigger
+                    and triggered
+                ):
+                    self.trigger = True
+                else:
+                    self.trigger = False
             else:
                 # If:
                 # 1. on_change is not required

--- a/ros_sugar/core/event.py
+++ b/ros_sugar/core/event.py
@@ -1,5 +1,6 @@
 """Event"""
 
+import inspect
 import json
 import time
 import uuid
@@ -204,10 +205,28 @@ class EventBlackboardEntry:
 
 
 class Event:
-    """An Event is defined by a change in a ROS2 message value on a specific topic. Events are created to alert a robot software stack to any dynamic change at runtime.
+    """A runtime trigger driven by ROS2 topic data or a callable condition.
 
-    Events are used by matching them to 'Actions'; an Action is meant to be executed at runtime once the Event is triggered.
+    An Event monitors one of three condition types and fires registered Actions
+    when the condition becomes true:
 
+    1. **Condition expression** – a declarative predicate on topic message
+       attributes (e.g. ``topic.msg.speed > 5.0``). The condition is evaluated
+       each time new data arrives on the involved topics.
+    2. **Topic (on-any)** – triggers whenever a valid message is available on
+       the given topic(s), regardless of content.
+    3. **Callable** – a user-supplied function polled at ``check_rate`` whose
+       boolean return value determines the trigger state.
+
+    Trigger behaviour can be further refined with:
+
+    * ``on_change`` – fire only on a *rising edge* (condition transitions from
+      false to true), rather than every evaluation cycle.
+    * ``handle_once`` – fire at most once and then become inert.
+    * ``keep_event_delay`` – hold the *under-processing* flag for a fixed
+      duration after actions complete, throttling re-triggers.
+
+    Actions are executed asynchronously via a shared ``ThreadPoolExecutor``.
     """
 
     # SHARED EXECUTOR across all Event instances to prevent thread explosion.
@@ -218,29 +237,35 @@ class Event:
 
     def __init__(
         self,
-        event_condition: Union[Topic, Condition],
+        event_condition: Union[Topic, Condition, Callable],
         on_change: bool = False,
         handle_once: bool = False,
         keep_event_delay: float = 0.0,
+        check_rate: Optional[float] = None,
     ) -> None:
-        """Creates an event
+        """Create a new Event.
 
-        :param event_name: Event key name
-        :type event_name: str
-        :param event_source: Event source configured using a Topic instance or a valid json/dict config
-        :type event_source: Union[Topic, str, Dict]
-        :param trigger_value: Triggers event using this reference value
-        :type trigger_value: Union[float, int, bool, str, List, None]
-        :param nested_attributes: Attribute names to access within the event_source Topic
-        :type nested_attributes: Union[str, List[str]]
-        :param handle_once: Handle the event only once during the node lifetime, defaults to False
+        :param event_condition: The source that drives this event. Can be a
+            ``Condition`` expression on topic attributes, a ``Topic`` for
+            on-any monitoring, or a ``Callable`` that returns ``bool`` and is
+            polled at ``check_rate``.
+        :type event_condition: Union[Topic, Condition, Callable]
+        :param on_change: If True, trigger only on a rising edge (condition
+            transitions from False to True), defaults to False.
+        :type on_change: bool, optional
+        :param handle_once: If True, execute registered actions at most once
+            across the lifetime of this event, defaults to False.
         :type handle_once: bool, optional
-        :param keep_event_delay: Add a time delay between consecutive event handling instances, defaults to 0.0
+        :param keep_event_delay: Minimum delay in seconds to hold the
+            under-processing flag after actions complete, throttling
+            re-triggers, defaults to 0.0.
         :type keep_event_delay: float, optional
-
-        :raises AttributeError: If a non-valid event_source is provided
-
-        :raises TypeError: If the provided nested_attributes cannot be accessed in the Topic message type
+        :param check_rate: Polling rate in Hz for callable-based conditions. If not provided, the component loop_rate is used instead.
+            Only used when ``event_condition`` is a Callable, defaults to None.
+        :type check_rate: Optional[float], optional
+        :raises TypeError: If a callable-based condition is a component-bound
+            method or does not return bool.
+        :raises AttributeError: If ``event_condition`` is not a supported type.
         """
         # Unique event ID
         self.__id = str(uuid.uuid4())
@@ -255,9 +280,15 @@ class Event:
         # Case 1: Init from Condition Expression (topic.msg.data > 5)
         if isinstance(event_condition, Condition):
             self._condition = event_condition
+            self._action_condition: Optional[Action] = None
+            self._is_action_based: bool = False
+            self.check_rate: Optional[float] = None
 
-        # Topics are passed for on_any event
+        # Case 2: Topics are passed for on_any event
         elif isinstance(event_condition, Topic):
+            self._action_condition: Optional[Action] = None
+            self._is_action_based: bool = False
+            self.check_rate: Optional[float] = None
             self._condition = Condition(
                 topic_name=event_condition.name,
                 topic_msg_type=event_condition.msg_type.__name__,
@@ -267,9 +298,28 @@ class Event:
                 ref_value=None,
             )
             self._on_any = True
+        # Case 3: Callable-based polling: action return value is the boolean condition
+        elif isinstance(event_condition, Callable):
+            self._condition = None
+            self._action_condition = Action(method=event_condition)
+            self._is_action_based = True
+            self.check_rate = check_rate
+            # Validate: must not be a @component_action (bound to a component lifecycle)
+            if self._action_condition.component_action:
+                raise TypeError(
+                    f"Cannot use a component method '{event_condition.__name__}' as an event_condition. "
+                    f"Use a plain callable instead."
+                )
+            # Validate: return type must be bool
+            return_type = inspect.signature(event_condition).return_annotation
+            if return_type is not inspect.Parameter.empty and return_type is not bool:
+                raise TypeError(
+                    f"event_condition callable must return bool, "
+                    f"but '{event_condition.__name__}' has return annotation '{return_type}'."
+                )
         else:
             raise AttributeError(
-                f"Cannot initialize Event class. Must provide 'event_source' as a Topic or a valid config from json or dictionary or a condition, got {type(event_condition)}"
+                f"Cannot initialize Event class. Must provide 'event_condition' as a Topic, a Condition on a Topic or a valid Method to be checked at check_rate, got {type(event_condition)}"
             )
 
         # Init trigger as False
@@ -280,9 +330,10 @@ class Event:
 
         # Required topics registry
         self.__required_topics: List[Topic] = []
-        required_topics_dict: Dict = self._condition._get_involved_topics()
-        for topic_name, topic_dict in required_topics_dict.items():
-            self.__required_topics.append(Topic(name=topic_name, **topic_dict))
+        if not self._is_action_based:
+            required_topics_dict: Dict = self._condition._get_involved_topics()
+            for topic_name, topic_dict in required_topics_dict.items():
+                self.__required_topics.append(Topic(name=topic_name, **topic_dict))
 
         # Additional Action Topics
         self.__additional_action_topics: List[Topic] = []
@@ -343,9 +394,10 @@ class Event:
         :return: Event description dictionary
         :rtype: Dict
         """
+        # NOTE: callable-based events are always handled by the Monitor (main process). Events with callable conditions will never be ran in a different process, so the serialization/deserialization of action_condition is not needed
         event_dict = {
             "name": self.__id,
-            "condition": self._condition.to_json(),
+            "condition": self._condition.to_json() if self._condition else None,
             "handle_once": self._handle_once,
             "keep_event_delay": self._keep_event_delay,
             "on_change": self._on_change,
@@ -468,6 +520,7 @@ class Event:
         finally:
             # Reset the flag only after work + delay are done
             self.under_processing = False
+            self._processed_once = True
 
     def register_actions(
         self, actions: Union[Action, Callable, List[Union[Action, Callable]]]
@@ -477,7 +530,6 @@ class Event:
         :param actions: Action or a list of Actions
         :type actions: Union[Action, List[Action]]
         """
-        self._registered_on_trigger_actions = []
         actions = actions if isinstance(actions, List) else [actions]
         # If it is a simple condition
         topics = self.get_involved_topics()
@@ -499,12 +551,12 @@ class Event:
         Evaluates the root Condition tree against the global cache.
         """
         topics_dict = {key: value.msg for key, value in global_topic_cache.items()}
-        self._previous_trigger = copy(self.trigger)
 
         if self._on_any:
             # Check that all involved topics has values
             topics_names = [topic.name for topic in self.get_involved_topics()]
             self.trigger = all(topics_dict.get(key, None) for key in topics_names)
+            self._previous_trigger = copy(self.trigger)
         else:
             # This assumes self.event_condition is now the root Condition object
             triggered = self._condition.evaluate(topics_dict)
@@ -527,6 +579,7 @@ class Event:
                 # or 2. the event previous value is the same as the current value (no change happened)
                 # then just directly update the trigger
                 self.trigger = triggered
+            self._previous_trigger = copy(triggered)
 
         if self.trigger:
             # If triggered update the last processed IDs
@@ -537,8 +590,32 @@ class Event:
             self._execute_actions(topics_dict)
         return
 
+    def check_action_condition(
+        self, global_topic_cache: Dict[str, EventBlackboardEntry]
+    ) -> None:
+        """Evaluate the action-based condition and execute registered actions if triggered.
+        Called periodically by a component timer; should only be used on action-based events.
+        """
+        triggered = bool(self._action_condition())
+
+        if self._on_change and self._previous_trigger is not None:
+            self.trigger = triggered and not self._previous_trigger
+        else:
+            self.trigger = triggered
+
+        if self.trigger:
+            topics_dict = {key: value.msg for key, value in global_topic_cache.items()}
+            self.__last_processed_ids = {
+                key: value.id for key, value in global_topic_cache.items()
+            }
+            self._execute_actions(topics_dict)
+
+        self._previous_trigger = copy(triggered)
+
     def __str__(self) -> str:
         """
         str for Event object
         """
+        if self._is_action_based:
+            return f"Callable Based Event(On '{self._action_condition.action_name}' returns true polled at {self.check_rate if self.check_rate else 'loop_rate'}Hz) (ID {self.__id})"
         return f"{self._condition._readable()} (ID {self.__id})"

--- a/ros_sugar/core/monitor.py
+++ b/ros_sugar/core/monitor.py
@@ -175,6 +175,8 @@ class Monitor(Node):
         # Create health status subscribers
         if self._components_to_monitor:
             for component_name in self._components_to_monitor:
+                # TODO: Adds status subscribers with heart beat check for
+                # process fail recovery
                 self._turn_on_component_management(component_name)
 
         # Activate event monitoring

--- a/ros_sugar/core/monitor.py
+++ b/ros_sugar/core/monitor.py
@@ -43,7 +43,7 @@ class Monitor(Node):
     def __init__(
         self,
         components_names: List[str],
-        events_actions: Optional[Dict[str, List[Action]]] = None,
+        events_actions: Optional[Dict[Event, List[Action]]] = None,
         events_to_emit: Optional[List[Event]] = None,
         config: Optional[BaseConfig] = None,
         services_components: Optional[List[BaseComponent]] = None,
@@ -175,7 +175,6 @@ class Monitor(Node):
 
         # Create health status subscribers
         if self._components_to_monitor:
-            self._create_status_subscribers()
             for component_name in self._components_to_monitor:
                 self._turn_on_component_management(component_name)
 
@@ -685,8 +684,7 @@ class Monitor(Node):
         """
         self.__events = []
         if self._monitor_events_actions:
-            for serialized_event, actions in self._monitor_events_actions.items():
-                event = Event.from_json(serialized_event)
+            for event, actions in self._monitor_events_actions.items():
                 for action in actions:
                     method = getattr(self, action.action_name)
                     # register action to the event
@@ -730,32 +728,3 @@ class Monitor(Node):
             )
             self.__event_listeners.append(listener)
 
-    def _create_status_subscribers(self) -> None:
-        """
-        Creates subscribers to all the health status topics of the components
-        """
-        # Reentrant group for multi threaded monitoring
-        callback_group = ReentrantCallbackGroup()
-        for component_name in self._components_to_monitor:
-            logger.info(f"Creating health status subscriber for: {component_name}")
-            self.create_subscription(
-                ComponentStatus,
-                topic=f"{component_name}/status",
-                callback=partial(
-                    self._status_check_callback, component_name=component_name
-                ),
-                qos_profile=10,
-                callback_group=callback_group,
-            )
-
-    def _status_check_callback(self, msg, component_name: str):
-        """
-        Callback to check the health status of a component
-
-        :param msg: Health status message
-        :type msg: ComponentStatus
-        :param component: Node under check
-        :type component: Component
-        """
-        # TODO: handle status
-        self.get_logger().debug(f"Form {component_name} got status {msg}")

--- a/ros_sugar/core/monitor.py
+++ b/ros_sugar/core/monitor.py
@@ -7,8 +7,7 @@ import json
 from typing import Any, Callable, Dict, List, Optional, Union, Tuple
 from rclpy.node import Node
 from rclpy.publisher import Publisher
-from rclpy.callback_groups import MutuallyExclusiveCallbackGroup, ReentrantCallbackGroup
-from automatika_ros_sugar.msg import ComponentStatus
+from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from automatika_ros_sugar.srv import (
     ChangeParameter,
     ChangeParameters,
@@ -646,6 +645,28 @@ class Monitor(Node):
             return
         publisher.publish(msg)
 
+    # -------- EVENT MANAGEMENT ------------------
+
+    def __start_callable_based_event_timers(self) -> None:
+        """Create one periodic timer per action-based event sourced from _internal_events.
+
+        Recipe-level action-based events are passed as live Event objects (with the
+        condition callable intact) via _internal_events. The Monitor polls them here.
+        """
+        self.__action_event_timers = []
+        for event in self.__events:
+            if event._is_action_based:
+                rate = event.check_rate or self.config.loop_rate
+                self.__action_event_timers.append(
+                    self.create_timer(
+                        timer_period_sec=1.0 / rate,
+                        callback=partial(
+                            event.check_action_condition, self._events_topics_blackboard
+                        ),
+                        callback_group=MutuallyExclusiveCallbackGroup(),
+                    )
+                )
+
     def __event_topic_callback(self, topic_name: str, msg: Any):
         """
         Central Handler:
@@ -676,13 +697,11 @@ class Monitor(Node):
                 if valid_entry:
                     clean_cache_subset[topic.name] = valid_entry
             # Pass the clean subset to the event
-            event.check_condition(clean_cache_subset)
+            if not event._is_action_based:
+                event.check_condition(clean_cache_subset)
 
-    def _activate_event_monitoring(self) -> None:
-        """
-        Turn on all events
-        """
-        self.__events = []
+    def __reconstruct_monitor_actions(self):
+        self.__events: List[Event] = []
         if self._monitor_events_actions:
             for event, actions in self._monitor_events_actions.items():
                 for action in actions:
@@ -695,6 +714,13 @@ class Monitor(Node):
         if self._internal_events:
             # Add internal events (to emit back to launcher)
             self.__events.extend(self._internal_events)
+
+    def _activate_event_monitoring(self) -> None:
+        """
+        Turn on all events
+        """
+
+        self.__reconstruct_monitor_actions()
 
         # TURN ON EVENTS MANAGEMENT
         # Blackboard to store latest messages for all topics required for all event:
@@ -728,3 +754,4 @@ class Monitor(Node):
             )
             self.__event_listeners.append(listener)
 
+        self.__start_callable_based_event_timers()

--- a/ros_sugar/launch/launcher.py
+++ b/ros_sugar/launch/launcher.py
@@ -51,6 +51,7 @@ from .system_info import (
 from ..io import Topic
 from ..io.supported_types import _additional_types
 from ..core.action import LogInfo
+from ..actions import publish_message
 from ..config.base_config import ComponentRunType
 from ..core.action import Action
 from ..core.component import BaseComponent
@@ -159,7 +160,7 @@ class Launcher:
         self._internal_event_names: Optional[List[str]] = None
         self._ros_events_actions: Dict[str, List[ROSLaunchAction]] = {}
         # Dictionaries {serialized_event: actions}
-        self._monitor_events_actions: Dict[str, List[Action]] = {}
+        self._monitor_events_actions: Dict[Event, List[Action]] = {}
         self._components_events_actions: Dict[str, List[Action]] = {}
         self.__events_names: List[str] = []
 
@@ -521,10 +522,17 @@ class Launcher:
         """
         self.__events_names.extend(event.id for event in events_actions_dict)
         for event, action_set in events_actions_dict.items():
+            bridge_events_per_target: Dict[str, Event] = {}
             for action in action_set:
                 # Verify that the action inputs are available from the event topic(s)
                 if isinstance(action, Action):
                     event.verify_required_action_topics(action)
+                # Callable-based events have their own routing logic
+                if event._is_action_based:
+                    self.__route_action_based_event(
+                        event, action, bridge_events_per_target
+                    )
+                    continue
                 # Check if it is a component action:
                 if isinstance(action, Action) and action.component_action:
                     action_object = action.executable.__self__
@@ -546,15 +554,91 @@ class Launcher:
                         )
                 elif isinstance(action, Action) and action._is_monitor_action:
                     # Action to execute through the monitor
-                    serialized_condition: str = (
-                        event.to_json() if isinstance(event, Event) else event
-                    )
-                    self.__update_dict_list(
-                        self._monitor_events_actions, serialized_condition, action
-                    )
+                    self.__update_dict_list(self._monitor_events_actions, event, action)
                 elif isinstance(action, Action) or isinstance(action, ROSLaunchAction):
                     # If it is a valid ROS launch action -> nothing is required
                     self._update_ros_events_actions(event, action)
+
+    def __route_action_based_event(
+        self,
+        event: Event,
+        action: Action,
+        bridge_events_per_target: Dict[str, Event],
+    ) -> None:
+        """Route an action-based event to the appropriate owner.
+
+        Two cases based on who owns the consequence Action:
+
+        1. Recipe-condition + Recipe-action: route both directly to Monitor.
+        2. Recipe-condition + Component-action: Monitor publishes a Bool bridge topic when the
+           condition fires; the consequence component monitors that bridge topic.
+
+        :param event: The action-based event
+        :type event: Event
+        :param action: The consequence action
+        :type action: Action
+        :param bridge_events_per_target: Cache of already-created bridge events keyed by
+            consequence owner name, shared across actions of the same event
+        :type bridge_events_per_target: Dict[str, Event]
+        """
+        from std_msgs.msg import Bool
+
+        # condition_owner is always the Recipe (Launcher/Monitor)
+        consequence_owner: Optional[str] = (
+            action.parent_component if isinstance(action, Action) else None
+        )
+
+        # Case 1: Recipe-level condition + non-component consequence.
+        # The condition callable lives in the launch process; route the event via
+        # _internal_events so ComponentLaunchAction registers _on_internal_event on it
+        # and the Monitor creates a polling timer for it.
+        if not consequence_owner:
+            logger.debug(
+                f"Action-based event '{event}': recipe-level condition + launch-level"
+                f" action, routing via internal event"
+            )
+            if isinstance(action, Action) and action._is_monitor_action:
+                # Action to execute through the monitor
+                self.__update_dict_list(self._monitor_events_actions, event, action)
+            elif isinstance(action, Action) or isinstance(action, ROSLaunchAction):
+                # If it is a valid ROS launch action -> nothing is required
+                self._update_ros_events_actions(event, action)
+            return
+
+        # Case 2: Recipe-level condition + component-owned consequence.
+        # Require a Bool bridge topic so the Monitor can signal
+        # the consequence owner across process boundaries.
+        event_id_safe = event.id.replace("-", "_")
+        bridge_topic_name = f"/event_bridge/e_{event_id_safe}_{consequence_owner}"
+
+        # Reuse an already-created bridge event for this (event, consequence_owner) pair
+        bridge_event = bridge_events_per_target.get(consequence_owner)
+        if bridge_event is None:
+            bridge_topic = Topic(name=bridge_topic_name, msg_type="Bool")
+            bridge_event = Event(event_condition=bridge_topic)
+            bridge_event.verify_required_action_topics(action)
+            bridge_events_per_target[consequence_owner] = bridge_event
+        bridge_serialized: str = bridge_event.to_json()
+
+        # The Monitor polls the condition via a timer and, when it fires, publishes
+        # Bool(True) on the bridge topic (via the _on_internal_event → OnInternalEvent
+        # → publish_message path). The consequence component subscribes to the bridge.
+        logger.debug(
+            f"Action-based event '{event}': recipe-level condition + component-action"
+            f" '{consequence_owner}', bridge topic '{bridge_topic_name}'"
+        )
+        bridge_publish_action = publish_message(
+            topic=Topic(name=bridge_topic_name, msg_type="Bool"),
+            msg=Bool(data=True),
+        )
+        # Action to execute through the monitor
+        self.__update_dict_list(
+            self._monitor_events_actions, event, bridge_publish_action
+        )
+        self.__update_dict_list(
+            self._components_events_actions, bridge_serialized, action
+        )
+        return
 
     def _activate_components_action(self) -> SomeEntitiesType:
         """

--- a/test/actions_test.py
+++ b/test/actions_test.py
@@ -75,19 +75,14 @@ def generate_test_description():
     # Component publishing to the event topic
     component = ChildComponent(component_name="test_component")
 
-    # health status topic
-    status_topic = Topic(name="test_component/status", msg_type="ComponentStatus")
-
     test_topic = Topic(name="test_topic", msg_type="Float32")
 
     # On any
-    event_on_health_status = Event(status_topic, handle_once=True)
+    event_on_health_status = Event(component.status_topic, handle_once=True)
 
     event_on_published_message = Event(test_topic, handle_once=True)
 
-    def inline_method(**_):
-        global inline_action_py_event
-        logging.info("Testing inline action")
+    def inline_method():
         inline_action_py_event.set()
 
     msg = Float32()
@@ -139,7 +134,7 @@ def generate_test_description():
 class TestActions(unittest.TestCase):
     """Tests that all action types are executed correctly"""
 
-    wait_time = 10.0  # seconds
+    wait_time = 20.0  # seconds
 
     def test_inline_action(cls):
         global inline_action_py_event

--- a/test/generic_events_test.py
+++ b/test/generic_events_test.py
@@ -1,0 +1,242 @@
+import time
+import unittest
+from threading import Event as ThreadingEvent
+import launch_testing
+import launch_testing.actions
+import launch_testing.markers
+import pytest
+
+from ros_sugar.core import BaseComponent, Event
+from ros_sugar import Launcher
+from ros_sugar.io import Topic
+from ros_sugar.actions import Action, LogInfo
+
+# ------------------------------------------------------------------
+# Threading events used to signal that consequence actions fired
+# ------------------------------------------------------------------
+
+# Case 1: recipe-level
+basic_trigger_py_event = ThreadingEvent()
+# Case 2: component-action, on_change
+on_change_py_event = ThreadingEvent()
+# Case 3: component-action, handle_once
+handle_once_first_py_event = ThreadingEvent()
+# Case 4: recipe-level dynamic arg
+dynamic_arg_recipe_py_event = ThreadingEvent()
+# Case 5: component-action dynamic arg
+dynamic_arg_comp_py_event = ThreadingEvent()
+
+# Mutable counter for handle_once; using a list for thread-safe appends
+handle_once_invocations = []
+EXPECTED_VALUE = 45.0
+
+# ------------------------------------------------------------------
+# Components
+# ------------------------------------------------------------------
+
+
+class ComponentA(BaseComponent):
+    """Owns all condition methods and the same-component consequence methods (Case 3)."""
+
+    def __init__(self, component_name, inputs=None, outputs=None, **kwargs):
+        super().__init__(component_name, inputs, outputs, **kwargs)
+
+    def _execution_step(self):
+        pass
+
+    # --- Component consequence methods ---
+    def on_change_trigger(self, **_) -> None:
+        global on_change_py_event
+        on_change_py_event.set()
+
+    def on_handle_once_trigger(self, **_) -> None:
+        global handle_once_first_py_event
+        handle_once_invocations.append(1)
+        handle_once_first_py_event.set()
+
+    def on_dynamic_trigger(self, value, **_) -> None:
+        global dynamic_arg_comp_py_event
+        if value == EXPECTED_VALUE:
+            dynamic_arg_comp_py_event.set()
+
+
+class PublisherComponent(BaseComponent):
+    """Publishes a Float32 value on a topic so dynamic-arg actions can read it."""
+
+    def __init__(self, component_name, inputs=None, outputs=None, **kwargs):
+        super().__init__(component_name, inputs, outputs, **kwargs)
+        self._counter = 0
+
+    def _execution_step(self):
+        self._counter += 1
+        if self.publishers_dict.get("float_test"):
+            self.publishers_dict["float_test"].publish(EXPECTED_VALUE)
+
+# ------------------------------------------------------------------
+# Launch description
+# ------------------------------------------------------------------
+
+
+@pytest.mark.launch_test
+@launch_testing.markers.keep_alive
+def generate_test_description():
+    float_topic = Topic(name="float_test", msg_type="Float32")
+
+    publisher = PublisherComponent(
+        component_name="publisher",
+        outputs=[float_topic],
+    )
+    component_a = ComponentA(component_name="component_a")
+
+    global counter, toggler
+    counter = 0.0
+    toggler = False
+
+    def becomes_true_condition(**_) -> bool:
+        global counter
+        counter += 1
+        return counter > 5
+
+    def handle_once_condition(**_) -> bool:
+        global counter
+        return counter > 5
+
+    def dynamic_args_recipe_condition(**_) -> bool:
+        global counter
+        return counter > 10
+
+    def dynamic_args_comp_condition(**_) -> bool:
+        global counter
+        return counter > 8
+
+    def toggling_condition(**_) -> bool:
+        global toggler
+        toggler = not toggler
+        return toggler
+
+    # ------ Actions --------
+    def on_basic_trigger(**_) -> None:
+        global basic_trigger_py_event
+        basic_trigger_py_event.set()
+
+    def on_dynamic_trigger(value, **_) -> None:
+        global dynamic_arg_recipe_py_event
+        if value == EXPECTED_VALUE:
+            dynamic_arg_recipe_py_event.set()
+
+    # --- Case 1: recipe-level basic trigger ---
+    # Condition starts False, becomes True after execution counter exceeds 5
+    event_basic = Event(
+        becomes_true_condition,
+        check_rate=1.0,
+    )
+
+    # --- Case 2: on_change ---
+    # Toggling condition with on_change=True fires only on False-to-True transition
+    event_on_change = Event(
+        toggling_condition,
+        check_rate=1.0,
+        on_change=True,
+    )
+
+    # --- Case 3: handle_once ---
+    event_handle_once = Event(
+        handle_once_condition,
+        check_rate=1.0,
+        handle_once=True,
+    )
+
+    # --- Case 4: dynamic arg (recipe action) ---
+    event_dynamic_recipe = Event(
+        dynamic_args_recipe_condition,
+        check_rate=1.0,
+    )
+
+    # --- Case 5: dynamic arg (component action) ---
+    event_dynamic_comp = Event(
+        dynamic_args_comp_condition,
+        check_rate=1.0,
+    )
+
+    launcher = Launcher()
+    launcher.add_pkg(
+        components=[component_a, publisher],
+        events_actions={
+            event_basic: [
+                LogInfo(msg="[Case 1] Recipe-level condition and action"),
+                Action(method=on_basic_trigger),
+            ],
+            event_on_change: [
+                LogInfo(msg="[Case 2] on_change component action triggered"),
+                Action(method=component_a.on_change_trigger),
+            ],
+            event_handle_once: [
+                LogInfo(msg="[Case 3] handle_once component action triggered"),
+                Action(method=component_a.on_handle_once_trigger),
+            ],
+            event_dynamic_recipe: [
+                LogInfo(msg="[Case 4] Recipe-level action with dynamic args"),
+                Action(
+                    method=component_a.on_dynamic_trigger, args=float_topic.msg.data
+                ),
+            ],
+            event_dynamic_comp: [
+                LogInfo(msg="[Case 5] Component-level action with dynamic args"),
+                Action(method=on_dynamic_trigger, args=float_topic.msg.data),
+            ],
+        },
+    )
+
+    launcher.setup_launch_description()
+    launcher._description.add_action(launch_testing.actions.ReadyToTest())
+    return launcher._description
+
+
+# ------------------------------------------------------------------
+# Tests
+# ------------------------------------------------------------------
+
+
+class TestActionBasedEvents(unittest.TestCase):
+    """Tests for the action-based event polling mechanism (Event with Action condition)."""
+
+    wait_time = 20.0  # seconds
+
+    # --- Case 3: same-component condition + same-component action ---
+
+    def test_basic_action_based_trigger(cls):
+        """[Case 1] Consequence fires once the condition Action starts returning True."""
+        assert basic_trigger_py_event.wait(cls.wait_time), (
+            "Action-based event failed to trigger when condition became True"
+        )
+
+    def test_on_change_action_based_trigger(cls):
+        """[Case 2] Consequence fires on a False-to-True transition when on_change=True."""
+        assert on_change_py_event.wait(cls.wait_time), (
+            "Action-based event with on_change=True failed to trigger on False-to-True transition"
+        )
+
+    def test_handle_once(cls):
+        """[Case 3] Consequence fires exactly once even when the condition stays True."""
+        assert handle_once_first_py_event.wait(cls.wait_time), (
+            "handle_once action-based event never fired"
+        )
+        # Wait several more check periods (10 Hz -> 0.5 s covers ~5 additional checks)
+        time.sleep(5.0)
+        assert len(handle_once_invocations) == 1, (
+            f"handle_once action-based event fired {len(handle_once_invocations)} "
+            f"time(s), expected exactly 1"
+        )
+
+    def test_dynamic_args_recipe_action_based_trigger(cls):
+        """[Case 4]"""
+        assert dynamic_arg_recipe_py_event.wait(cls.wait_time), (
+            "Action-based event with dynamic args in the recipe failed to trigger"
+        )
+
+    def test_dynamic_args_comp_action_based_trigger(cls):
+        """[Case 4]"""
+        assert dynamic_arg_comp_py_event.wait(cls.wait_time), (
+            "Action-based event with dynamic args in the component failed to trigger"
+        )
+

--- a/test/generic_events_test.py
+++ b/test/generic_events_test.py
@@ -72,6 +72,7 @@ class PublisherComponent(BaseComponent):
         if self.publishers_dict.get("float_test"):
             self.publishers_dict["float_test"].publish(EXPECTED_VALUE)
 
+
 # ------------------------------------------------------------------
 # Launch description
 # ------------------------------------------------------------------
@@ -202,8 +203,6 @@ class TestActionBasedEvents(unittest.TestCase):
 
     wait_time = 20.0  # seconds
 
-    # --- Case 3: same-component condition + same-component action ---
-
     def test_basic_action_based_trigger(cls):
         """[Case 1] Consequence fires once the condition Action starts returning True."""
         assert basic_trigger_py_event.wait(cls.wait_time), (
@@ -235,8 +234,7 @@ class TestActionBasedEvents(unittest.TestCase):
         )
 
     def test_dynamic_args_comp_action_based_trigger(cls):
-        """[Case 4]"""
+        """[Case 5]"""
         assert dynamic_arg_comp_py_event.wait(cls.wait_time), (
             "Action-based event with dynamic args in the component failed to trigger"
         )
-


### PR DESCRIPTION
# Summary

This PR (Resolves #36) allows constructing events based on more general-purpose definitions for the triggering condition. The Event class now accepts a plain `Callable` (inline Recipe-level Python method) as a condition. This method is polled at runtime using a configurable check_rate via timers, and the event is triggered when the method returns `True`. This allows triggering events based on low-level system checks, or external API calls outside the ROS2 network, with no topic subscription needed.

Supports:
- Recipe-level event conditions with recipe-level action(s).
-  Recipe-level event conditions with component or system action(s).  In this case an internal Bool bridge topic is created.

## Tests

New tests added in `generic_events_test.py`, the tests covers events-action pairs to test the callable-based generic events paired with:
- Recipe-level action (inline method), with and without dynamic arguments coming from a ROS2 topic (Case 1 and 4)
- Component-level action, with and without dynamic arguments coming from a ROS2 topic. (Case 2, 3 and 5)
- Testing with Event options `on_change` and `handle_once` (Case 2 and 3)