### PR TITLE
Add process crash recovery via Launcher.on_process_fail

### DIFF
--- a/ros_sugar/config/base_config.py
+++ b/ros_sugar/config/base_config.py
@@ -109,6 +109,8 @@ class BaseConfig(BaseAttrs):
 
     :param loop_rate: Rate (Hz) in which the node executes
     :type loop_rate: float
+    :param executor_spin_timeout: Timeout (seconds) for the executor spin_once call. Controls how long the executor blocks waiting for work when no callbacks are pending. Independent of loop_rate.
+    :type executor_spin_timeout: float
     :param visualization: To publish additional topics for visualization
     :type visualization: bool
     """
@@ -117,6 +119,9 @@ class BaseConfig(BaseAttrs):
     loop_rate: float = field(
         default=100.0, validator=base_validators.in_range(min_value=1e-4, max_value=1e9)
     )  # Hz
+    executor_spin_timeout: float = field(
+        default=0.01, validator=base_validators.in_range(min_value=1e-4, max_value=1.0)
+    )  # seconds
 
 
 class ComponentRunType(Enum):

--- a/ros_sugar/core/monitor.py
+++ b/ros_sugar/core/monitor.py
@@ -15,6 +15,9 @@ from automatika_ros_sugar.srv import (
     ReplaceTopic,
     ExecuteMethod,
 )
+from lifecycle_msgs.srv import ChangeState as ChangeStateSrv
+from lifecycle_msgs.srv import GetState as GetStateSrv
+from lifecycle_msgs.msg import State, Transition
 
 from .. import base_clients
 from .component import BaseComponent
@@ -107,11 +110,22 @@ class Monitor(Node):
 
         self._components_to_activate_on_start: List[str] = activate_on_start or []
 
-        self.__components_activation_event: Optional[Callable] = None
-
         # Handle timeout when waiting for looking for the components to activate
         self.__activation_timeout = activation_timeout
         self.__activation_attempt_time = activation_attempt_time
+
+        # Per-watch state for _arm_discovery_watch: keyed by watch_key.
+        # Entry is a dict with target_names, timeout_sec, elapsed, timer, on_ready
+        self.__discovery_watches: Dict[str, Dict[str, Any]] = {}
+
+        # Launch-context emit callables are registered in _pure_internal_events.
+        # activate_all flows through the launch event system for initial activation
+        self._pure_internal_events: List[str] = ["activate_all"]
+
+        # TODO: Additional internal actions that can be populated by downstream
+        # packages. Processing can be moved to upstream launcher after finalizing
+        # downstream API
+        self._additional_internal_actions = {}
 
         # Emit exit all to the launcher
         self._emit_exit_to_launcher: Optional[Callable] = None
@@ -133,11 +147,6 @@ class Monitor(Node):
         :param action: Action to be executed on event trigger
         :type action: Action
         """
-        if not hasattr(self, "_pure_internal_events") or not hasattr(
-            self, "_additional_internal_actions"
-        ):
-            self._pure_internal_events = []
-            self._additional_internal_actions = {}
         self._pure_internal_events.append(event_id)
         self._additional_internal_actions[event_id] = action
 
@@ -148,28 +157,30 @@ class Monitor(Node):
         Node.__init__(self, self.node_name, *args, **kwargs)
         self.get_logger().info(f"NODE {self.get_name()} STARTED")
 
-    def add_components_activation_event(self, method) -> None:
-        """
-        Adds a method to be executed when components are activated
-
-        :param method: Method to be executed on components activation
-        :type method: Callable
-        """
-        self.__components_activation_event = method
-
     def start(self):
         return self.activate()
 
     def activate(self):
         """Activate all subscribers/publishers/etc..."""
-        # Create a timer for components activation
+        # Poll the ROS graph for all components to activate and emit
+        # activate_all once they are up, as a single atomic barrier.
         if self._components_to_activate_on_start:
-            callback_group = MutuallyExclusiveCallbackGroup()
-            self.__activation_wait_time: float = 0.0
-            self.__components_monitor_timer = self.create_timer(
-                timer_period_sec=self.__activation_attempt_time,
-                callback=self._check_and_activate_components,
-                callback_group=callback_group,
+
+            def _emit_activate_all() -> None:
+                emit = self.emit_internal_event_methods.get("activate_all")
+                if emit is not None:
+                    emit()
+                else:
+                    logger.warning(
+                        "No launch-context emitter for 'activate_all'; "
+                        "initial activation will not trigger."
+                    )
+
+            self._arm_discovery_watch(
+                target_names=self._components_to_activate_on_start,
+                on_ready=_emit_activate_all,
+                watch_key="activate_all",
+                timeout_sec=self.__activation_timeout,
             )
 
         # Create health status subscribers
@@ -210,35 +221,229 @@ class Monitor(Node):
                     )
                 )
 
-    def _check_and_activate_components(self) -> None:
+    def _arm_discovery_watch(
+        self,
+        target_names: List[str],
+        on_ready: Callable[[], None],
+        watch_key: str,
+        timeout_sec: Optional[float] = None,
+    ) -> None:
         """
-        Checks and activates requested components
+        Start polling the ROS graph for ``target_names`` and invoke ``on_ready``
+        once all targets appear in ``get_node_names()`` and their lifecycle
+        ``change_state`` services are in the graph.
+
+        Idempotent: re-arming for the same ``watch_key`` cancels the previous
+        watch. The timer destroys itself after ``on_ready`` is invoked.
+
+        :param target_names: Component node names to wait for.
+        :param on_ready: Callable invoked once with no args when all targets
+            are ready. Typically either emits an internal event to the launch
+            context (initial activation) or drives direct lifecycle service
+            calls (respawn reactivation).
+        :param watch_key: Opaque key identifying this watch, used for idempotent
+            re-arming.
+        :param timeout_sec: If set, emit exit_all and raise LookupError when
+            the wait exceeds this many seconds. ``None`` waits indefinitely.
         """
-        self.__activation_wait_time += self.__activation_attempt_time
-        node_names = self.get_node_names()
-        __notfound: Optional[set[str]] = None
-        if set(self._components_to_activate_on_start).issubset(set(node_names)):
+        existing = self.__discovery_watches.get(watch_key)
+        if existing is not None and existing.get("timer") is not None:
+            self.destroy_timer(existing["timer"])
+
+        watch: Dict[str, Any] = {
+            "target_names": list(target_names),
+            "timeout_sec": timeout_sec,
+            "elapsed": 0.0,
+            "timer": None,
+            "on_ready": on_ready,
+        }
+        self.__discovery_watches[watch_key] = watch
+        watch["timer"] = self.create_timer(
+            timer_period_sec=self.__activation_attempt_time,
+            callback=partial(self._run_discovery_watch, watch_key),
+            callback_group=MutuallyExclusiveCallbackGroup(),
+        )
+
+    def _run_discovery_watch(self, watch_key: str) -> None:
+        """Timer callback for a single discovery watch.
+
+        A target is considered ready when it is present in
+        ``get_node_names()`` and its lifecycle ``change_state`` service is
+        in the graph. Note that after a process crash this check can match
+        a stale DDS entry from the dead process; respawn callers handle
+        that in a follow-up probe phase rather than at the watch level.
+        """
+        watch = self.__discovery_watches.get(watch_key)
+        if watch is None:
+            return
+
+        watch["elapsed"] += self.__activation_attempt_time
+        node_names_set = set(self.get_node_names())
+        present_services = {name for name, _ in self.get_service_names_and_types()}
+
+        missing = set()
+        for target in watch["target_names"]:
+            lifecycle_service = f"/{target}/change_state"
+            if (
+                target not in node_names_set
+                or lifecycle_service not in present_services
+            ):
+                missing.add(target)
+
+        if not missing:
             logger.info(
-                f"NODES '{self._components_to_activate_on_start}' ARE UP ... ACTIVATING"
+                f"NODES '{watch['target_names']}' ARE UP ... "
+                f"triggering on_ready for watch '{watch_key}'"
             )
-            if self.__components_activation_event:
-                self.__components_activation_event()
-            self.destroy_timer(self.__components_monitor_timer)
-        else:
-            __notfound = set(self._components_to_activate_on_start).difference(
-                set(node_names)
-            )
-            logger.info(f"Waiting for Nodes '{__notfound}' to come up to activate ...")
-        if (
-            self.__activation_timeout
-            and self.__activation_wait_time > self.__activation_timeout
-        ):
+            on_ready = watch["on_ready"]
+            self.destroy_timer(watch["timer"])
+            del self.__discovery_watches[watch_key]
+            try:
+                on_ready()
+            except Exception as exc:
+                logger.error(f"on_ready callback for watch '{watch_key}' raised: {exc}")
+            return
+
+        logger.info(f"Waiting for {missing} to come up for watch '{watch_key}' ...")
+
+        timeout = watch["timeout_sec"]
+        if timeout and watch["elapsed"] > timeout:
             if self._emit_exit_to_launcher:
                 self._emit_exit_to_launcher()
-
             raise LookupError(
-                f"Timeout while Waiting for nodes '{__notfound}' to come up to activate. A process might have died. If all processes are starting without errors, then this might be a ROS2 discovery problem. Run 'ros2 node list' to see if nodes with the same name already exist or old nodes are not killed properly. Alternatively, try to restart ROS2 daemon."
+                f"Timeout while waiting for nodes '{missing}' to come up for "
+                f"watch '{watch_key}'. A process might have died. If "
+                f"all processes are starting without errors, then this might be "
+                f"a ROS2 discovery problem. Run 'ros2 node list' to see if nodes "
+                f"with the same name already exist or old nodes are not killed "
+                f"properly. Alternatively, try to restart ROS2 daemon."
             )
+
+    def watch_and_activate_component(self, component_name: str) -> None:
+        """
+        Poll for a respawned component and drive it back to the ``active``
+        state via direct lifecycle service calls once it is reachable.
+
+        Called by the Launcher after a process-level respawn. Bypasses the
+        ``LifecycleTransition`` launch action to avoid duplicate ChangeState
+        dispatch from stale ``LifecycleEventManager`` instances left behind
+        by the crashed process.
+        """
+        logger.info(f"Watching for respawned '{component_name}' to reactivate")
+        self._arm_discovery_watch(
+            target_names=[component_name],
+            on_ready=partial(self._transition_component_to_active, component_name),
+            watch_key=f"reactivate_{component_name}",
+            timeout_sec=None,
+        )
+
+    def _call_service(
+        self,
+        client: Any,
+        request: Any,
+        timeout_sec: Optional[float] = None,
+    ) -> Optional[Any]:
+        """
+        Send ``request`` on ``client`` asynchronously and wait for the response.
+
+        If ``timeout_sec`` is given, the future is cancelled after that many
+        seconds and the method returns ``None`` (used by the probe loop so a
+        zombie endpoint does not hang us). If ``timeout_sec`` is ``None``, we
+        wait indefinitely — appropriate for transition calls, where the
+        response time depends on the user's ``configure``/``activate``
+        callbacks and can legitimately be long.
+
+        Uses ``time.sleep`` to wait; since the Monitor runs on a
+        MultiThreadedExecutor, other callbacks continue on other threads.
+        """
+        future = client.call_async(request)
+        deadline = time.time() + timeout_sec if timeout_sec is not None else None
+        while not future.done():
+            if deadline is not None and time.time() > deadline:
+                future.cancel()
+                return None
+            time.sleep(0.05)
+        return future.result()
+
+    def _probe_for_unconfigured(self, component_name: str) -> None:
+        """
+        Poll GetState on the target component until it reports
+        ``PRIMARY_STATE_UNCONFIGURED``. Unbounded retries: zombie DDS
+        endpoints from the crashed process will eventually be cleaned up.
+        Each attempt creates and destroys its own service client so DDS
+        discovery starts fresh. Each call has ``__activation_attempt_time``
+        as its timeout, and we sleep the same interval between attempts.
+        """
+        attempt = 0
+        while True:
+            attempt += 1
+            client = self.create_client(GetStateSrv, f"/{component_name}/get_state")
+            try:
+                result = self._call_service(
+                    client,
+                    GetStateSrv.Request(),
+                    timeout_sec=self.__activation_attempt_time,
+                )
+                if result is None:
+                    logger.info(
+                        f"Probe {attempt} for '{component_name}' timed out; retrying"
+                    )
+                else:
+                    if result.current_state.id == State.PRIMARY_STATE_UNCONFIGURED:
+                        logger.info(
+                            f"'{component_name}' is unconfigured after "
+                            f"respawn; proceeding with reactivation"
+                        )
+                        return
+                    logger.info(
+                        f"'{component_name}' state is "
+                        f"'{result.current_state.label}'; waiting for "
+                        f"'unconfigured'"
+                    )
+            finally:
+                self.destroy_client(client)
+            time.sleep(self.__activation_attempt_time)
+
+    def _transition_component_to_active(self, component_name: str) -> None:
+        """
+        Drive a lifecycle component from ``unconfigured`` to ``active`` via two
+        direct ChangeState service calls, preceded by a GetState probe that
+        verifies we are talking to the freshly-spawned rclpy node and not a
+        zombie DDS endpoint from the dead process. Every service client is
+        freshly created here and destroyed afterwards.
+        """
+        logger.info(f"Starting reactivation for '{component_name}'")
+        self._probe_for_unconfigured(component_name)
+
+        client = self.create_client(ChangeStateSrv, f"/{component_name}/change_state")
+        try:
+            for transition_id, name in (
+                (Transition.TRANSITION_CONFIGURE, "CONFIGURE"),
+                (Transition.TRANSITION_ACTIVATE, "ACTIVATE"),
+            ):
+                req = ChangeStateSrv.Request()
+                req.transition.id = transition_id
+                # No timeout: the node's configure()/activate() callbacks may
+                # legitimately take a long time (e.g. model loading). We have
+                # already confirmed via the probe that we are talking to a
+                # live node, so an unbounded wait is safe here.
+                result = self._call_service(client, req)
+                if result is None:
+                    logger.error(
+                        f"{name} for '{component_name}' returned no result; "
+                        f"aborting reactivation."
+                    )
+                    return
+                if not result.success:
+                    logger.error(
+                        f"{name} for '{component_name}' returned "
+                        f"success=False; aborting reactivation."
+                    )
+                    return
+        finally:
+            self.destroy_client(client)
+
+        logger.info(f"'{component_name}' is active again after respawn")
 
     def _turn_on_component_management(self, component_name: str) -> None:
         """

--- a/ros_sugar/core/monitor.py
+++ b/ros_sugar/core/monitor.py
@@ -354,15 +354,18 @@ class Monitor(Node):
         callbacks and can legitimately be long.
 
         Uses ``time.sleep`` to wait; since the Monitor runs on a
-        MultiThreadedExecutor, other callbacks continue on other threads.
+        MultiThreadedExecutor, other callbacks continue on other threads. The
+        sleep interval tracks this node's ``loop_rate`` so one knob governs
+        polling responsiveness consistently with the rest of the Monitor.
         """
         future = client.call_async(request)
         deadline = time.time() + timeout_sec if timeout_sec is not None else None
+        sleep_interval = 1.0 / self.config.loop_rate
         while not future.done():
             if deadline is not None and time.time() > deadline:
                 future.cancel()
                 return None
-            time.sleep(0.05)
+            time.sleep(sleep_interval)
         return future.result()
 
     def _probe_for_unconfigured(self, component_name: str) -> None:

--- a/ros_sugar/launch/launch_actions.py
+++ b/ros_sugar/launch/launch_actions.py
@@ -180,7 +180,7 @@ class ComponentLaunchAction(NodeLaunchAction):
 
     def _run(self):
         """
-        Overrides _run method of launch_ros.actions.Node to spin using the monitor loop_rate
+        Overrides _run method of launch_ros.actions.Node to spin using the executor spin timeout
         """
         if not self.__ros_executor:
             raise Exception("Node executor is unknown")
@@ -190,7 +190,7 @@ class ComponentLaunchAction(NodeLaunchAction):
                 # TODO: switch this to `spin()` when it considers
                 #   asynchronously added subscriptions.
                 self.__ros_executor.spin_once(
-                    timeout_sec=1 / self.__ros_node.config.loop_rate
+                    timeout_sec=self.__ros_node.config.executor_spin_timeout
                 )
         except KeyboardInterrupt:
             pass

--- a/ros_sugar/launch/launch_actions.py
+++ b/ros_sugar/launch/launch_actions.py
@@ -10,7 +10,6 @@ from launch_ros.actions import Node as NodeLaunchAction
 from rclpy.context import Context
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.impl.logging_severity import LoggingSeverity
-from rclpy.lifecycle.managed_entity import ManagedEntity
 from rclpy.logging import set_logger_level
 
 from . import logger
@@ -136,12 +135,6 @@ class ComponentLaunchAction(NodeLaunchAction):
                 self.__ros_node._emit_exit_to_launcher = partial(
                     self._on_internal_event, "exit_all"
                 )
-
-            # Adds an emit event for components activation
-            self.__logger.debug("Registering Conditional Activation Handle")
-            self.__ros_node.add_components_activation_event(
-                partial(self._on_internal_event, "activate_all")
-            )
 
         # Get rclpy context and init the monitor
         self.__ros_context = Context()

--- a/ros_sugar/launch/launcher.py
+++ b/ros_sugar/launch/launcher.py
@@ -17,6 +17,7 @@ from typing import (
     Any,
     Tuple,
     Mapping,
+    cast,
 )
 from concurrent.futures import ThreadPoolExecutor
 from collections import defaultdict
@@ -32,9 +33,11 @@ from launch.actions import (
     GroupAction,
     OpaqueCoroutine,
     OpaqueFunction,
+    RegisterEventHandler,
     Shutdown,
     SetEnvironmentVariable,
 )
+from launch.event_handlers import OnProcessExit, OnShutdown
 from launch_ros.actions import LifecycleNode as LifecycleNodeLaunchAction
 from launch_ros.actions import Node as NodeLaunchAction
 from launch_ros.actions import PushRosNamespace
@@ -73,6 +76,12 @@ else:
 
 # patch msgpack for numpy arrays
 m_pack.patch()
+
+
+# Return codes that indicate the process was terminated by a signal rather
+# than a genuine crash. Launch/subprocess reports signal terminations as
+# negative values (-signum); shells that propagate them use 128+signum.
+_SIGNAL_EXIT_CODES = frozenset({-2, -9, -15, 130, 137, 143})
 
 
 UI_EXTENSIONS = {}
@@ -166,6 +175,11 @@ class Launcher:
 
         # Thread pool for external processors
         self._thread_pool: Union[ThreadPoolExecutor, None] = None
+
+        # Process-level crash recovery state
+        self._process_fail_max_retries: Optional[int] = None
+        self._process_retry_counts: Dict[str, int] = {}
+        self._is_shutting_down: bool = False
 
     def add_pkg(
         self,
@@ -740,37 +754,25 @@ class Launcher:
         for component in self._components:
             component.fallback_rate = value
 
-    def on_fail(self, action_name: str, max_retries: Optional[int] = None) -> None:
+    def on_process_fail(self, max_retries: int = 3) -> None:
         """
-        Set the fallback strategy (action) on any fail for all components
+        Enable process-level crash recovery for all multi-process components.
 
-        :param action: Action to be executed on failure
-        :type action: Union[List[Action], Action]
-        :param max_retries: Maximum number of action execution retries. None is equivalent to unlimited retries, defaults to None
-        :type max_retries: Optional[int], optional
+        When a component process exits unexpectedly (non-zero return code, not during
+        launcher shutdown, and not via user signal), the launcher will respawn it up
+        to ``max_retries`` times. After the limit is reached, the component is left
+        down and a terminal error is logged.
+
+        :param max_retries: Maximum number of respawn attempts per component. Must be
+            a positive integer. Defaults to 3.
+        :type max_retries: int
+        :raises ValueError: if ``max_retries`` is not a positive integer.
         """
-        for component in self._components:
-            if action_name in component.fallbacks:
-                method = getattr(component, action_name)
-                method_params = inspect.signature(method).parameters
-                if any(
-                    x.default is inspect.Parameter.empty
-                    and x.kind
-                    not in (
-                        inspect.Parameter.VAR_POSITIONAL,
-                        inspect.Parameter.VAR_KEYWORD,
-                    )
-                    for x in method_params.values()
-                ):
-                    raise ValueError(
-                        f"{method} takes {method_params} as arguments. Only actions without any arguments or with keyword only arguments can be set as on_fail actions from the launcher. Use component.on_fail to pass specific arguments."
-                    )
-                action = Action(method=method)
-                component.on_fail(action, max_retries)
-            else:
-                raise ValueError(
-                    f"Non valid action fallback {action_name}: Fallback is not available in component {component.node_name}. Available component fallbacks are the following methods: '{component.fallbacks}'"
-                )
+        if not isinstance(max_retries, int) or max_retries < 1:
+            raise ValueError(
+                f"max_retries must be a positive integer, got {max_retries!r}"
+            )
+        self._process_fail_max_retries = max_retries
 
     def _get_action_launch_entity(self, action: Action) -> SomeEntitiesType:
         """Gets the action launch entity for a given Action.
@@ -1058,6 +1060,139 @@ class Launcher:
                     processor,  # type: ignore
                 )
 
+    def _build_component_launch_action(
+        self,
+        component: BaseComponent,
+        pkg_name: str,
+        executable_name: str,
+    ) -> Union[LifecycleNodeLaunchAction, NodeLaunchAction]:
+        """
+        Build a fresh NodeLaunchAction (or lifecycle variant) for the given
+        component. Used both for initial launch and for respawning on crash.
+        """
+        name = component.node_name
+        rclpy_log_level = self._rclpy_log_level.get(component.node_name)
+        if rclpy_log_level:
+            arguments = component.launch_cmd_args + [
+                "--additional_types",
+                json.dumps(list(_additional_types.keys())),
+                "--ros-args",
+                "--log-level",
+                rclpy_log_level,
+            ]
+        else:
+            arguments = component.launch_cmd_args
+        if issubclass(component.__class__, ManagedEntity):
+            return LifecycleNodeLaunchAction(
+                package=pkg_name,
+                exec_name=name,
+                namespace=self._namespace,
+                name=name,
+                executable=executable_name,
+                output="screen",
+                arguments=arguments,
+            )
+        return NodeLaunchAction(
+            package=pkg_name,
+            exec_name=name,
+            namespace=self._namespace,
+            name=name,
+            executable=executable_name,
+            output="screen",
+            arguments=arguments,
+        )
+
+    def _build_exit_handler_entity(
+        self,
+        component: BaseComponent,
+        pkg_name: str,
+        executable_name: str,
+        node_action: Union[LifecycleNodeLaunchAction, NodeLaunchAction],
+    ) -> RegisterEventHandler:
+        """
+        Build a RegisterEventHandler that respawns the component on unexpected exit.
+
+        The handler is only constructed when process-level recovery is enabled.
+
+        On exit the callback does one of three things:
+
+        1. Ignore: orderly shutdown (``_is_shutting_down`` set), clean exit
+           (returncode 0), signal-terminated (Ctrl+C race before shutdown flag was
+           set), or missing returncode.
+        2. Give up: real crash but retry budget exhausted — log and stop.
+        3. Respawn: real crash within budget — increment counter, build a fresh
+           launch action plus a fresh exit handler bound to it, return both.
+        """
+        component_name = component.node_name
+
+        def _on_exit(event, context):
+            returncode = getattr(event, "returncode", None)
+
+            # Do not respawn
+            if (
+                self._is_shutting_down
+                or returncode is None
+                or returncode == 0
+                or returncode in _SIGNAL_EXIT_CODES
+            ):
+                return None
+
+            # Genuine crash. This handler is only built when
+            # _process_fail_max_retries is set.
+            max_retries = cast(int, self._process_fail_max_retries)
+            count = self._process_retry_counts.get(component_name, 0)
+            if count >= max_retries:
+                logger.error(
+                    f"Component '{component_name}' exceeded max_retries "
+                    f"({max_retries}); giving up on process recovery."
+                )
+                return None
+
+            attempt = count + 1
+            self._process_retry_counts[component_name] = attempt
+            logger.warning(
+                f"Component '{component_name}' exited with code {returncode}. "
+                f"Respawning (attempt {attempt}/{max_retries})..."
+            )
+
+            # Clear the dead node's entry from launch_ros' name tracker so the
+            # respawned Node action does not issue warnings about node name
+            # NOTE: The key stored is the fully-qualified node name "/component_name"
+            # The dict is created lazily by launch_ros; guard in case it is missing.
+            try:
+                node_names_dict = context.locals.unique_ros_node_names
+                for registered in list(node_names_dict.keys()):
+                    if registered == component_name or registered.endswith(
+                        f"/{component_name}"
+                    ):
+                        node_names_dict[registered] = 0
+            except AttributeError:
+                pass
+
+            new_action = self._build_component_launch_action(
+                component, pkg_name, executable_name
+            )
+            entities: List[ROSLaunchAction] = [new_action]
+            # Hand off reactivation to the Monitor: it polls for node+service
+            # readiness and drives CONFIGURE+ACTIVATE via direct rclpy calls.
+            # No delay needed here because the polling loop itself waits for
+            # the new lifecycle service to appear in the graph.
+            if isinstance(component, ManagedEntity):
+                def _kick_monitor_watch(_ctx, name=component_name):
+                    self.monitor_node.watch_and_activate_component(name)
+
+                entities.append(OpaqueFunction(function=_kick_monitor_watch))
+            entities.append(
+                self._build_exit_handler_entity(
+                    component, pkg_name, executable_name, new_action
+                )
+            )
+            return entities
+
+        return RegisterEventHandler(
+            OnProcessExit(target_action=node_action, on_exit=_on_exit)
+        )
+
     def _setup_component_in_process(
         self,
         component: BaseComponent,
@@ -1070,47 +1205,18 @@ class Launcher:
         :param ros_log_level: Log level for ROS2
         :type ros_log_level: str, default to "info"
         """
-        name = component.node_name
         component._update_cmd_args_list()
         self._setup_external_processors(component)
-        rclpy_log_level = (
-            self._rclpy_log_level[component.node_name]
-            if component.node_name in self._rclpy_log_level
-            else None
+        new_node = self._build_component_launch_action(
+            component, pkg_name, executable_name
         )
-        if rclpy_log_level:
-            arguments = component.launch_cmd_args + [
-                "--additional_types",
-                json.dumps(list(_additional_types.keys())),
-                "--ros-args",
-                "--log-level",
-                rclpy_log_level,
-            ]
-        else:
-            arguments = component.launch_cmd_args
-        # Check if the component is a lifecycle node
-        if issubclass(component.__class__, ManagedEntity):
-            new_node = LifecycleNodeLaunchAction(
-                package=pkg_name,
-                exec_name=name,
-                namespace=self._namespace,
-                name=name,
-                executable=executable_name,
-                output="screen",
-                arguments=arguments,
-            )
-        else:
-            new_node = NodeLaunchAction(
-                package=pkg_name,
-                exec_name=name,
-                namespace=self._namespace,
-                name=name,
-                executable=executable_name,
-                output="screen",
-                arguments=arguments,
-            )
-
         self._launch_group.append(new_node)
+        if self._process_fail_max_retries is not None:
+            self._launch_group.append(
+                self._build_exit_handler_entity(
+                    component, pkg_name, executable_name, new_node
+                )
+            )
 
     def _setup_component_in_thread(self, component: BaseComponent):
         """
@@ -1232,6 +1338,23 @@ class Launcher:
                 logger.exception(error_msg)
                 raise ValueError(error_msg)
 
+    def _register_shutdown_guards(self) -> None:
+        """
+        Register an OnShutdown handler that flips ``_is_shutting_down`` before child
+        processes are signaled. This lets the respawn logic in OnProcessExit
+        handlers distinguish between a crash and an intentional shutdown. Ctrl+C,
+        a Shutdown launch action, and the existing ``exit_all`` internal event
+        (which ultimately emits Shutdown) all flow through here.
+        """
+
+        def _mark_shutting_down(*_args, **_kwargs):
+            self._is_shutting_down = True
+            return None
+
+        self._description.add_action(
+            RegisterEventHandler(OnShutdown(on_shutdown=_mark_shutting_down))
+        )
+
     def setup_launch_description(
         self,
     ):
@@ -1244,6 +1367,9 @@ class Launcher:
             setproctitle.setproctitle(logger.name)
         except ImportError:
             pass
+
+        if self._process_fail_max_retries is not None:
+            self._register_shutdown_guards()
 
         self._setup_events_actions()
 

--- a/ros_sugar/launch/launcher.py
+++ b/ros_sugar/launch/launcher.py
@@ -89,20 +89,43 @@ UI_EXTENSIONS = {}
 
 class Launcher:
     """
-    Launcher is a class created to provide a more pythonic way to launch and configure ROS nodes.
+    Launcher is a pythonic front-end for bringing up a stack of ROS2 components.
 
-    Launcher starts a pre-configured component or a set of components as ROS2 nodes. Launcher can also manage a set of Events-Actions through its internal Monitor node (See Monitor class).
+    A Launcher groups one or more components into a launch description, manages
+    their lifecycle, wires up an internal :class:`Monitor` node to coordinate
+    their activation and to route events and actions, and can optionally serve
+    a web UI for them.
 
-    ## Available options:
-    - Provide a ROS2 namespace to all the components
-    - Provide a config file.
-    - Enable/Disable events monitoring
+    ## What it does
 
-    Launcher forwards all the provided Events to its internal Monitor, when the Monitor detects an Event trigger it emits an InternalEvent back to the Launcher. Execution of the Action is done directly by the Launcher or a request is forwarded to the Monitor depending on the selected run method (multi-processes or multi-threaded).
+    - Starts components as ROS2 nodes, either in separate processes
+      (``multiprocessing=True`` on :meth:`add_pkg`) or in threads within the
+      launcher's own process (threaded default).
+    - Applies a shared ROS2 namespace and optional config file to all
+      components.
+    - Manages lifecycle transitions so every lifecycle component reaches the
+      ``active`` state once the ROS graph confirms it is discoverable.
+    - Dispatches events to actions. Every event/action pair registered via
+      :meth:`add_pkg` or the component's own ``on_fail`` hook flows through
+      the internal Monitor: the Monitor detects triggers and either invokes
+      the action directly (component actions) or emits an internal event
+      back to the Launcher which executes the corresponding launch action.
+    - Process-level crash recovery via :meth:`on_process_fail`: when enabled,
+      multi-process components that exit unexpectedly are respawned and
+      driven back to the ``active`` state, up to a configurable retry cap.
+      Clean exits, shutdown, and user signals (Ctrl+C, SIGTERM) are not
+      treated as crashes and do not trigger respawns.
+    - Optional web UI via :meth:`enable_ui`.
 
-    :::{note} While Launcher supports executing standard [ROS2 launch actions](https://github.com/ros2/launch). Launcher does not support standard [ROS2 launch events](https://github.com/ros2/launch/tree/rolling/launch/launch/events) for the current version.
-    :::
+    ## Events and actions
 
+    Use this project's richer event/action system instead of the low-level
+    ROS2 launch event primitives. See :class:`~ros_sugar.core.event.Event`,
+    :class:`~ros_sugar.core.action.Action`, and the ``events_actions``
+    parameter on :meth:`add_pkg`: events can be built from topic conditions,
+    compositional boolean expressions, internal signals, or arbitrary
+    callables, and they can drive component methods, lifecycle transitions,
+    or any ROS2 launch action.
     """
 
     def __init__(


### PR DESCRIPTION
## Summary

- Opt-in crash recovery for multi-process components: `launcher.on_process_fail(max_retries=3)` installs a per-component `OnProcessExit` handler that classifies the exit and respawns unexpected crashes up to the retry cap.
- Handler is self-renewing: every respawn includes a fresh handler bound to the new process, so subsequent crashes of the new instance are caught.
- Shutdown guards (`OnShutdown` + signal-exit-code classification for `-2/-9/-15/130/137/143`) prevent respawn loops on Ctrl+C or a Shutdown action.
- Respawned lifecycle components are driven back to `active` by the Monitor using direct `GetState` + `ChangeState` service calls (bypasses `LifecycleTransition`'s broadcast semantics, which would duplicate into stale `LifecycleEventManager`s from the dead process).
- `_arm_discovery_watch` generalized: initial activation emits `activate_all`; respawn reactivation runs a `_probe_for_unconfigured` GetState loop with fresh clients per attempt to step over zombie DDS endpoints, then issues CONFIGURE and ACTIVATE with unbounded waits (user `configure()` callbacks can legitimately take long).
- Legacy `add_components_activation_event` plumbing removed; `activate_all` now flows through the unified `_pure_internal_events` path.

Closes #35