### PR TITLE
Add output logging display for geometry types

### DIFF
--- a/ros_sugar/ui_node/elements.py
+++ b/ros_sugar/ui_node/elements.py
@@ -900,7 +900,26 @@ def _log_text_element(logging_card, output, data_src: str, id: str = "text"):
     return logging_card(_styled_logging_text(output, data_src, id))
 
 
-# _INPUT_ELEMENTS and _OUTPUT_ELEMENTS are the main dictionaries used to link message types with their UI elements
+def _log_geometry_element(logging_card, output, data_src: str, id: str = "geometry"):
+    """Adds a Point/PointStamped/Pose/PoseStamped output to the main logging card.
+
+    Upstream callbacks emit `{"data": [x, y, z]}` for Point variants and
+    `{"data": [x, y, z, heading]}` for Pose variants. Dispatch on length.
+    """
+    data = output.get("data") if isinstance(output, dict) else None
+    if data is None or len(data) < 3:
+        formatted = f"Geometry: {output}"
+    elif len(data) == 3:
+        formatted = f"Point: x={data[0]:.3f}, y={data[1]:.3f}, z={data[2]:.3f}"
+    else:
+        formatted = (
+            f"Pose: x={data[0]:.3f}, y={data[1]:.3f}, "
+            f"z={data[2]:.3f}, heading={data[3]:.3f}"
+        )
+    return logging_card(_styled_logging_text(formatted, data_src, id))
+
+
+# NOTE: _INPUT_ELEMENTS and _OUTPUT_ELEMENTS are the main dictionaries used to link message types with their UI elements
 # (both inputs: _INPUT_ELEMENTS and outputs: _OUTPUT_ELEMENTS)
 # Other Sugarcoat-based packages can implement their own UI elements
 # and these dictionaries will be populated and updated automatically
@@ -923,6 +942,10 @@ _OUTPUT_ELEMENTS: Dict = {
     "Float64": _log_text_element,
     "Bool": _log_text_element,
     "Audio": _log_audio_element,
+    "Point": _log_geometry_element,
+    "PointStamped": _log_geometry_element,
+    "Pose": _log_geometry_element,
+    "PoseStamped": _log_geometry_element,
     "Image": _out_image_element,
     "CompressedImage": _out_image_element,
     "OccupancyGrid": _out_map_element,

--- a/scripts/ui_node_executable
+++ b/scripts/ui_node_executable
@@ -422,9 +422,21 @@ def main():
     async def on_conn(send):
         """When a client connects, register its callback."""
 
+        # NOTE: Types that will be routed to the map websocket once it attaches.
+        # They are dropped from the default log callback to avoid a brief
+        # flash in the log during the startup window between the main /ws
+        # connecting and /ws_map attaching its per-type callbacks.
+        map_overlay_types = (
+            {t for _, t in fh.get_all_map_overlay_outputs()}
+            if fh.get_all_map_outputs()
+            else set()
+        )
+
         # Callback function for ROS node
         async def websocket_callback(data: Dict, **_):
             # Recieve json style data from node and pass to UI with send
+            if data.get("type") in map_overlay_types:
+                return
             if len(data["payload"]) > 0:
                 await log_data(
                     send, data["payload"], data_type=data["type"], data_src="robot"


### PR DESCRIPTION
## Summary

Adds a formatted log display for Point, PointStamped, Pose, and PoseStamped output topics, which previously had no output element registered and would silently drop when no map was present.

- Introduces `_log_geometry_element` in `ros_sugar/ui_node/elements.py` that dispatches on the length of the upstream payload: 3-element data renders as `Point: x=..., y=..., z=...` and 4-element data renders as `Pose: x=..., y=..., z=..., heading=...`.
- Registers all four geometry types in `_OUTPUT_ELEMENTS` against the same function.
- Suppresses a startup-window log flash in `scripts/ui_node_executable`: when a map output exists, the default log websocket callback drops messages whose type is in `get_all_map_overlay_outputs()`. This avoids a brief flash in the log between the main `/ws` connecting and `/ws_map` attaching its per-type callbacks. Steady-state behaviour is unchanged because the map callbacks bypass the default entirely.

Closes #37.