### PR TITLE
Return method result from ExecuteMethod service

### DIFF
--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -2154,15 +2154,29 @@ class BaseComponent(lifecycle.Node):
         try:
             method = getattr(self, request.name)
             result = method(**kwargs)
-            if result is not None and isinstance(result, bool):
+            if isinstance(result, bool):
                 response.success = result
+                # TODO: If the error is caught in the method and it returns false
+                # we consider this a failure. This is for backward compatibility
+                # Thus component actions cannot return False as a legitimate
+                # response. We should ensure all component actions in downstream
+                # packages are modified before changing this behaviour.
                 if not result:
                     response.error_msg = f"The method '{request.name}' executed but returned False, indicating failure without an exception."
-            elif result is not None and isinstance(result, str):
+                else:
+                    response.response_json = json.dumps(result)
+            # NOTE: empty responses are considered successful
+            elif result is None:
                 response.success = True
-                response.error_msg = f"The method '{request.name}' executed and returned the following string: {result}"
             else:
                 response.success = True
+                try:
+                    response.response_json = json.dumps(result)
+                except (TypeError, ValueError) as e:
+                    response.response_json = ""
+                    response.error_msg = (
+                        f"The method '{request.name}' returned a value that is not JSON serializable: {e}"
+                    )
         except Exception as e:
             response.success = False
             response.error_msg = f"Component {self.node_name} has a method with requested name '{request.name}' but the following error raised while running: {e}"

--- a/ros_sugar/utils.py
+++ b/ros_sugar/utils.py
@@ -108,7 +108,8 @@ def component_action(
 ):
     """
     Decorator for components actions
-    Verifies that the function is a valid Component method, returns a boolean or None, and that the Component is active
+    Verifies that the function is a valid Component method and that the Component is active.
+    Actions may return any JSON-serializable value, or None.
 
     Can be used as:
         @component_action
@@ -131,13 +132,6 @@ def component_action(
             self = args[0]
             if not isinstance(self, LifecycleNode):
                 raise TypeError(f"'{func.__name__}' is not a valid Component method")
-
-            # Check return type
-            return_type = inspect.signature(func).return_annotation
-            if return_type is not bool and return_type:
-                raise TypeError(
-                    f"Action methods must return boolean or None. Method '{func.__name__}' cannot have '@component_action' decorator"
-                )
 
             # Check Component is active
             if rclpy_is_ok() and hasattr(self, "_state_machine"):
@@ -214,7 +208,7 @@ def component_fallback(
                     return None
             else:
                 logger.error(
-                    f"Cannot use component action method '{func.__name__}' without initializing rclpy and the Component"
+                    f"Cannot use component fallback method '{func.__name__}' without initializing rclpy and the Component"
                 )
 
         _wrapper.__name__ = func.__name__

--- a/srv/ExecuteMethod.srv
+++ b/srv/ExecuteMethod.srv
@@ -3,3 +3,4 @@ string kwargs_json
 ---
 bool success
 string error_msg
+string response_json

--- a/test/component/execute_method_test.py
+++ b/test/component/execute_method_test.py
@@ -1,0 +1,143 @@
+import json
+import unittest
+import launch_testing
+import launch_testing.actions
+import launch_testing.markers
+import pytest
+import rclpy
+
+from ros_sugar.core import BaseComponent
+from ros_sugar import Launcher
+from ros_sugar.utils import component_action
+from automatika_ros_sugar.srv import ExecuteMethod
+
+
+EXPECTED_DICT = {"status": "ok", "count": 3, "items": ["a", "b"]}
+EXPECTED_INT = 42
+EXPECTED_STRING = "hello"
+
+
+class ReturningComponent(BaseComponent):
+    """Component with component_action methods returning various non-bool types."""
+
+    def __init__(self, component_name, **kwargs):
+        super().__init__(component_name, **kwargs)
+
+    def _execution_step(self):
+        return
+
+    @component_action
+    def return_dict(self):
+        return EXPECTED_DICT
+
+    @component_action
+    def return_int(self):
+        return EXPECTED_INT
+
+    @component_action
+    def return_string(self):
+        return EXPECTED_STRING
+
+    @component_action
+    def return_none(self):
+        return None
+
+    @component_action
+    def return_true(self) -> bool:
+        return True
+
+    @component_action
+    def return_false(self) -> bool:
+        return False
+
+    @component_action
+    def return_non_serializable(self):
+        return object()
+
+
+@pytest.mark.launch_test
+@launch_testing.markers.keep_alive
+def generate_test_description():
+    component = ReturningComponent(component_name="returning_component")
+    component.loop_rate = 10.0
+
+    launcher = Launcher()
+    launcher.add_pkg(components=[component])
+    launcher.setup_launch_description()
+    launcher._description.add_action(launch_testing.actions.ReadyToTest())
+    return launcher._description
+
+
+class TestExecuteMethodResponse(unittest.TestCase):
+    """Tests that ExecuteMethod.srv response_json is populated for non-bool returns."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.context = rclpy.Context()
+        cls.context.init()
+        cls.node = rclpy.create_node(
+            "test_execute_method_client", context=cls.context
+        )
+        cls.client = cls.node.create_client(
+            ExecuteMethod, "returning_component/execute_method"
+        )
+        assert cls.client.wait_for_service(timeout_sec=30.0), (
+            "execute_method service was not available within timeout"
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        cls.context.try_shutdown()
+
+    def _call(self, method_name: str):
+        req = ExecuteMethod.Request()
+        req.name = method_name
+        req.kwargs_json = ""
+        future = self.client.call_async(req)
+        rclpy.spin_until_future_complete(
+            self.node, future, timeout_sec=10.0, executor=rclpy.executors.SingleThreadedExecutor(context=self.context)
+        )
+        self.assertTrue(future.done(), f"Service call '{method_name}' did not complete")
+        return future.result()
+
+    def test_dict_return_is_json_encoded(self):
+        resp = self._call("return_dict")
+        self.assertTrue(resp.success)
+        self.assertEqual(json.loads(resp.response_json), EXPECTED_DICT)
+
+    def test_int_return_is_json_encoded(self):
+        resp = self._call("return_int")
+        self.assertTrue(resp.success)
+        self.assertEqual(json.loads(resp.response_json), EXPECTED_INT)
+
+    def test_string_return_is_json_encoded(self):
+        resp = self._call("return_string")
+        self.assertTrue(resp.success)
+        self.assertEqual(json.loads(resp.response_json), EXPECTED_STRING)
+
+    def test_none_return_has_empty_response_json(self):
+        resp = self._call("return_none")
+        self.assertTrue(resp.success)
+        self.assertEqual(resp.response_json, "")
+
+    def test_true_bool_return(self):
+        resp = self._call("return_true")
+        self.assertTrue(resp.success)
+        self.assertEqual(json.loads(resp.response_json), True)
+
+    def test_false_bool_return(self):
+        resp = self._call("return_false")
+        self.assertFalse(resp.success)
+        self.assertNotEqual(resp.error_msg, "")
+
+    def test_non_serializable_return_sets_error(self):
+        resp = self._call("return_non_serializable")
+        self.assertTrue(resp.success)
+        self.assertEqual(resp.response_json, "")
+        self.assertIn("not JSON serializable", resp.error_msg)
+
+    def test_unknown_method_fails(self):
+        resp = self._call("this_method_does_not_exist")
+        self.assertFalse(resp.success)
+        self.assertIn("does not have a method", resp.error_msg)


### PR DESCRIPTION
## Summary

Extends the `ExecuteMethod` service so its response carries the actual return value of the invoked component method, not just a `bool success` flag. This lets orchestrator components (e.g. task planners) obtain structured results from the actions they dispatch.

- Adds a `string response_json` field to `srv/ExecuteMethod.srv`.
- Updates `_execute_method_srv_callback` to JSON-encode the return value: `None` yields an empty string, booleans behave as before, any other JSON-serializable value is encoded into `response_json`, and non-serializable returns leave `response_json` empty and populate `error_msg`.
- Relaxes the `@component_action` decorator to accept any return type, not just `bool` / `None`.
- Adds `test/component/execute_method_test.py` covering dict, int, string, None, True, False, non-serializable, and unknown-method cases.

Closes #39.