### PR TITLE
Add safe_restart context manager to BaseComponent

### DIFF
--- a/.github/workflows/debian_packaging.yml
+++ b/.github/workflows/debian_packaging.yml
@@ -2,7 +2,6 @@ name: Build Debian packaging
 
 on:
   workflow_dispatch:
-  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,46 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  tests:
+    name: Tests (ROS 2 ${{ matrix.ros_distro }})
+    runs-on: ubuntu-latest
+    env:
+      PIP_BREAK_SYSTEM_PACKAGES: "1"
+    strategy:
+      matrix:
+        ros_distro: [humble, jazzy, kilted, rolling]
+    container:
+      image: ros:${{ matrix.ros_distro }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          apt-get update
+          apt-get install -y python3-pip
+          pip install pytest
+
+      - name: Build workspace
+        run: |
+          . /opt/ros/${{ matrix.ros_distro }}/setup.sh
+          mkdir -p /ws/src
+          ln -s $GITHUB_WORKSPACE /ws/src/sugarcoat
+          cd /ws
+          pip install numpy 'attrs>=23.2.0' jinja2 httpx \
+                      msgpack msgpack-numpy setproctitle platformdirs tqdm websockets
+          colcon build --symlink-install
+        shell: bash
+
+      - name: Run tests
+        run: |
+          . /opt/ros/${{ matrix.ros_distro }}/setup.sh
+          . /ws/install/setup.sh
+          cd $GITHUB_WORKSPACE
+          python3 -m pytest test/ -v
+        shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,8 +32,8 @@ jobs:
           mkdir -p /ws/src
           ln -s $GITHUB_WORKSPACE /ws/src/sugarcoat
           cd /ws
-          pip install numpy 'attrs>=23.2.0' jinja2 \
-                      msgpack msgpack-numpy setproctitle platformdirs tqdm websockets
+          pip install numpy opencv-python-headless 'attrs>=23.2.0' jinja2 \
+                      msgpack msgpack-numpy setproctitle pyyaml toml
           colcon build --symlink-install
         shell: bash
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
           mkdir -p /ws/src
           ln -s $GITHUB_WORKSPACE /ws/src/sugarcoat
           cd /ws
-          pip install opencv-python-headless 'attrs>=23.2.0' jinja2 \
+          pip install --ignore-installed opencv-python-headless 'attrs>=23.2.0' jinja2 \
                       msgpack msgpack-numpy setproctitle pyyaml toml
           colcon build --symlink-install
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
           mkdir -p /ws/src
           ln -s $GITHUB_WORKSPACE /ws/src/sugarcoat
           cd /ws
-          pip install numpy 'attrs>=23.2.0' jinja2 httpx \
+          pip install numpy 'attrs>=23.2.0' jinja2 \
                       msgpack msgpack-numpy setproctitle platformdirs tqdm websockets
           colcon build --symlink-install
         shell: bash
@@ -42,5 +42,5 @@ jobs:
           . /opt/ros/${{ matrix.ros_distro }}/setup.sh
           . /ws/install/setup.sh
           cd $GITHUB_WORKSPACE
-          python3 -m pytest test/ -v
+          python3 -m pytest test/ -v -p no:anyio
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
           mkdir -p /ws/src
           ln -s $GITHUB_WORKSPACE /ws/src/sugarcoat
           cd /ws
-          pip install numpy opencv-python-headless 'attrs>=23.2.0' jinja2 \
+          pip install opencv-python-headless 'attrs>=23.2.0' jinja2 \
                       msgpack msgpack-numpy setproctitle pyyaml toml
           colcon build --symlink-install
         shell: bash

--- a/ros_sugar/base_clients.py
+++ b/ros_sugar/base_clients.py
@@ -137,14 +137,14 @@ class ServiceClientHandler:
             timeout_sec=self.config.attempt_period_secs
         ):
             # If the service is not available give warning
-            self.node.get_logger().warn(
+            self.node.get_logger().warning(
                 f"Service {self.config.name} not available, Waiting... timeout in {(self.config.timeout_secs - _timeout_count):.2f} secs"
             )
             _timeout_count += self.config.attempt_period_secs
 
             # Check for service request timeout
             if _timeout_count > self.config.timeout_secs:
-                self.node.get_logger().warn(
+                self.node.get_logger().warning(
                     f"Service {self.config.name} is not available, Cancelling"
                 )
                 return None

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -8,6 +8,7 @@ import toml
 import socket
 from abc import abstractmethod
 from copy import deepcopy
+from contextlib import contextmanager
 import threading
 from typing import Any, Dict, List, Optional, Union, Callable, Sequence, Tuple, Type
 from functools import wraps, partial
@@ -2978,6 +2979,34 @@ class BaseComponent(lifecycle.Node):
             return self.on_shutdown(state)
 
         return super().on_error(state)
+
+    @contextmanager
+    def safe_restart(self):
+        """Stop the component, yield for operations, then restart and wait for ACTIVE state."""
+        self._maintain_default_services = True
+
+        try:
+            self.stop()
+            self.trigger_cleanup()
+            yield
+        finally:
+            self.start()
+
+            timeout_counter = 0
+            while self.lifecycle_state != LifecycleStateMsg.PRIMARY_STATE_ACTIVE and (
+                timeout_counter < self.config.wait_for_restart_time
+            ):
+                self.get_logger().warn(
+                    f"Component {self.node_name} is not in ACTIVE state. Waiting for it to become active again.",
+                    once=True,
+                )
+                # NOTE: Callbacks will not fire during this sleep
+                time.sleep(1 / self.config.loop_rate)
+                timeout_counter += 1 / self.config.loop_rate
+
+            if self.lifecycle_state != LifecycleStateMsg.PRIMARY_STATE_ACTIVE:
+                self.health_status.set_fail_component()
+                raise RuntimeError("Error restarting the component")
 
     def custom_on_configure(self) -> None:
         """

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -299,11 +299,11 @@ class BaseComponent(lifecycle.Node):
 
                 if isinstance(plugin_value, Topic):
                     if topic.name != plugin_value.name:
-                        self.get_logger().warn(
+                        self.get_logger().warning(
                             f"Input Topic is given with name '{topic.name}' ({msg_type_name}), "
                             f"but robot plugin provides default name '{plugin_value.name}' ({plugin_value.msg_type.__name__})."
                         )
-                        self.get_logger().warn(
+                        self.get_logger().warning(
                             f"Robot Plugin Topic Name will be Used! To change it, replace the name in '{self.config._robot_plugin}'"
                         )
                     self._replace_input_topic(
@@ -318,11 +318,11 @@ class BaseComponent(lifecycle.Node):
 
                 if isinstance(plugin_value, Topic):
                     if topic.name != plugin_value.name:
-                        self.get_logger().warn(
+                        self.get_logger().warning(
                             f"Input Topic is given with name '{topic.name}' ({msg_type_name}), "
                             f"but robot plugin provides default name '{plugin_value.name}' ({plugin_value.msg_type.__name__})."
                         )
-                        self.get_logger().warn(
+                        self.get_logger().warning(
                             f"Robot Plugin Topic Name will be Used! To change it, replace the name in '{self.config._robot_plugin}'"
                         )
                     self._replace_output_topic(
@@ -1612,7 +1612,7 @@ class BaseComponent(lifecycle.Node):
         :return: _description_
         :rtype: _type_
         """
-        self.get_logger().warn("Received cancel request")
+        self.get_logger().warning("Received cancel request")
         try:
             return CancelResponse.ACCEPT
         except Exception as e:
@@ -1837,7 +1837,7 @@ class BaseComponent(lifecycle.Node):
         while self.lifecycle_state != LifecycleStateMsg.PRIMARY_STATE_ACTIVE and (
             timeout_counter < self.config.wait_for_restart_time
         ):
-            self.get_logger().warn(
+            self.get_logger().warning(
                 f"Component {self.node_name} is not in ACTIVE state. Waiting for it to become active again.",
                 once=True,
             )
@@ -1984,7 +1984,7 @@ class BaseComponent(lifecycle.Node):
             self.in_topics.pop(idx)
             self.in_topics.insert(idx, new_topic)
         except ValueError:
-            self.get_logger().warn(
+            self.get_logger().warning(
                 f"Old topic {old_topic.name} not found in self.in_topics. "
                 "Updating callbacks anyway."
             )
@@ -2051,7 +2051,7 @@ class BaseComponent(lifecycle.Node):
             self.out_topics.pop(idx)
             self.out_topics.insert(idx, new_topic)
         except ValueError:
-            self.get_logger().warn(
+            self.get_logger().warning(
                 f"Old topic {old_topic.name} not found in self.out_topics. "
                 "Updating publisher dictionary anyway."
             )
@@ -2149,7 +2149,7 @@ class BaseComponent(lifecycle.Node):
                 response.error_msg = (
                     f"Expecting json style keyword arguments, got {request.kwargs_json}"
                 )
-                self.get_logger().warn(f"Error parsing request parameters: {e}")
+                self.get_logger().warning(f"Error parsing request parameters: {e}")
                 return response
         try:
             method = getattr(self, request.name)
@@ -2332,7 +2332,7 @@ class BaseComponent(lifecycle.Node):
         while (
             self.lifecycle_state >= LifecycleStateMsg.TRANSITION_STATE_CONFIGURING
         ) and (timeout_counter < self.config._lifecycle_state_transition_timeout):
-            self.get_logger().warn(
+            self.get_logger().warning(
                 "Waiting for ongoing transition to end before executing new transition",
                 once=True,
             )
@@ -2414,7 +2414,7 @@ class BaseComponent(lifecycle.Node):
         :return: If the component is Reconfigured
         :rtype: bool
         """
-        self.get_logger().warn("Reconfiguring component...")
+        self.get_logger().warning("Reconfiguring component...")
 
         if keep_alive:
             # set new config as params attr
@@ -2479,7 +2479,7 @@ class BaseComponent(lifecycle.Node):
             return False
 
         if wait_time:
-            self.get_logger().warn(
+            self.get_logger().warning(
                 f"Waiting for requested time '{wait_time}'seconds before starting again...",
             )
             time.sleep(wait_time)
@@ -2584,7 +2584,7 @@ class BaseComponent(lifecycle.Node):
                 self.health_status.is_algorithm_fail
                 and self.__fallbacks.on_algorithm_fail
             ):
-                self.get_logger().warn(
+                self.get_logger().warning(
                     "Algorithm Failure Detected -> Executing Fallback ..."
                 )
                 self.__fallbacks_giveup = self.__fallbacks.execute_algorithm_fallback()
@@ -2593,13 +2593,13 @@ class BaseComponent(lifecycle.Node):
                 self.health_status.is_component_fail
                 and self.__fallbacks.on_component_fail
             ):
-                self.get_logger().warn(
+                self.get_logger().warning(
                     "Component Failure Detected -> Executing Fallback ..."
                 )
                 self.__fallbacks_giveup = self.__fallbacks.execute_component_fallback()
 
             elif self.health_status.is_system_fail and self.__fallbacks.on_system_fail:
-                self.get_logger().warn(
+                self.get_logger().warning(
                     "System Failure Detected -> Executing Fallback ..."
                 )
                 self.__fallbacks_giveup = self.__fallbacks.execute_system_fallback()
@@ -2612,7 +2612,7 @@ class BaseComponent(lifecycle.Node):
 
         except ValueError:
             # ValueError is thrown when no fallbacks are defined for detected failure
-            self.get_logger().warn(
+            self.get_logger().warning(
                 "No fallback policy is defined for detected failure -> Failure is broadcasted"
             )
 
@@ -2996,7 +2996,7 @@ class BaseComponent(lifecycle.Node):
             while self.lifecycle_state != LifecycleStateMsg.PRIMARY_STATE_ACTIVE and (
                 timeout_counter < self.config.wait_for_restart_time
             ):
-                self.get_logger().warn(
+                self.get_logger().warning(
                     f"Component {self.node_name} is not in ACTIVE state. Waiting for it to become active again.",
                     once=True,
                 )
@@ -3088,7 +3088,7 @@ class BaseComponent(lifecycle.Node):
         )
 
         if transition_id not in available_transition_ids:
-            self.get_logger().warn(
+            self.get_logger().warning(
                 f"Invalid transition requested for for node {self.node_name}."
             )
             resp.success = False

--- a/ros_sugar/io/publisher.py
+++ b/ros_sugar/io/publisher.py
@@ -75,7 +75,7 @@ class Publisher:
                 # type check processor output if incorrect, raise an error
                 pre_output_type = type(pre_output)
                 if out_type is not type(pre_output):
-                    get_logger(self.node_name).warn(
+                    get_logger(self.node_name).warning(
                         f"The output produced by the component for topic {self.output_topic.name} is of type {out_type}. Got pre_processor output of type {pre_output_type}"
                     )
                 # if all good, set output equal to post output

--- a/test/component/safe_restart_test.py
+++ b/test/component/safe_restart_test.py
@@ -1,0 +1,132 @@
+import unittest
+from threading import Event as ThreadingEvent
+import launch_testing
+import launch_testing.actions
+import launch_testing.markers
+import pytest
+
+from ros_sugar.core import BaseComponent
+from ros_sugar import Launcher
+from lifecycle_msgs.msg import State as LifecycleStateMsg
+
+
+# Threading events signalling test outcomes
+happy_path_completed = ThreadingEvent()
+happy_path_active_after = ThreadingEvent()
+timeout_raised = ThreadingEvent()
+timeout_health_failed = ThreadingEvent()
+exception_restarted = ThreadingEvent()
+exception_propagated = ThreadingEvent()
+
+
+class HappyPathComponent(BaseComponent):
+    """Calls safe_restart once from a post-activation one-shot timer."""
+
+    def __init__(self, component_name, **kwargs):
+        super().__init__(component_name, **kwargs)
+        self._observed_value = None
+        self._fired = False
+
+    def _execution_step(self):
+        if self._fired:
+            return
+        self._fired = True
+        with self.safe_restart():
+            self._observed_value = 42
+        if self.lifecycle_state == LifecycleStateMsg.PRIMARY_STATE_ACTIVE:
+            happy_path_active_after.set()
+        if self._observed_value == 42:
+            happy_path_completed.set()
+
+
+class TimeoutComponent(BaseComponent):
+    """Forces the timeout path by stubbing start() to a no-op."""
+
+    def __init__(self, component_name, **kwargs):
+        super().__init__(component_name, **kwargs)
+        self._fired = False
+
+    def _execution_step(self):
+        if self._fired:
+            return
+        self._fired = True
+        # Minimum allowed by validator; start() is stubbed so the wait always times out
+        self.config.wait_for_restart_time = 10.0
+        self.start = lambda: None
+        try:
+            with self.safe_restart():
+                pass
+        except RuntimeError:
+            timeout_raised.set()
+            if self.health_status.is_component_fail:
+                timeout_health_failed.set()
+
+
+class ExceptionComponent(BaseComponent):
+    """Raises inside the with block to test exception propagation + restart."""
+
+    def __init__(self, component_name, **kwargs):
+        super().__init__(component_name, **kwargs)
+        self._fired = False
+
+    def _execution_step(self):
+        if self._fired:
+            return
+        self._fired = True
+        try:
+            with self.safe_restart():
+                raise ValueError("intentional test error")
+        except ValueError:
+            exception_propagated.set()
+        if self.lifecycle_state == LifecycleStateMsg.PRIMARY_STATE_ACTIVE:
+            exception_restarted.set()
+
+
+@pytest.mark.launch_test
+@launch_testing.markers.keep_alive
+def generate_test_description():
+    happy = HappyPathComponent(component_name="happy_component")
+    timeout = TimeoutComponent(component_name="timeout_component")
+    exc = ExceptionComponent(component_name="exception_component")
+
+    for c in (happy, timeout, exc):
+        c.run_type = "Timed"
+
+    launcher = Launcher()
+    launcher.add_pkg(components=[happy, timeout, exc])
+    launcher.setup_launch_description()
+    launcher._description.add_action(launch_testing.actions.ReadyToTest())
+    return launcher._description
+
+
+class TestSafeRestart(unittest.TestCase):
+    """Tests for BaseComponent.safe_restart context manager."""
+
+    wait_time = 30.0  # seconds
+
+    def test_happy_path(cls):
+        """Component restarts successfully and the yielded operation runs."""
+        assert happy_path_completed.wait(cls.wait_time), (
+            "safe_restart yielded block did not run to completion"
+        )
+        assert happy_path_active_after.wait(cls.wait_time), (
+            "Component did not return to ACTIVE state after safe_restart"
+        )
+
+    def test_timeout_raises_and_fails_health(cls):
+        """safe_restart raises RuntimeError when component fails to become ACTIVE."""
+        assert timeout_raised.wait(cls.wait_time), (
+            "safe_restart did not raise RuntimeError on timeout"
+        )
+        assert timeout_health_failed.wait(cls.wait_time), (
+            "health_status was not marked as failed on timeout"
+        )
+
+    def test_exception_in_block_still_restarts(cls):
+        """Exceptions raised inside the with block propagate but restart still runs."""
+        assert exception_propagated.wait(cls.wait_time), (
+            "Exception raised inside safe_restart was not propagated"
+        )
+        assert exception_restarted.wait(cls.wait_time), (
+            "Component was not restarted after exception inside safe_restart"
+        )


### PR DESCRIPTION
## Summary

Adds a `safe_restart` context manager on `BaseComponent` for use in component actions that need to restart the component for changes to take effect. The context manager stops the component, triggers cleanup, yields for the caller to perform operations, then restarts and blocks until the component reaches ACTIVE state (bounded by `config.wait_for_restart_time`). If the component fails to become ACTIVE within the timeout, the health status is marked as failed and a `RuntimeError` is raised.

Closes #34.