### PR TITLE
Give TF listener timer its own callback group

### DIFF
--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -878,7 +878,9 @@ class BaseComponent(lifecycle.Node):
         transform_listener = TransformListener(buffer=tf_handler.tf_buffer, node=self)
         tf_handler.set_listener(transform_listener)
         transform_timer = self.create_timer(
-            1 / tf_config.lookup_rate, tf_handler.timer_callback
+            1 / tf_config.lookup_rate,
+            tf_handler.timer_callback,
+            callback_group=MutuallyExclusiveCallbackGroup(),
         )  # timer to lookup the transform with given rate
         tf_handler.timer = transform_timer
         return tf_handler


### PR DESCRIPTION
## Summary

The TF listener timer created in `BaseComponent.create_tf_listener` did not specify a `callback_group`, so it fell back to the node's default `MutuallyExclusiveCallbackGroup`. This meant the transform-lookup timer was serialized against every other callback on the node that also used the default group, risking avoidable blocking behaviour.

The timer now gets its own dedicated `MutuallyExclusiveCallbackGroup`, matching how the main execution timer, event listeners, fallback listeners, and default services are assigned groups elsewhere in `BaseComponent`.

Closes #43.