### PR TITLE
Decouple executor spin timeout from loop_rate

### DIFF
--- a/ros_sugar/config/base_config.py
+++ b/ros_sugar/config/base_config.py
@@ -109,6 +109,8 @@ class BaseConfig(BaseAttrs):
 
     :param loop_rate: Rate (Hz) in which the node executes
     :type loop_rate: float
+    :param executor_spin_timeout: Timeout (seconds) for the executor spin_once call. Controls how long the executor blocks waiting for work when no callbacks are pending. Independent of loop_rate.
+    :type executor_spin_timeout: float
     :param visualization: To publish additional topics for visualization
     :type visualization: bool
     """
@@ -117,6 +119,9 @@ class BaseConfig(BaseAttrs):
     loop_rate: float = field(
         default=100.0, validator=base_validators.in_range(min_value=1e-4, max_value=1e9)
     )  # Hz
+    executor_spin_timeout: float = field(
+        default=0.01, validator=base_validators.in_range(min_value=1e-4, max_value=1.0)
+    )  # seconds
 
 
 class ComponentRunType(Enum):

--- a/ros_sugar/launch/launch_actions.py
+++ b/ros_sugar/launch/launch_actions.py
@@ -180,7 +180,7 @@ class ComponentLaunchAction(NodeLaunchAction):
 
     def _run(self):
         """
-        Overrides _run method of launch_ros.actions.Node to spin using the monitor loop_rate
+        Overrides _run method of launch_ros.actions.Node to spin using the executor spin timeout
         """
         if not self.__ros_executor:
             raise Exception("Node executor is unknown")
@@ -190,7 +190,7 @@ class ComponentLaunchAction(NodeLaunchAction):
                 # TODO: switch this to `spin()` when it considers
                 #   asynchronously added subscriptions.
                 self.__ros_executor.spin_once(
-                    timeout_sec=1 / self.__ros_node.config.loop_rate
+                    timeout_sec=self.__ros_node.config.executor_spin_timeout
                 )
         except KeyboardInterrupt:
             pass


### PR DESCRIPTION
## Summary

- Adds `executor_spin_timeout` field to `BaseConfig` (default 10ms) to independently control how long the executor blocks in `spin_once`
- Replaces `1 / loop_rate` in `launch_actions.py` with the new config value, so `loop_rate` strictly controls the execution timer period

Closes #40