### PR TITLE
Display action server activity in UI log card (#46)

### DIFF
--- a/scripts/ui_node_executable
+++ b/scripts/ui_node_executable
@@ -232,6 +232,14 @@ def main():
                 duration=0,
             )
             fh.action_clients_ft[action_name].total_calls += 1
+            # display the action on the main logging card
+            goal_payload = {k: v for k, v in data_dict.items() if k != "action_name"}
+            elements.update_logging_card(
+                fh.outputs_log,
+                f"Action '{action_name}' goal sent: {goal_payload}",
+                data_type="String",
+                data_src="user",
+            )
         return fh.get_main_page()
 
     @app.post("/action/cancel")
@@ -245,6 +253,13 @@ def main():
             fh.toasting(result, session, "error", duration=100000)
         else:
             fh.toasting(f"{result}", session, "info", duration=100000)
+            # display cancellation request on the main logging card
+            elements.update_logging_card(
+                fh.outputs_log,
+                f"Action '{action_name}' cancelled.",
+                data_type="String",
+                data_src="user",
+            )
         return fh.get_main_page()
 
     # -- WS handling --
@@ -356,6 +371,16 @@ def main():
                 await send(fh.action_clients_ft[_name].card)
 
                 if data["status"] in ["aborted", "completed", "canceled"]:
+                    # display action aborted as an error on the main logging card
+                    if data["status"] == "aborted":
+                        await log_data(
+                            send,
+                            f"Action '{_name}' aborted: {feedback}"
+                            if feedback
+                            else f"Action '{_name}' aborted",
+                            data_type="String",
+                            data_src="error",
+                        )
                     ros_node.cleanup_action(action_name=_name)
                     fh.action_clients_ft[_name].cleanup()
 

--- a/scripts/ui_node_executable
+++ b/scripts/ui_node_executable
@@ -226,7 +226,7 @@ def main():
         if not result_code:
             fh.toasting(result, session, "error", duration=100000)
         else:
-            fh.toasting(f"Action goal sent: {result}", session, "info", duration=100000)
+            fh.toasting(f"Task sent: {result}", session, "info", duration=100000)
             fh.action_clients_ft[action_name].update(
                 status="accepted",
                 duration=0,
@@ -236,7 +236,7 @@ def main():
             goal_payload = {k: v for k, v in data_dict.items() if k != "action_name"}
             elements.update_logging_card(
                 fh.outputs_log,
-                f"Action '{action_name}' goal sent: {goal_payload}",
+                f"Start Task '{action_name}': {goal_payload}",
                 data_type="String",
                 data_src="user",
             )
@@ -256,7 +256,7 @@ def main():
             # display cancellation request on the main logging card
             elements.update_logging_card(
                 fh.outputs_log,
-                f"Action '{action_name}' cancelled.",
+                f"Cancel Task '{action_name}'.",
                 data_type="String",
                 data_src="user",
             )
@@ -375,9 +375,9 @@ def main():
                     if data["status"] == "aborted":
                         await log_data(
                             send,
-                            f"Action '{_name}' aborted: {feedback}"
+                            f"Task '{_name}' aborted: {feedback}"
                             if feedback
-                            else f"Action '{_name}' aborted",
+                            else f"Task '{_name}' aborted",
                             data_type="String",
                             data_src="error",
                         )


### PR DESCRIPTION
## Summary
- Logs action goal sends, cancel requests, and aborted terminal states in the main log card via existing `update_logging_card` dispatcher. No new config, no changes to `_OUTPUT_ELEMENTS`.
- Goal and cancel entries use `data_src="user"` (user-initiated). Aborted entries use `data_src="error"` and include the final feedback when available.
- Scoped to three call sites in `scripts/ui_node_executable`: `/action/goal` success branch, `/action/cancel` success branch, and the `feedback_callback` terminal-status block.

Closes #46.