### PR TITLE
Add front-end-agnostic JSON/WebSocket API for enable_ui interfaces

### DIFF
--- a/.github/workflows/debian_packaging.yml
+++ b/.github/workflows/debian_packaging.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: automatika-robotics/create-ros-debs-action@v1
         with:
-          ros-versions-matrix: 'humble iron jazzy kilted'
+          ros-versions-matrix: 'humble iron jazzy kilted lyrical'
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       PIP_BREAK_SYSTEM_PACKAGES: "1"
     strategy:
       matrix:
-        ros_distro: [humble, jazzy, kilted, rolling]
+        ros_distro: [humble, jazzy, kilted, lyrical, rolling]
     container:
       image: ros:${{ matrix.ros_distro }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,8 @@ jobs:
           ln -s $GITHUB_WORKSPACE /ws/src/sugarcoat
           cd /ws
           pip install --ignore-installed opencv-python-headless 'attrs>=23.2.0' jinja2 \
-                      msgpack msgpack-numpy setproctitle pyyaml toml
+                      msgpack msgpack-numpy setproctitle pyyaml toml \
+                      httpx python-fasthtml MonsterUI
           colcon build --symlink-install
         shell: bash
 

--- a/ros_sugar/base_clients.py
+++ b/ros_sugar/base_clients.py
@@ -1,7 +1,7 @@
 """ROS Service/Action Client Wrapper"""
 
 import time
-from typing import Any, Optional, Dict, Union, Tuple
+from typing import Any, Callable, Optional, Dict, Union, Tuple
 from attrs import Factory, define, field
 
 from rclpy.action.client import ActionClient
@@ -194,6 +194,10 @@ class ActionClientHandler:
         :type config: ActionClientConfig
         """
         self._check_server_alive_timer = None
+        # Zero-arg listeners fired (in the ROS executor thread) on every feedback
+        # message and on terminal state, so feedback can be pushed to multiple
+        # consumers can push feedback as it arrives instead of polling.
+        self._feedback_listeners = set()
         self.reset()
 
         if not config and (action_name and action_type):
@@ -272,7 +276,7 @@ class ActionClientHandler:
         self,
         request_fields: Dict[str, Union[str, Dict]],
         wait_until_first_feedback: bool = False,
-    ):
+    ) -> Optional[bool]:
         """Send an action request using a serialized Dict request data
 
         :param request_fields: Request data [key, value]
@@ -393,6 +397,24 @@ class ActionClientHandler:
         """
         self.action_result = future.result().result
         self.action_returned = True
+        # Notify listeners of the terminal transition (no further feedback).
+        self._notify_feedback_listeners()
+
+    def add_feedback_listener(self, listener: Callable[[], None]) -> None:
+        """Register a zero-arg callback fired on every feedback message and on
+        terminal state (in the ROS executor thread)."""
+        self._feedback_listeners.add(listener)
+
+    def remove_feedback_listener(self, listener: Callable[[], None]) -> None:
+        """Remove a previously registered feedback listener."""
+        self._feedback_listeners.discard(listener)
+
+    def _notify_feedback_listeners(self) -> None:
+        for listener in list(self._feedback_listeners):
+            try:
+                listener()
+            except Exception:
+                pass
 
     def action_feedback_callback(self, feedback_msg: Any):
         """
@@ -404,6 +426,7 @@ class ActionClientHandler:
         self.goal_accepted = True
         self.feedback_count += 1
         self.feedback_msg = feedback_msg
+        self._notify_feedback_listeners()
 
     def _check_alive_callback(self):
         """Timed callback to check if server is sending a feedback"""

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -1209,7 +1209,7 @@ class BaseComponent(lifecycle.Node):
 
         # Check if all callbacks of the selected topics got input messages
         for callback in inputs_dict_to_check.values():
-            if callback._subscriber and not callback.got_msg:
+            if not callback.got_msg:
                 return False
         return True
 

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -6,7 +6,6 @@ import json
 import yaml
 import toml
 import socket
-from abc import abstractmethod
 from copy import deepcopy
 from contextlib import contextmanager
 import threading
@@ -1763,7 +1762,6 @@ class BaseComponent(lifecycle.Node):
     # TODO: Implement dunder methods for a more intuitive API with components
 
     # MAIN ACTION SERVER HELPER METHODS AND CALLBACKS
-    @abstractmethod
     def main_action_callback(self, goal_handle) -> Any:
         """
         Component main action server callback - used if component started with run_as_action_server=True
@@ -1863,7 +1861,6 @@ class BaseComponent(lifecycle.Node):
         """
         self._main_srv_name = value
 
-    @abstractmethod
     def main_service_callback(self, request, response):
         """
         Component main service callback - used if component started with run_as_server=True

--- a/ros_sugar/io/callbacks.py
+++ b/ros_sugar/io/callbacks.py
@@ -227,6 +227,11 @@ class StdMsgArrayCallback(GenericCallback):
         except Exception as e:
             raise ValueError(f"Failed to parse MultiArray message: {str(e)}") from e
 
+    def _get_ui_content(self, **_) -> Optional[List]:
+        """Get JSON-serializable UI content for a MultiArray."""
+        output = self.get_output(clear_last=True)
+        return output.tolist() if output is not None else None
+
 
 class ImageCallback(GenericCallback):
     """
@@ -492,7 +497,8 @@ class OdomCallback(GenericCallback):
         :returns:   Topic content
         :rtype:     Any
         """
-        return {"frame_id": self.frame_id, "data": self.get_output(clear_last=True)}
+        output = self.get_output(clear_last=True)
+        return {"frame_id": self.frame_id, "data": output.tolist() if output is not None else None}
 
     def _process(self, msg: Odometry) -> np.ndarray:
         """Takes Odometry ROS object and converts it to a numpy array with [x, y, z, heading, speed]
@@ -568,7 +574,8 @@ class PointCallback(GenericCallback):
         :returns:   Topic content
         :rtype:     Any
         """
-        return {"data": self.get_output(clear_last=True)}
+        output = self.get_output(clear_last=True)
+        return {"data": output.tolist() if output is not None else None}
 
 
 class PointStampedCallback(GenericCallback):
@@ -602,7 +609,8 @@ class PointStampedCallback(GenericCallback):
         :returns:   Topic content
         :rtype:     Any
         """
-        return {"frame_id": self.frame_id, "data": self.get_output(clear_last=True)}
+        output = self.get_output(clear_last=True)
+        return {"frame_id": self.frame_id, "data": output.tolist() if output is not None else None}
 
 
 class PoseCallback(GenericCallback):
@@ -707,7 +715,8 @@ class PoseCallback(GenericCallback):
         :returns:   Topic content
         :rtype:     Any
         """
-        return {"data": self.get_output(clear_last=True)}
+        output = self.get_output(clear_last=True)
+        return {"data": output.tolist() if output is not None else None}
 
 
 class PoseStampedCallback(PoseCallback):
@@ -747,7 +756,8 @@ class PoseStampedCallback(PoseCallback):
         :returns:   Topic content
         :rtype:     Any
         """
-        return {"frame_id": self.frame_id, "data": self.get_output(clear_last=True)}
+        output = self.get_output(clear_last=True)
+        return {"frame_id": self.frame_id, "data": output.tolist() if output is not None else None}
 
 
 class PathCallback(GenericCallback):

--- a/ros_sugar/io/callbacks.py
+++ b/ros_sugar/io/callbacks.py
@@ -1,6 +1,7 @@
 """ROS Subscribers Callback Classes"""
 
 import os
+import array
 from abc import abstractmethod
 from typing import Any, Callable, Optional, Union, Dict, List
 from socket import socket
@@ -160,7 +161,7 @@ class GenericCallback:
         :returns:   Topic content
         :rtype:     Any
         """
-        return self.get_output(clear_last=True)
+        return self.get_output()
 
     @property
     def got_msg(self):
@@ -229,7 +230,7 @@ class StdMsgArrayCallback(GenericCallback):
 
     def _get_ui_content(self, **_) -> Optional[List]:
         """Get JSON-serializable UI content for a MultiArray."""
-        output = self.get_output(clear_last=True)
+        output = self.get_output()
         return output.tolist() if output is not None else None
 
 
@@ -497,7 +498,7 @@ class OdomCallback(GenericCallback):
         :returns:   Topic content
         :rtype:     Any
         """
-        output = self.get_output(clear_last=True)
+        output = self.get_output()
         return {"frame_id": self.frame_id, "data": output.tolist() if output is not None else None}
 
     def _process(self, msg: Odometry) -> np.ndarray:
@@ -574,7 +575,7 @@ class PointCallback(GenericCallback):
         :returns:   Topic content
         :rtype:     Any
         """
-        output = self.get_output(clear_last=True)
+        output = self.get_output()
         return {"data": output.tolist() if output is not None else None}
 
 
@@ -609,7 +610,7 @@ class PointStampedCallback(GenericCallback):
         :returns:   Topic content
         :rtype:     Any
         """
-        output = self.get_output(clear_last=True)
+        output = self.get_output()
         return {"frame_id": self.frame_id, "data": output.tolist() if output is not None else None}
 
 
@@ -715,7 +716,7 @@ class PoseCallback(GenericCallback):
         :returns:   Topic content
         :rtype:     Any
         """
-        output = self.get_output(clear_last=True)
+        output = self.get_output()
         return {"data": output.tolist() if output is not None else None}
 
 
@@ -756,7 +757,7 @@ class PoseStampedCallback(PoseCallback):
         :returns:   Topic content
         :rtype:     Any
         """
-        output = self.get_output(clear_last=True)
+        output = self.get_output()
         return {"frame_id": self.frame_id, "data": output.tolist() if output is not None else None}
 
 
@@ -903,15 +904,25 @@ class OccupancyGridCallback(GenericCallback):
 
         return threeD_coordinates
 
-    def _get_ui_content(self, **_) -> str:
-        """Get ui content for occupancy grid"""
-        # Convert occupancy grid values to grayscale image
-        output = self.get_output(get_obstacles=False, get_three_d=False)
-        img = np.zeros_like(output, dtype=np.uint8)
-        img[output == -1] = 127  # unknown
-        img[output == 0] = 255  # free
-        img[output > 0] = 0  # occupied
+    def _get_ui_content(self, **_) -> Optional[Dict]:
+        """Get UI content for an occupancy grid.
 
-        # Flip vertically (ROS map origin is bottom-left, OpenCV image top-left)
-        img = np.flipud(img)
-        return utils.convert_img_to_jpeg_str(img, self.node_name)
+        Returns only what a map renderer needs -- frame, metadata (resolution,
+        size, origin) and the occupancy data (base64-encoded int8) -- not a
+        rendered image and not the unused header/stamp fields.
+        """
+        if not self.msg:
+            return None
+        data = self.msg.data
+        if isinstance(data, array.array):
+            raw_bytes = data.tobytes()
+        elif isinstance(data, (bytes, bytearray)):
+            raw_bytes = bytes(data)
+        else:
+            # list (or other array-like) of int8
+            raw_bytes = array.array("b", list(data)).tobytes()
+        return {
+            "frame_id": self.frame_id,
+            **self._get_output(get_metadata=True),
+            "data": base64.b64encode(raw_bytes).decode("ascii"),
+        }

--- a/ros_sugar/io/supported_types.py
+++ b/ros_sugar/io/supported_types.py
@@ -37,6 +37,7 @@ from std_msgs.msg import (
 )
 
 from . import callbacks
+from .utils import _convert_ros_scalar, _split_ros_field_type
 from .utils import numpy_to_multiarray
 
 
@@ -141,11 +142,8 @@ def get_ros_msg_fields_dict(msg_class: type) -> Dict[str, Any]:
     msg_fields = msg_class.get_fields_and_field_types()
 
     for field_name, field_type_str in msg_fields.items():
-        # Check if it is an array (dynamic '[]' or static '[3]')
-        is_array = "[" in field_type_str
-
-        # Extract base type (remove array notation)
-        base_type = field_type_str.split("[")[0]
+        # Split into base type + sequence flag
+        base_type, is_array = _split_ros_field_type(field_type_str)
 
         # Check if it is a complex type (contains slash)
         if "/" in base_type:
@@ -204,6 +202,7 @@ def set_ros_msg_from_dict(msg_class: type, data_dict: Dict[str, Any]) -> Any:
 
     :param msg_class: The ROS message class to instantiate (e.g., geometry_msgs.msg.Point)
     :param data_dict: Dictionary containing the values (keys must match message fields)
+    :raises ValueError: If a value cannot be converted to its declared field type.
     :return: An instance of msg_class populated with data
     """
     # Instantiate the message
@@ -218,42 +217,58 @@ def set_ros_msg_from_dict(msg_class: type, data_dict: Dict[str, Any]) -> Any:
             continue
 
         ros_type = msg_fields_types[field_name]
+        base_type, is_sequence = _split_ros_field_type(ros_type)
 
-        # Check if the field is an array/list (contains '[')
-        is_array = "[" in ros_type
-
-        # Handle Complex Types (nested messages, e.g., 'geometry_msgs/Point')
-        if "/" in ros_type:
-            # Extract base type name (remove array brackets if present)
-            base_type = ros_type.split("[")[0]
-            (module_str_name, msg_str_name) = base_type.split("/")
-
-            try:
+        try:
+            # Handle Complex Types (nested messages, e.g., 'geometry_msgs/Point')
+            if "/" in base_type:
+                (module_str_name, msg_str_name) = base_type.split("/")
                 msg_module = importlib.import_module(f"{module_str_name}.msg")
                 nested_msg_class = getattr(msg_module, msg_str_name)
 
-                if is_array:
-                    # If it's a list of complex objects, recurse for each item
+                if is_sequence:
                     # field_value is expected to be a list of dicts
-                    complex_array = []
-                    for item in field_value:
-                        complex_array.append(
+                    setattr(
+                        msg,
+                        field_name,
+                        [
                             set_ros_msg_from_dict(nested_msg_class, item)
-                        )
-                    setattr(msg, field_name, complex_array)
+                            for item in field_value
+                        ],
+                    )
                 else:
                     # Single complex object, recurse once
-                    # field_value is expected to be a dict
-                    nested_msg = set_ros_msg_from_dict(nested_msg_class, field_value)
-                    setattr(msg, field_name, nested_msg)
-
-            except (ModuleNotFoundError, ValueError, AttributeError) as e:
-                print(f"Error instantiating nested message for {field_name}: {e}")
-
-        # Handle Simple Types (int, float, string, etc.)
-        else:
-            attr_type = type(getattr(msg, field_name))
-            setattr(msg, field_name, attr_type(field_value))
+                    setattr(
+                        msg, field_name, set_ros_msg_from_dict(nested_msg_class, field_value)
+                    )
+            elif is_sequence:
+                # Require an actual list. So we don't coerce e.g a string into
+                # a list of characters which would crash native serialization
+                if isinstance(field_value, (str, bytes)) or not hasattr(
+                    field_value, "__iter__"
+                ):
+                    raise ValueError(
+                        f"expected a list of '{base_type}' values, "
+                        f"got {type(field_value).__name__}"
+                    )
+                setattr(
+                    msg,
+                    field_name,
+                    [_convert_ros_scalar(base_type, item) for item in field_value],
+                )
+            # Handle Simple Types (int, float, string, etc.)
+            else:
+                setattr(msg, field_name, _convert_ros_scalar(base_type, field_value))
+        except (
+            ValueError,
+            TypeError,
+            AttributeError,
+            ModuleNotFoundError,
+            AssertionError,
+        ) as e:
+            raise ValueError(
+                f"Invalid value for field '{field_name}' ({ros_type}): {e}"
+            ) from e
 
     return msg
 

--- a/ros_sugar/io/supported_types.py
+++ b/ros_sugar/io/supported_types.py
@@ -309,10 +309,6 @@ class SupportedType:
         """
         return cls._ros_type
 
-    @classmethod
-    def convert_ui_dict(cls, data: Dict, **_) -> str:
-        return data.get("data", "")
-
 
 class String(SupportedType):
     """String."""
@@ -346,11 +342,6 @@ class Bool(SupportedType):
         msg = ROSBool()
         msg.data = output
         return msg
-
-    @classmethod
-    def convert_ui_dict(cls, data: Dict, **_) -> str:
-        val = data.get("data", "")
-        return val == "on" or val == "1"
 
 
 class Float32(SupportedType):
@@ -588,17 +579,6 @@ class Point(SupportedType):
         msg.z = output[2]
         return msg
 
-    @classmethod
-    def convert_ui_dict(cls, data: Dict, **_) -> str:
-        return np.array(
-            [
-                float(data.get("x", 0.0)),
-                float(data.get("y", 0.0)),
-                float(data.get("z", 0.0)),
-            ],
-            dtype=np.float64,
-        )
-
 
 class PointStamped(Point):
     """PointStamped"""
@@ -657,23 +637,6 @@ class Pose(SupportedType):
             msg.orientation.y = output[5]
             msg.orientation.z = output[6]
         return msg
-
-    @classmethod
-    def convert_ui_dict(cls, data: Dict, **_) -> str:
-        return np.array(
-            [
-                float(data.get("x", 0.0)),
-                float(data.get("y", 0.0)),
-                float(data.get("z", 0.0)),
-                float(
-                    data.get("ori_w", 0.0) or "1.0"
-                ),  # 'or' is added to handle empty inputs (orientation is optional)
-                float(data.get("ori_x", 0.0) or "0.0"),
-                float(data.get("ori_y", 0.0) or "0.0"),
-                float(data.get("ori_z", 0.0) or "0.0"),
-            ],
-            dtype=np.float64,
-        )
 
 
 class PoseStamped(Pose):

--- a/ros_sugar/io/supported_types.py
+++ b/ros_sugar/io/supported_types.py
@@ -291,6 +291,13 @@ class SupportedType:
     # callback class
     callback = callbacks.GenericCallback
 
+    # Whether the UI/API output stream for this type is rate-sampled by
+    # default instead of event-pushed per message. Set True on continuous
+    # high-bandwidth types (e.g. images, occupancy grids) where clients almost
+    # never want unthrottled raw frames. Derived packages should set this on
+    # their own heavy streaming types.
+    _ui_rate_sampled: bool = False
+
     @classmethod
     def convert(cls, *output, **_) -> Any:
         """ROS message converter function for datatype
@@ -413,6 +420,7 @@ class Image(SupportedType):
 
     _ros_type = ROSImage
     callback = callbacks.ImageCallback
+    _ui_rate_sampled = True  # continuous frames; also inherited by CompressedImage
 
     @classmethod
     def convert(cls, output: Union[ROSImage, np.ndarray], **_) -> ROSImage:
@@ -516,6 +524,7 @@ class OccupancyGrid(SupportedType):
 
     _ros_type = ROSOccupancyGrid
     callback = callbacks.OccupancyGridCallback
+    _ui_rate_sampled = True  # large continuous grid
 
     @classmethod
     def convert(

--- a/ros_sugar/io/utils.py
+++ b/ros_sugar/io/utils.py
@@ -603,3 +603,44 @@ def run_external_processor(
         get_logger(logger_name).error(
             f"Error in external processor for {topic_name}: {e}"
         )
+
+
+# NOTE: Scalar ROS field type names mapped when building messages from
+# JSON-shaped dicts. Conversion goes by the DECLARED field type (not the default
+# value's Python type).
+_ROS_INT_TYPES = frozenset({
+    "int8", "uint8", "int16", "uint16", "int32", "uint32", "int64", "uint64", "char",
+})
+_ROS_FLOAT_TYPES = frozenset({"float", "double", "float32", "float64"})
+
+
+def _split_ros_field_type(ros_type: str) -> Tuple[str, bool]:
+    """Split a ROS field type string into (base_type, is_sequence).
+
+    Handles ``sequence<T>``, bounded ``sequence<T, N>``, static ``T[N]``
+    and plain scalars.
+    """
+    if ros_type.startswith("sequence<"):
+        inner = ros_type[len("sequence<"):].rstrip(">")
+        return inner.split(",")[0].strip(), True
+    if "[" in ros_type:
+        return ros_type.split("[")[0], True
+    return ros_type, False
+
+
+def _convert_ros_scalar(base_type: str, value: Any) -> Any:
+    """Convert a JSON value to the Python value of a scalar ROS field type."""
+    if base_type in _ROS_INT_TYPES:
+        return int(value)
+    if base_type in _ROS_FLOAT_TYPES:
+        return float(value)
+    if base_type == "boolean":
+        return bool(value)
+    if base_type == "octet":
+        # rclpy represents octet as a length-1 bytes object
+        if isinstance(value, (bytes, bytearray)) and len(value) == 1:
+            return bytes(value)
+        return bytes([int(value)])
+    if base_type.startswith(("string", "wstring")):
+        return str(value)
+    raise ValueError(f"unsupported ROS field type '{base_type}'")

--- a/ros_sugar/ui_node/api.py
+++ b/ros_sugar/ui_node/api.py
@@ -164,16 +164,19 @@ def build_interfaces(ros_node: UINode) -> Dict[str, Any]:
     :param ros_node: The running UI node.
     :return: A JSON-serializable discovery document.
     """
-    inputs = [
-        {
+    inputs = []
+    for topic in ros_node.out_topics or []:
+        entry = {
             "name": topic.name,
             "kind": "topic",
             "msg_type": topic.msg_type.__name__,
             "schema": _topic_schema(topic),
             "publish": f"POST {API_BASE}/inputs/{topic.name}",
         }
-        for topic in (ros_node.out_topics or [])
-    ]
+        if topic.msg_type.__name__ == "Audio":
+            # Audio is uploaded over a WS (base64 frames), not a JSON POST.
+            entry["audio_stream"] = f"WS {API_BASE}/inputs/{topic.name}/audio"
+        inputs.append(entry)
 
     outputs = []
     for topic in ros_node.in_topics or []:
@@ -266,6 +269,10 @@ def build_api_app(ros_node: UINode, browser_app: Optional[Any] = None) -> Starle
         for t in (ros_node.in_topics or [])
         if t.msg_type.__name__ in _OVERLAY_TYPES or t.msg_type.__name__ == _PATH_TYPE
     ]
+    # Declared Audio input topics, which accept uploads over a dedicated WS.
+    audio_input_names = {
+        t.name for t in (ros_node.out_topics or []) if t.msg_type.__name__ == "Audio"
+    }
 
     async def health(request):
         """Liveness probe for the API server."""
@@ -531,10 +538,44 @@ def build_api_app(ros_node: UINode, browser_app: Optional[Any] = None) -> Starle
         except (WebSocketDisconnect, RuntimeError):
             return
 
+    async def stream_audio_input(websocket):
+        """Receive base64 audio frames from the client and publish them to a
+        declared Audio input topic (client -> server). Acks each frame.
+        """
+        name = websocket.path_params["name"]
+        if name not in audio_input_names:
+            await websocket.close(code=1008)  # not a declared Audio input
+            return
+        await websocket.accept()
+        try:
+            while True:
+                data = await websocket.receive_json()
+                audio_b64 = (
+                    data.get("payload") or data.get("data")
+                    if isinstance(data, dict)
+                    else None
+                )
+                if not audio_b64:
+                    continue
+                try:
+                    ros_node.publish_audio(name, audio_b64)
+                except RuntimeError as e:
+                    await websocket.send_json({"error": str(e)})
+                    continue
+                except Exception as e:
+                    await websocket.send_json({
+                        "error": f"Failed to publish audio: {e}"
+                    })
+                    continue
+                await websocket.send_json({"published": name})
+        except (WebSocketDisconnect, RuntimeError):
+            return
+
     routes = [
         Route(f"{API_BASE}/health", health, methods=["GET"]),
         Route(f"{API_BASE}/interfaces", interfaces, methods=["GET"]),
         Route(f"{API_BASE}/inputs/{{name}}", publish_input, methods=["POST"]),
+        WebSocketRoute(f"{API_BASE}/inputs/{{name}}/audio", stream_audio_input),
         Route(f"{API_BASE}/services/{{name}}", call_service, methods=["POST"]),
         Route(f"{API_BASE}/outputs/{{name}}/latest", output_latest, methods=["GET"]),
         WebSocketRoute(f"{API_BASE}/outputs/{{name}}", stream_output),

--- a/ros_sugar/ui_node/api.py
+++ b/ros_sugar/ui_node/api.py
@@ -1,0 +1,115 @@
+"""JSON / WebSocket API for the UI node"""
+
+from typing import Any, Dict
+
+try:
+    from starlette.responses import JSONResponse
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(
+        "In order to serve the recipe API, please install FastHTML "
+        "with `pip install python-fasthtml MonsterUI`"
+    ) from e
+
+from ..io.supported_types import get_ros_msg_fields_dict
+
+from .ui_node import UINode
+
+# All API routes are namespaced under this prefix
+API_BASE = "/api"
+
+# Output message types served as dedicated binary/visual WebSocket streams
+# rather than as JSON data
+_BINARY_STREAM_TYPES = frozenset({"Image", "CompressedImage", "OccupancyGrid", "Audio"})
+
+
+def _topic_schema(topic) -> Dict[str, Any]:
+    """Field schema for a topic's ROS message type (empty dict on failure)."""
+    try:
+        return get_ros_msg_fields_dict(topic.ros_msg_type)
+    except Exception:
+        return {}
+
+
+def build_interfaces(ros_node: UINode) -> Dict[str, Any]:
+    """Build the discovery document describing every declared interface.
+
+    :param ros_node: The running UI node.
+    :return: A JSON-serializable discovery document.
+    """
+    inputs = [
+        {
+            "name": topic.name,
+            "kind": "topic",
+            "msg_type": topic.msg_type.__name__,
+            "schema": _topic_schema(topic),
+            "publish": f"POST {API_BASE}/inputs/{topic.name}",
+        }
+        for topic in (ros_node.out_topics or [])
+    ]
+
+    outputs = []
+    for topic in ros_node.in_topics or []:
+        type_name = topic.msg_type.__name__
+        outputs.append({
+            "name": topic.name,
+            "kind": "topic",
+            "msg_type": type_name,
+            "binary": type_name in _BINARY_STREAM_TYPES,
+            "schema": _topic_schema(topic),
+            "stream": f"WS {API_BASE}/outputs/{topic.name}",
+            "latest": f"GET {API_BASE}/outputs/{topic.name}/latest",
+        })
+
+    services = [
+        {
+            "name": client["name"],
+            "type": client["type"],
+            "request_schema": client["fields"],
+            "call": f"POST {API_BASE}/services/{client['name']}",
+        }
+        for client in ros_node.srv_clients_inputs_dicts()
+    ]
+
+    actions = [
+        {
+            "name": client["name"],
+            "type": client["type"],
+            "goal_schema": client["fields"],
+            "send": f"POST {API_BASE}/actions/{client['name']}",
+            "feedback": f"WS {API_BASE}/actions/{client['name']}/feedback",
+            "cancel": f"POST {API_BASE}/actions/{client['name']}/cancel",
+        }
+        for client in ros_node.action_clients_inputs_dicts()
+    ]
+
+    return {
+        "inputs": inputs,
+        "outputs": outputs,
+        "services": services,
+        "actions": actions,
+        "stream": {
+            "default_rate": ros_node.config.api_stream_default_rate,
+            "max_rate": ros_node.config.api_max_stream_rate,
+        },
+    }
+
+
+def register_api(app, ros_node: UINode) -> None:
+    """Register the JSON / WebSocket API routes on the UI app.
+
+    Called by the UI node executable after the app is built and before uvicorn
+    starts serving.
+
+    :param app: The FastHTML application (a Starlette app).
+    :param ros_node: The running UI node providing the declared interfaces.
+    """
+
+    @app.get(f"{API_BASE}/health")
+    def _api_health():
+        """Liveness probe for the API server."""
+        return JSONResponse({"status": "ok"})
+
+    @app.get(f"{API_BASE}/interfaces")
+    def _api_interfaces():
+        """Discovery document: every declared input/output/service/action."""
+        return JSONResponse(build_interfaces(ros_node))

--- a/ros_sugar/ui_node/api.py
+++ b/ros_sugar/ui_node/api.py
@@ -1,14 +1,19 @@
 """JSON / WebSocket API for the UI node"""
 
+import array
+import base64
 from typing import Any, Dict
 
 try:
+    from starlette.concurrency import run_in_threadpool
     from starlette.responses import JSONResponse
 except ModuleNotFoundError as e:
     raise ModuleNotFoundError(
         "In order to serve the recipe API, please install FastHTML "
         "with `pip install python-fasthtml MonsterUI`"
     ) from e
+
+from rosidl_runtime_py.convert import message_to_ordereddict
 
 from ..io.supported_types import get_ros_msg_fields_dict
 
@@ -26,6 +31,32 @@ def _topic_schema(topic) -> Dict[str, Any]:
     """Field schema for a topic's ROS message type (empty dict on failure)."""
     try:
         return get_ros_msg_fields_dict(topic.ros_msg_type)
+    except Exception:
+        return {}
+
+
+def _coerce(value: Any) -> Any:
+    """Coerce ``bytes``/``array.array`` (from message_to_ordereddict) to JSON-safe values."""
+    if isinstance(value, (bytes, bytearray)):
+        return base64.b64encode(bytes(value)).decode("ascii")
+    if isinstance(value, array.array):
+        return value.tolist()
+    if isinstance(value, dict):
+        return {key: _coerce(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_coerce(item) for item in value]
+    return value
+
+
+def _msg_to_jsonable(msg: Any) -> Any:
+    """JSON-serializable representation of a ROS message (e.g. a service response)."""
+    return _coerce(message_to_ordereddict(msg))
+
+
+async def _json_body(request) -> Any:
+    """Parse a request's JSON body, returning ``{}`` on an empty/invalid body."""
+    try:
+        return await request.json()
     except Exception:
         return {}
 
@@ -104,6 +135,10 @@ def register_api(app, ros_node: UINode) -> None:
     :param ros_node: The running UI node providing the declared interfaces.
     """
 
+    # Declared interface names - Collected once at registration time
+    input_names = {topic.name for topic in (ros_node.out_topics or [])}
+    service_names = {client["name"] for client in ros_node.srv_clients_inputs_dicts()}
+
     @app.get(f"{API_BASE}/health")
     def _api_health():
         """Liveness probe for the API server."""
@@ -113,3 +148,53 @@ def register_api(app, ros_node: UINode) -> None:
     def _api_interfaces():
         """Discovery document: every declared input/output/service/action."""
         return JSONResponse(build_interfaces(ros_node))
+
+    @app.post(f"{API_BASE}/inputs/{{name}}")
+    async def _api_publish_input(name: str, request):
+        """Publish a JSON message (matching the topic schema) to an input topic."""
+        if name not in input_names:
+            return JSONResponse(
+                {"error": f"Unknown input topic '{name}'"}, status_code=404
+            )
+        body = await _json_body(request)
+        if not isinstance(body, dict):
+            return JSONResponse(
+                {"error": "Request body must be a JSON object"}, status_code=400
+            )
+        try:
+            subscribers = ros_node.publish_data({"topic_name": name, **body})
+        except RuntimeError as e:
+            return JSONResponse({"error": str(e)}, status_code=503)
+        except ValueError as e:
+            return JSONResponse({"error": str(e)}, status_code=400)
+        except Exception as e:
+            return JSONResponse({"error": f"Failed to publish: {e}"}, status_code=500)
+        return JSONResponse({"published": name, "subscribers": subscribers})
+
+    @app.post(f"{API_BASE}/services/{{name}}")
+    async def _api_call_service(name: str, request):
+        """Call a service with a JSON request body and return its JSON response."""
+        if name not in service_names:
+            return JSONResponse(
+                {"error": f"Unknown service '{name}'"}, status_code=404
+            )
+        body = await _json_body(request)
+        if not isinstance(body, dict):
+            return JSONResponse(
+                {"error": "Request body must be a JSON object"}, status_code=400
+            )
+        try:
+            # send_srv_call blocks on the ROS future, so offload it off the
+            # event loop to keep uvicorn responsive.
+            response = await run_in_threadpool(
+                ros_node.send_srv_call, {"srv_name": name, **body}
+            )
+        except RuntimeError as e:
+            return JSONResponse({"error": str(e)}, status_code=503)
+        except Exception as e:
+            return JSONResponse({"error": f"Service call failed: {e}"}, status_code=500)
+        if response is None:
+            return JSONResponse(
+                {"error": f"No response from service '{name}'"}, status_code=502
+            )
+        return JSONResponse({"service": name, "response": _msg_to_jsonable(response)})

--- a/ros_sugar/ui_node/api.py
+++ b/ros_sugar/ui_node/api.py
@@ -26,9 +26,6 @@ from .ui_node import UINode
 # All API routes are namespaced under this prefix
 API_BASE = "/api"
 
-# Output types that are rate-sampled by default.
-_SAMPLED_TYPES = frozenset({"Image", "CompressedImage", "OccupancyGrid"})
-
 # Composition of the /api/world map scene: an occupancy grid plus point-like
 # overlays and paths rendered on it
 _GRID_TYPE = "OccupancyGrid"
@@ -230,7 +227,7 @@ def build_interfaces(ros_node: UINode) -> Dict[str, Any]:
             "msg_type": type_name,
             "schema": _topic_schema(topic),
             "stream": f"WS {API_BASE}/outputs/{topic.name}",
-            "mode": "sampled" if type_name in _SAMPLED_TYPES else "push",
+            "mode": "sampled" if topic.msg_type._ui_rate_sampled else "push",
             "latest": f"GET {API_BASE}/outputs/{topic.name}/latest",
         })
 
@@ -391,8 +388,11 @@ def _service_routes(ros_node: UINode) -> List:
 def _output_routes(ros_node: UINode) -> List:
     """Routes for reading and streaming the declared output topics."""
     output_names = {topic.name for topic in (ros_node.in_topics or [])}
-    output_types = {
-        topic.name: topic.msg_type.__name__ for topic in (ros_node.in_topics or [])
+    # Topics whose type declares its stream rate-sampled by default
+    rate_sampled_names = {
+        topic.name
+        for topic in (ros_node.in_topics or [])
+        if topic.msg_type._ui_rate_sampled
     }
 
     async def output_latest(request):
@@ -433,8 +433,8 @@ def _output_routes(ros_node: UINode) -> List:
         except (TypeError, ValueError):
             requested_rate = None
         if requested_rate is None:
-            # No override. Push by default, except for sampled types.
-            push = output_types.get(name) not in _SAMPLED_TYPES
+            # No override. Push by default, except for rate-sampled types.
+            push = name not in rate_sampled_names
         else:
             push = requested_rate == 0  # explicit ?rate=0 forces push
 

--- a/ros_sugar/ui_node/api.py
+++ b/ros_sugar/ui_node/api.py
@@ -77,6 +77,45 @@ async def _json_body(request) -> Any:
         return {}
 
 
+async def _stream_at_rate(websocket, default_rate, max_rate, sample) -> None:
+    """Accept a websocket and push sampled JSON at the client's requested rate.
+
+    Reads an optional ``?rate=<hz>`` query param (clamped to ``max_rate``).
+    ``sample()`` returns ``(payload, done)``: ``payload`` is sent as JSON when
+    not ``None``; the loop stops when ``done`` is True or the client
+    disconnects. The caller must validate the resource before calling this
+    (it accepts the connection).
+    """
+    await websocket.accept()
+    try:
+        rate = float(websocket.query_params.get("rate", default_rate))
+    except (TypeError, ValueError):
+        rate = default_rate
+    if rate <= 0:
+        rate = default_rate
+    period = 1.0 / min(rate, max_rate)
+
+    try:
+        while True:
+            payload, done = sample()
+            if payload is not None:
+                await websocket.send_json(payload)
+            if done:
+                break
+            # Wait one period for a client message: a timeout is the normal
+            # tick (inbound messages are ignored); a disconnect ends the stream.
+            try:
+                await asyncio.wait_for(websocket.receive(), timeout=period)
+            except asyncio.TimeoutError:
+                pass
+    except (WebSocketDisconnect, RuntimeError):
+        return
+    try:
+        await websocket.close()
+    except RuntimeError:
+        pass
+
+
 def build_interfaces(ros_node: UINode) -> Dict[str, Any]:
     """Build the discovery document describing every declared interface.
 
@@ -156,6 +195,7 @@ def build_api_app(ros_node: UINode, browser_app: Optional[Any] = None) -> Starle
     input_names = {topic.name for topic in (ros_node.out_topics or [])}
     service_names = {client["name"] for client in ros_node.srv_clients_inputs_dicts()}
     output_names = {topic.name for topic in (ros_node.in_topics or [])}
+    action_names = {client["name"] for client in ros_node.action_clients_inputs_dicts()}
 
     async def health(request):
         """Liveness probe for the API server."""
@@ -238,41 +278,129 @@ def build_api_app(ros_node: UINode, browser_app: Optional[Any] = None) -> Starle
         if name not in output_names:
             await websocket.close(code=1008)  # policy violation
             return
-        await websocket.accept()
-        try:
-            rate = float(
-                websocket.query_params.get(
-                    "rate", ros_node.config.api_stream_default_rate
-                )
+
+        def sample():
+            content = ros_node.get_latest_output(name)
+            if content is None:
+                return None, False
+            return {"topic": name, "payload": _content_to_jsonable(content)}, False
+
+        await _stream_at_rate(
+            websocket,
+            ros_node.config.api_stream_default_rate,
+            ros_node.config.api_max_stream_rate,
+            sample,
+        )
+
+    async def send_goal(request):
+        """Send a JSON goal to an action; returns 202 once the server accepts it."""
+        name = request.path_params["name"]
+        if name not in action_names:
+            return JSONResponse({"error": f"Unknown action '{name}'"}, status_code=404)
+        body = await _json_body(request)
+        if not isinstance(body, dict):
+            return JSONResponse(
+                {"error": "Request body must be a JSON object"}, status_code=400
             )
-        except (TypeError, ValueError):
-            rate = ros_node.config.api_stream_default_rate
-        if rate <= 0:
-            rate = ros_node.config.api_stream_default_rate
-        period = 1.0 / min(rate, ros_node.config.api_max_stream_rate)
-
-        async def _drain():
-            # receive() raises WebSocketDisconnect when the client goes away.
-            try:
-                while True:
-                    await websocket.receive()
-            except WebSocketDisconnect:
-                pass
-
-        drain = asyncio.ensure_future(_drain())
         try:
-            while not drain.done():
-                content = ros_node.get_latest_output(name)
-                if content is not None:
-                    await websocket.send_json({
-                        "topic": name,
-                        "payload": _content_to_jsonable(content),
-                    })
-                await asyncio.sleep(period)
+            # send_action_goal blocks until the goal is accepted/rejected.
+            accepted = await run_in_threadpool(
+                ros_node.send_action_goal, {"action_name": name, **body}
+            )
+        except RuntimeError as e:
+            return JSONResponse({"error": str(e)}, status_code=503)
+        except Exception as e:
+            return JSONResponse({"error": f"Failed to send goal: {e}"}, status_code=500)
+        if not accepted:
+            return JSONResponse(
+                {"error": f"Action server '{name}' rejected the goal"}, status_code=502
+            )
+        return JSONResponse(
+            {
+                "accepted": True,
+                "action": name,
+                "feedback": f"{API_BASE}/actions/{name}/feedback",
+            },
+            status_code=202,
+        )
+
+    async def cancel_goal(request):
+        """Cancel the ongoing goal of an action."""
+        name = request.path_params["name"]
+        if name not in action_names:
+            return JSONResponse({"error": f"Unknown action '{name}'"}, status_code=404)
+        try:
+            cancelled, message = await run_in_threadpool(ros_node.cancel_action, name)
+        except RuntimeError as e:
+            return JSONResponse({"error": str(e)}, status_code=503)
+        except Exception as e:
+            return JSONResponse({"error": f"Failed to cancel: {e}"}, status_code=500)
+        return JSONResponse({"cancelled": cancelled, "message": message})
+
+    async def stream_action_feedback(websocket):
+        """Push an action's status/feedback as JSON the moment it arrives.
+
+        The stream ends on a terminal state (completed/aborted/canceled) or when
+        the client disconnects.
+        """
+        name = websocket.path_params["name"]
+        if name not in action_names:
+            await websocket.close(code=1008)  # policy violation
+            return
+        await websocket.accept()
+
+        loop = asyncio.get_running_loop()
+        updated = asyncio.Event()
+
+        def _on_update():  # fired in the ROS executor thread by the base client
+            loop.call_soon_threadsafe(updated.set)
+
+        if not ros_node.add_action_feedback_listener(name, _on_update):
+            await websocket.close(code=1011)  # action client not ready
+            return
+
+        def _payload(fb):
+            return {
+                "status": fb["status"],
+                "feedback": _content_to_jsonable(fb["feedback"])
+                if fb.get("feedback") is not None
+                else None,
+                "timestep": fb["timestep"],
+                "duration_secs": fb["duration_secs"],
+            }
+
+        try:
+            terminal = False
+            while not terminal:
+                # Clear before reading so a feedback arriving mid-emit re-wakes us.
+                updated.clear()
+                fb = ros_node.get_action_feedback(name)
+                if fb is not None:
+                    await websocket.send_json(_payload(fb))
+                    terminal = fb["status"] in ("completed", "aborted", "canceled")
+                if terminal:
+                    break
+                # Wait for the next feedback/terminal event or a client disconnect.
+                recv = asyncio.ensure_future(websocket.receive())
+                wake = asyncio.ensure_future(updated.wait())
+                try:
+                    done, _ = await asyncio.wait(
+                        {recv, wake}, return_when=asyncio.FIRST_COMPLETED
+                    )
+                finally:
+                    for task in (recv, wake):
+                        if not task.done():
+                            task.cancel()
+                if recv in done and recv.exception() is not None:
+                    break  # client disconnected
         except (WebSocketDisconnect, RuntimeError):
             pass
         finally:
-            drain.cancel()
+            ros_node.remove_action_feedback_listener(name, _on_update)
+            try:
+                await websocket.close()
+            except RuntimeError:
+                pass
 
     routes = [
         Route(f"{API_BASE}/health", health, methods=["GET"]),
@@ -281,6 +409,9 @@ def build_api_app(ros_node: UINode, browser_app: Optional[Any] = None) -> Starle
         Route(f"{API_BASE}/services/{{name}}", call_service, methods=["POST"]),
         Route(f"{API_BASE}/outputs/{{name}}/latest", output_latest, methods=["GET"]),
         WebSocketRoute(f"{API_BASE}/outputs/{{name}}", stream_output),
+        Route(f"{API_BASE}/actions/{{name}}", send_goal, methods=["POST"]),
+        Route(f"{API_BASE}/actions/{{name}}/cancel", cancel_goal, methods=["POST"]),
+        WebSocketRoute(f"{API_BASE}/actions/{{name}}/feedback", stream_action_feedback),
     ]
     # Mount the browser app last so the specific /api/* routes take precedence
     if browser_app is not None:

--- a/ros_sugar/ui_node/api.py
+++ b/ros_sugar/ui_node/api.py
@@ -30,6 +30,12 @@ API_BASE = "/api"
 # rather than as JSON data
 _BINARY_STREAM_TYPES = frozenset({"Image", "CompressedImage", "OccupancyGrid", "Audio"})
 
+# Composition of the /api/world map scene: an occupancy grid plus point-like
+# overlays and paths rendered on it
+_GRID_TYPE = "OccupancyGrid"
+_PATH_TYPE = "Path"
+_OVERLAY_TYPES = frozenset({"Point", "PointStamped", "Pose", "PoseStamped", "Odometry"})
+
 
 def _topic_schema(topic) -> Dict[str, Any]:
     """Field schema for a topic's ROS message type (empty dict on failure)."""
@@ -69,6 +75,41 @@ def _content_to_jsonable(content: Any) -> Any:
     return _coerce(content)
 
 
+def _marker_from_content(
+    topic_name: str, type_name: str, content: Any
+) -> Optional[Dict]:
+    """Turn an overlay/path payload into a map op.
+
+    Point/Pose/Odometry become ``{op:"overlay", x, y[, theta]}`` markers; Path
+    becomes ``{op:"path", points}``. Returns ``None`` if there is nothing to render.
+    """
+    if not isinstance(content, dict):
+        return None
+    data = content.get("data")
+    if not data:
+        return None
+    frame_id = content.get("frame_id", "")
+    if type_name == _PATH_TYPE:
+        return {"op": "path", "id": topic_name, "frame_id": frame_id, "points": data}
+    if type_name in ("Point", "PointStamped"):
+        return {
+            "op": "overlay",
+            "id": topic_name,
+            "frame_id": frame_id,
+            "x": data[0],
+            "y": data[1],
+        }
+    # Pose / PoseStamped / Odometry -> data is [x, y, z, heading, ...]
+    return {
+        "op": "overlay",
+        "id": topic_name,
+        "frame_id": frame_id,
+        "x": data[0],
+        "y": data[1],
+        "theta": data[3],
+    }
+
+
 async def _json_body(request) -> Any:
     """Parse a request's JSON body, returning ``{}`` on an empty/invalid body."""
     try:
@@ -102,8 +143,9 @@ async def _stream_at_rate(websocket, default_rate, max_rate, sample) -> None:
                 await websocket.send_json(payload)
             if done:
                 break
-            # Wait one period for a client message: a timeout is the normal
-            # tick (inbound messages are ignored); a disconnect ends the stream.
+            # NOTE: Wait one period for a client message. A timeout is the
+            # normal tick (inbound messages are ignored). Disconnect ends
+            # the stream.
             try:
                 await asyncio.wait_for(websocket.receive(), timeout=period)
             except asyncio.TimeoutError:
@@ -168,11 +210,30 @@ def build_interfaces(ros_node: UINode) -> Dict[str, Any]:
         for client in ros_node.action_clients_inputs_dicts()
     ]
 
+    # A "world" composes an occupancy grid with the overlay/path outputs drawn
+    # on it, streamed together over one socket.
+    overlay_outputs = [
+        {"name": t.name, "msg_type": t.msg_type.__name__}
+        for t in (ros_node.in_topics or [])
+        if t.msg_type.__name__ in _OVERLAY_TYPES or t.msg_type.__name__ == _PATH_TYPE
+    ]
+    worlds = [
+        {
+            "name": topic.name,
+            "grid": topic.name,
+            "overlays": overlay_outputs,
+            "stream": f"WS {API_BASE}/world/{topic.name}",
+        }
+        for topic in (ros_node.in_topics or [])
+        if topic.msg_type.__name__ == _GRID_TYPE
+    ]
+
     return {
         "inputs": inputs,
         "outputs": outputs,
         "services": services,
         "actions": actions,
+        "worlds": worlds,
         "stream": {
             "default_rate": ros_node.config.api_stream_default_rate,
             "max_rate": ros_node.config.api_max_stream_rate,
@@ -196,6 +257,15 @@ def build_api_app(ros_node: UINode, browser_app: Optional[Any] = None) -> Starle
     service_names = {client["name"] for client in ros_node.srv_clients_inputs_dicts()}
     output_names = {topic.name for topic in (ros_node.in_topics or [])}
     action_names = {client["name"] for client in ros_node.action_clients_inputs_dicts()}
+    grid_names = {
+        t.name for t in (ros_node.in_topics or []) if t.msg_type.__name__ == _GRID_TYPE
+    }
+    # Overlay/path output topics composed onto every world map
+    marker_topics = [
+        (t.name, t.msg_type.__name__)
+        for t in (ros_node.in_topics or [])
+        if t.msg_type.__name__ in _OVERLAY_TYPES or t.msg_type.__name__ == _PATH_TYPE
+    ]
 
     async def health(request):
         """Liveness probe for the API server."""
@@ -402,6 +472,65 @@ def build_api_app(ros_node: UINode, browser_app: Optional[Any] = None) -> Starle
             except RuntimeError:
                 pass
 
+    async def stream_world(websocket):
+        """Stream a composable map scene over one socket. The occupancy grid
+        plus the overlay/path outputs drawn on it (emitted on change).
+        The ``?rate`` query param caps the grid rate. Markers are checked at
+        the max rate so they stay responsive.
+        """
+        name = websocket.path_params["name"]
+        if name not in grid_names:
+            await websocket.close(code=1008)  # not an occupancy-grid output
+            return
+        await websocket.accept()
+
+        loop = asyncio.get_running_loop()
+        default_rate = ros_node.config.api_stream_default_rate
+        max_rate = ros_node.config.api_max_stream_rate
+        try:
+            grid_rate = float(websocket.query_params.get("rate", default_rate))
+        except (TypeError, ValueError):
+            grid_rate = default_rate
+        if grid_rate <= 0:
+            grid_rate = default_rate
+        grid_period = 1.0 / min(grid_rate, max_rate)  # checked at default rate
+        tick_period = 1.0 / max_rate  # markers checked at the fast tick
+
+        last_grid = None
+        last_grid_emit = loop.time() - grid_period  # emit the grid on connect
+        last_marker: Dict[str, Any] = {}
+
+        try:
+            while True:
+                now = loop.time()
+                # Grid
+                grid = ros_node.get_latest_output(name)
+                if (
+                    grid is not None
+                    and grid is not last_grid
+                    and (now - last_grid_emit) >= grid_period
+                ):
+                    await websocket.send_json({"op": "publish", "msg": grid})
+                    last_grid = grid
+                    last_grid_emit = now
+                # Overlays/paths. Emit each one only when its value changes.
+                for marker_name, marker_type in marker_topics:
+                    content = ros_node.get_latest_output(marker_name)
+                    if content is None or content is last_marker.get(marker_name):
+                        continue
+                    last_marker[marker_name] = content
+                    marker = _marker_from_content(marker_name, marker_type, content)
+                    if marker is not None:
+                        await websocket.send_json(marker)
+                # NOTE: Wait one tick for a client message. A timeout is the
+                # normal tick; a disconnect ends the stream.
+                try:
+                    await asyncio.wait_for(websocket.receive(), timeout=tick_period)
+                except asyncio.TimeoutError:
+                    pass
+        except (WebSocketDisconnect, RuntimeError):
+            return
+
     routes = [
         Route(f"{API_BASE}/health", health, methods=["GET"]),
         Route(f"{API_BASE}/interfaces", interfaces, methods=["GET"]),
@@ -412,6 +541,7 @@ def build_api_app(ros_node: UINode, browser_app: Optional[Any] = None) -> Starle
         Route(f"{API_BASE}/actions/{{name}}", send_goal, methods=["POST"]),
         Route(f"{API_BASE}/actions/{{name}}/cancel", cancel_goal, methods=["POST"]),
         WebSocketRoute(f"{API_BASE}/actions/{{name}}/feedback", stream_action_feedback),
+        WebSocketRoute(f"{API_BASE}/world/{{name}}", stream_world),
     ]
     # Mount the browser app last so the specific /api/* routes take precedence
     if browser_app is not None:

--- a/ros_sugar/ui_node/api.py
+++ b/ros_sugar/ui_node/api.py
@@ -374,6 +374,8 @@ def _service_routes(ros_node: UINode) -> List:
             )
         except RuntimeError as e:
             return JSONResponse({"error": str(e)}, status_code=503)
+        except ValueError as e:
+            return JSONResponse({"error": str(e)}, status_code=400)
         except Exception as e:
             return JSONResponse({"error": f"Service call failed: {e}"}, status_code=500)
         if response is None:
@@ -481,6 +483,8 @@ def _action_routes(ros_node: UINode) -> List:
             )
         except RuntimeError as e:
             return JSONResponse({"error": str(e)}, status_code=503)
+        except ValueError as e:
+            return JSONResponse({"error": str(e)}, status_code=400)
         except Exception as e:
             return JSONResponse({"error": f"Failed to send goal: {e}"}, status_code=500)
         if not accepted:

--- a/ros_sugar/ui_node/api.py
+++ b/ros_sugar/ui_node/api.py
@@ -106,6 +106,13 @@ def _marker_from_content(
     }
 
 
+def _name_param(conn) -> str:
+    """Interface name from the URL path, normalized like ``Topic`` names.
+    Routes use ``{name:path}`` so namespaced names (ns/topic) stay
+    addressable."""
+    return conn.path_params["name"].lstrip("/")
+
+
 async def _json_body(request) -> Any:
     """Parse a request's JSON body, returning ``{}`` on an empty/invalid body."""
     try:
@@ -294,7 +301,7 @@ def _input_routes(ros_node: UINode) -> List:
 
     async def publish_input(request):
         """Publish a JSON message (matching the topic schema) to an input topic."""
-        name = request.path_params["name"]
+        name = _name_param(request)
         if name not in input_names:
             return JSONResponse(
                 {"error": f"Unknown input topic '{name}'"}, status_code=404
@@ -317,7 +324,7 @@ def _input_routes(ros_node: UINode) -> List:
     async def stream_audio_input(websocket):
         """Receive base64 audio frames from the client and publish them to a
         declared Audio input topic. Acks each frame"""
-        name = websocket.path_params["name"]
+        name = _name_param(websocket)
         if name not in audio_input_names:
             await websocket.close(code=1008)  # not a declared Audio input
             return
@@ -347,8 +354,8 @@ def _input_routes(ros_node: UINode) -> List:
             return
 
     return [
-        Route(f"{API_BASE}/inputs/{{name}}", publish_input, methods=["POST"]),
-        WebSocketRoute(f"{API_BASE}/inputs/{{name}}/audio", stream_audio_input),
+        Route(f"{API_BASE}/inputs/{{name:path}}", publish_input, methods=["POST"]),
+        WebSocketRoute(f"{API_BASE}/inputs/{{name:path}}/audio", stream_audio_input),
     ]
 
 
@@ -358,7 +365,7 @@ def _service_routes(ros_node: UINode) -> List:
 
     async def call_service(request):
         """Call a service with a JSON request body and return its JSON response."""
-        name = request.path_params["name"]
+        name = _name_param(request)
         if name not in service_names:
             return JSONResponse({"error": f"Unknown service '{name}'"}, status_code=404)
         body = await _json_body(request)
@@ -384,7 +391,7 @@ def _service_routes(ros_node: UINode) -> List:
             )
         return JSONResponse({"service": name, "response": _msg_to_jsonable(response)})
 
-    return [Route(f"{API_BASE}/services/{{name}}", call_service, methods=["POST"])]
+    return [Route(f"{API_BASE}/services/{{name:path}}", call_service, methods=["POST"])]
 
 
 def _output_routes(ros_node: UINode) -> List:
@@ -399,7 +406,7 @@ def _output_routes(ros_node: UINode) -> List:
 
     async def output_latest(request):
         """Return the most recent value of an output topic as JSON."""
-        name = request.path_params["name"]
+        name = _name_param(request)
         if name not in output_names:
             return JSONResponse(
                 {"error": f"Unknown output topic '{name}'"}, status_code=404
@@ -419,7 +426,7 @@ def _output_routes(ros_node: UINode) -> List:
         rate (clamped to the max), ``?rate=0`` forces push. Multiple clients can
         stream the same topic independently.
         """
-        name = websocket.path_params["name"]
+        name = _name_param(websocket)
         if name not in output_names:
             await websocket.close(code=1008)  # policy violation
             return
@@ -457,8 +464,10 @@ def _output_routes(ros_node: UINode) -> List:
             )
 
     return [
-        Route(f"{API_BASE}/outputs/{{name}}/latest", output_latest, methods=["GET"]),
-        WebSocketRoute(f"{API_BASE}/outputs/{{name}}", stream_output),
+        Route(
+            f"{API_BASE}/outputs/{{name:path}}/latest", output_latest, methods=["GET"]
+        ),
+        WebSocketRoute(f"{API_BASE}/outputs/{{name:path}}", stream_output),
     ]
 
 
@@ -468,7 +477,7 @@ def _action_routes(ros_node: UINode) -> List:
 
     async def send_goal(request):
         """Send a JSON goal to an action; returns 202 once the server accepts it."""
-        name = request.path_params["name"]
+        name = _name_param(request)
         if name not in action_names:
             return JSONResponse({"error": f"Unknown action '{name}'"}, status_code=404)
         body = await _json_body(request)
@@ -502,7 +511,7 @@ def _action_routes(ros_node: UINode) -> List:
 
     async def cancel_goal(request):
         """Cancel the ongoing goal of an action."""
-        name = request.path_params["name"]
+        name = _name_param(request)
         if name not in action_names:
             return JSONResponse({"error": f"Unknown action '{name}'"}, status_code=404)
         try:
@@ -519,7 +528,7 @@ def _action_routes(ros_node: UINode) -> List:
         The stream ends on a terminal state (completed/aborted/canceled) or when
         the client disconnects.
         """
-        name = websocket.path_params["name"]
+        name = _name_param(websocket)
         if name not in action_names:
             await websocket.close(code=1008)  # policy violation
             return
@@ -546,9 +555,15 @@ def _action_routes(ros_node: UINode) -> List:
         )
 
     return [
-        Route(f"{API_BASE}/actions/{{name}}", send_goal, methods=["POST"]),
-        Route(f"{API_BASE}/actions/{{name}}/cancel", cancel_goal, methods=["POST"]),
-        WebSocketRoute(f"{API_BASE}/actions/{{name}}/feedback", stream_action_feedback),
+        # NOTE: /cancel must be registered before the goal route. The greedy
+        # {name:path} goal pattern would otherwise swallow ".../cancel" URLs.
+        Route(
+            f"{API_BASE}/actions/{{name:path}}/cancel", cancel_goal, methods=["POST"]
+        ),
+        Route(f"{API_BASE}/actions/{{name:path}}", send_goal, methods=["POST"]),
+        WebSocketRoute(
+            f"{API_BASE}/actions/{{name:path}}/feedback", stream_action_feedback
+        ),
     ]
 
 
@@ -570,7 +585,7 @@ def _world_routes(ros_node: UINode) -> List:
         The ``?rate`` query param caps the grid rate. Markers are checked at
         the max rate so they stay responsive.
         """
-        name = websocket.path_params["name"]
+        name = _name_param(websocket)
         if name not in grid_names:
             await websocket.close(code=1008)  # not an occupancy-grid output
             return
@@ -623,7 +638,7 @@ def _world_routes(ros_node: UINode) -> List:
         except (WebSocketDisconnect, RuntimeError):
             return
 
-    return [WebSocketRoute(f"{API_BASE}/world/{{name}}", stream_world)]
+    return [WebSocketRoute(f"{API_BASE}/world/{{name:path}}", stream_world)]
 
 
 def build_api_app(ros_node: UINode, browser_app: Optional[Any] = None) -> Starlette:

--- a/ros_sugar/ui_node/api.py
+++ b/ros_sugar/ui_node/api.py
@@ -3,7 +3,7 @@
 import array
 import asyncio
 import base64
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 try:
     from starlette.applications import Starlette
@@ -26,9 +26,8 @@ from .ui_node import UINode
 # All API routes are namespaced under this prefix
 API_BASE = "/api"
 
-# Output message types served as dedicated binary/visual WebSocket streams
-# rather than as JSON data
-_BINARY_STREAM_TYPES = frozenset({"Image", "CompressedImage", "OccupancyGrid", "Audio"})
+# Output types that are rate-sampled by default.
+_SAMPLED_TYPES = frozenset({"Image", "CompressedImage", "OccupancyGrid"})
 
 # Composition of the /api/world map scene: an occupancy grid plus point-like
 # overlays and paths rendered on it
@@ -158,6 +157,50 @@ async def _stream_at_rate(websocket, default_rate, max_rate, sample) -> None:
         pass
 
 
+async def _stream_pushed(websocket, subscribe, unsubscribe, sample) -> None:
+    """Accept a websocket and push JSON the moment new data arrives (no sampling)"""
+    await websocket.accept()
+    loop = asyncio.get_running_loop()
+    updated = asyncio.Event()
+
+    def _on_update():  # fired in the ROS executor thread
+        loop.call_soon_threadsafe(updated.set)
+
+    if not subscribe(_on_update):
+        await websocket.close(code=1011)  # resource not ready
+        return
+    try:
+        while True:
+            # Clear before reading so a message arriving mid-emit re-wakes
+            updated.clear()
+            payload, done = sample()
+            if payload is not None:
+                await websocket.send_json(payload)
+            if done:
+                break
+            # Wait for the next message event or a client disconnect.
+            recv = asyncio.ensure_future(websocket.receive())
+            wake = asyncio.ensure_future(updated.wait())
+            try:
+                finished, _ = await asyncio.wait(
+                    {recv, wake}, return_when=asyncio.FIRST_COMPLETED
+                )
+            finally:
+                for task in (recv, wake):
+                    if not task.done():
+                        task.cancel()
+            if recv in finished and recv.exception() is not None:
+                break  # client disconnected
+    except (WebSocketDisconnect, RuntimeError):
+        pass
+    finally:
+        unsubscribe(_on_update)
+        try:
+            await websocket.close()
+        except RuntimeError:
+            pass
+
+
 def build_interfaces(ros_node: UINode) -> Dict[str, Any]:
     """Build the discovery document describing every declared interface.
 
@@ -185,9 +228,9 @@ def build_interfaces(ros_node: UINode) -> Dict[str, Any]:
             "name": topic.name,
             "kind": "topic",
             "msg_type": type_name,
-            "binary": type_name in _BINARY_STREAM_TYPES,
             "schema": _topic_schema(topic),
             "stream": f"WS {API_BASE}/outputs/{topic.name}",
+            "mode": "sampled" if type_name in _SAMPLED_TYPES else "push",
             "latest": f"GET {API_BASE}/outputs/{topic.name}/latest",
         })
 
@@ -244,43 +287,13 @@ def build_interfaces(ros_node: UINode) -> Dict[str, Any]:
     }
 
 
-def build_api_app(ros_node: UINode, browser_app: Optional[Any] = None) -> Starlette:
-    """Build the application exposing the JSON / WS API.
-
-    If ``browser_app`` is given, it is mounted under ``/`` as the last route,
-    Omit it to run the API headless.
-
-    :param ros_node: The running UI node providing the declared interfaces.
-    :param browser_app: Optional FastHTML browser app to mount at ``/``.
-    :return: The Starlette API application.
-    """
-
-    # Declared interface names, collected once.
+def _input_routes(ros_node: UINode) -> List:
+    """Routes for publishing to the declared input topics."""
     input_names = {topic.name for topic in (ros_node.out_topics or [])}
-    service_names = {client["name"] for client in ros_node.srv_clients_inputs_dicts()}
-    output_names = {topic.name for topic in (ros_node.in_topics or [])}
-    action_names = {client["name"] for client in ros_node.action_clients_inputs_dicts()}
-    grid_names = {
-        t.name for t in (ros_node.in_topics or []) if t.msg_type.__name__ == _GRID_TYPE
-    }
-    # Overlay/path output topics composed onto every world map
-    marker_topics = [
-        (t.name, t.msg_type.__name__)
-        for t in (ros_node.in_topics or [])
-        if t.msg_type.__name__ in _OVERLAY_TYPES or t.msg_type.__name__ == _PATH_TYPE
-    ]
     # Declared Audio input topics, which accept uploads over a dedicated WS.
     audio_input_names = {
         t.name for t in (ros_node.out_topics or []) if t.msg_type.__name__ == "Audio"
     }
-
-    async def health(request):
-        """Liveness probe for the API server."""
-        return JSONResponse({"status": "ok"})
-
-    async def interfaces(request):
-        """Discovery document: every declared input/output/service/action."""
-        return JSONResponse(build_interfaces(ros_node))
 
     async def publish_input(request):
         """Publish a JSON message (matching the topic schema) to an input topic."""
@@ -303,6 +316,48 @@ def build_api_app(ros_node: UINode, browser_app: Optional[Any] = None) -> Starle
         except Exception as e:
             return JSONResponse({"error": f"Failed to publish: {e}"}, status_code=500)
         return JSONResponse({"published": name, "subscribers": subscribers})
+
+    async def stream_audio_input(websocket):
+        """Receive base64 audio frames from the client and publish them to a
+        declared Audio input topic. Acks each frame"""
+        name = websocket.path_params["name"]
+        if name not in audio_input_names:
+            await websocket.close(code=1008)  # not a declared Audio input
+            return
+        await websocket.accept()
+        try:
+            while True:
+                data = await websocket.receive_json()
+                audio_b64 = (
+                    data.get("payload") or data.get("data")
+                    if isinstance(data, dict)
+                    else None
+                )
+                if not audio_b64:
+                    continue
+                try:
+                    ros_node.publish_audio(name, audio_b64)
+                except RuntimeError as e:
+                    await websocket.send_json({"error": str(e)})
+                    continue
+                except Exception as e:
+                    await websocket.send_json({
+                        "error": f"Failed to publish audio: {e}"
+                    })
+                    continue
+                await websocket.send_json({"published": name})
+        except (WebSocketDisconnect, RuntimeError):
+            return
+
+    return [
+        Route(f"{API_BASE}/inputs/{{name}}", publish_input, methods=["POST"]),
+        WebSocketRoute(f"{API_BASE}/inputs/{{name}}/audio", stream_audio_input),
+    ]
+
+
+def _service_routes(ros_node: UINode) -> List:
+    """Route for calling the declared service clients."""
+    service_names = {client["name"] for client in ros_node.srv_clients_inputs_dicts()}
 
     async def call_service(request):
         """Call a service with a JSON request body and return its JSON response."""
@@ -330,6 +385,16 @@ def build_api_app(ros_node: UINode, browser_app: Optional[Any] = None) -> Starle
             )
         return JSONResponse({"service": name, "response": _msg_to_jsonable(response)})
 
+    return [Route(f"{API_BASE}/services/{{name}}", call_service, methods=["POST"])]
+
+
+def _output_routes(ros_node: UINode) -> List:
+    """Routes for reading and streaming the declared output topics."""
+    output_names = {topic.name for topic in (ros_node.in_topics or [])}
+    output_types = {
+        topic.name: topic.msg_type.__name__ for topic in (ros_node.in_topics or [])
+    }
+
     async def output_latest(request):
         """Return the most recent value of an output topic as JSON."""
         name = request.path_params["name"]
@@ -345,11 +410,12 @@ def build_api_app(ros_node: UINode, browser_app: Optional[Any] = None) -> Starle
         return JSONResponse({"topic": name, "payload": _content_to_jsonable(content)})
 
     async def stream_output(websocket):
-        """Stream an output topic as JSON, sampling the latest value at a rate.
+        """Stream an output topic as JSON.
 
-        The client may request a rate via ``?rate=<hz>`` (clamped to the
-        configured maximum); multiple clients can stream the same topic
-        independently because each samples the shared latest-value cache.
+        The default transport is chosen by message type. A client overrides
+        per connection with ``?rate``: ``?rate=<hz>`` forces sampling at that
+        rate (clamped to the max), ``?rate=0`` forces push. Multiple clients can
+        stream the same topic independently.
         """
         name = websocket.path_params["name"]
         if name not in output_names:
@@ -362,12 +428,41 @@ def build_api_app(ros_node: UINode, browser_app: Optional[Any] = None) -> Starle
                 return None, False
             return {"topic": name, "payload": _content_to_jsonable(content)}, False
 
-        await _stream_at_rate(
-            websocket,
-            ros_node.config.api_stream_default_rate,
-            ros_node.config.api_max_stream_rate,
-            sample,
-        )
+        try:
+            requested_rate = float(websocket.query_params.get("rate", ""))
+        except (TypeError, ValueError):
+            requested_rate = None
+        if requested_rate is None:
+            # No override. Push by default, except for sampled types.
+            push = output_types.get(name) not in _SAMPLED_TYPES
+        else:
+            push = requested_rate == 0  # explicit ?rate=0 forces push
+
+        if push:
+            # Lossless event push
+            await _stream_pushed(
+                websocket,
+                lambda cb: ros_node.add_output_listener(name, cb),
+                lambda cb: ros_node.remove_output_listener(name, cb),
+                sample,
+            )
+        else:
+            await _stream_at_rate(
+                websocket,
+                ros_node.config.api_stream_default_rate,
+                ros_node.config.api_max_stream_rate,
+                sample,
+            )
+
+    return [
+        Route(f"{API_BASE}/outputs/{{name}}/latest", output_latest, methods=["GET"]),
+        WebSocketRoute(f"{API_BASE}/outputs/{{name}}", stream_output),
+    ]
+
+
+def _action_routes(ros_node: UINode) -> List:
+    """Routes for sending, canceling and following the declared actions."""
+    action_names = {client["name"] for client in ros_node.action_clients_inputs_dicts()}
 
     async def send_goal(request):
         """Send a JSON goal to an action; returns 202 once the server accepts it."""
@@ -424,20 +519,12 @@ def build_api_app(ros_node: UINode, browser_app: Optional[Any] = None) -> Starle
         if name not in action_names:
             await websocket.close(code=1008)  # policy violation
             return
-        await websocket.accept()
 
-        loop = asyncio.get_running_loop()
-        updated = asyncio.Event()
-
-        def _on_update():  # fired in the ROS executor thread by the base client
-            loop.call_soon_threadsafe(updated.set)
-
-        if not ros_node.add_action_feedback_listener(name, _on_update):
-            await websocket.close(code=1011)  # action client not ready
-            return
-
-        def _payload(fb):
-            return {
+        def sample():
+            fb = ros_node.get_action_feedback(name)
+            if fb is None:
+                return None, False
+            payload = {
                 "status": fb["status"],
                 "feedback": _content_to_jsonable(fb["feedback"])
                 if fb.get("feedback") is not None
@@ -445,39 +532,33 @@ def build_api_app(ros_node: UINode, browser_app: Optional[Any] = None) -> Starle
                 "timestep": fb["timestep"],
                 "duration_secs": fb["duration_secs"],
             }
+            return payload, fb["status"] in ("completed", "aborted", "canceled")
 
-        try:
-            terminal = False
-            while not terminal:
-                # Clear before reading so a feedback arriving mid-emit re-wakes us.
-                updated.clear()
-                fb = ros_node.get_action_feedback(name)
-                if fb is not None:
-                    await websocket.send_json(_payload(fb))
-                    terminal = fb["status"] in ("completed", "aborted", "canceled")
-                if terminal:
-                    break
-                # Wait for the next feedback/terminal event or a client disconnect.
-                recv = asyncio.ensure_future(websocket.receive())
-                wake = asyncio.ensure_future(updated.wait())
-                try:
-                    done, _ = await asyncio.wait(
-                        {recv, wake}, return_when=asyncio.FIRST_COMPLETED
-                    )
-                finally:
-                    for task in (recv, wake):
-                        if not task.done():
-                            task.cancel()
-                if recv in done and recv.exception() is not None:
-                    break  # client disconnected
-        except (WebSocketDisconnect, RuntimeError):
-            pass
-        finally:
-            ros_node.remove_action_feedback_listener(name, _on_update)
-            try:
-                await websocket.close()
-            except RuntimeError:
-                pass
+        await _stream_pushed(
+            websocket,
+            lambda cb: ros_node.add_action_feedback_listener(name, cb),
+            lambda cb: ros_node.remove_action_feedback_listener(name, cb),
+            sample,
+        )
+
+    return [
+        Route(f"{API_BASE}/actions/{{name}}", send_goal, methods=["POST"]),
+        Route(f"{API_BASE}/actions/{{name}}/cancel", cancel_goal, methods=["POST"]),
+        WebSocketRoute(f"{API_BASE}/actions/{{name}}/feedback", stream_action_feedback),
+    ]
+
+
+def _world_routes(ros_node: UINode) -> List:
+    """Route streaming the composable map scene(s): grid + overlay/path markers."""
+    grid_names = {
+        t.name for t in (ros_node.in_topics or []) if t.msg_type.__name__ == _GRID_TYPE
+    }
+    # Overlay/path output topics composed onto every world map
+    marker_topics = [
+        (t.name, t.msg_type.__name__)
+        for t in (ros_node.in_topics or [])
+        if t.msg_type.__name__ in _OVERLAY_TYPES or t.msg_type.__name__ == _PATH_TYPE
+    ]
 
     async def stream_world(websocket):
         """Stream a composable map scene over one socket. The occupancy grid
@@ -538,51 +619,36 @@ def build_api_app(ros_node: UINode, browser_app: Optional[Any] = None) -> Starle
         except (WebSocketDisconnect, RuntimeError):
             return
 
-    async def stream_audio_input(websocket):
-        """Receive base64 audio frames from the client and publish them to a
-        declared Audio input topic (client -> server). Acks each frame.
-        """
-        name = websocket.path_params["name"]
-        if name not in audio_input_names:
-            await websocket.close(code=1008)  # not a declared Audio input
-            return
-        await websocket.accept()
-        try:
-            while True:
-                data = await websocket.receive_json()
-                audio_b64 = (
-                    data.get("payload") or data.get("data")
-                    if isinstance(data, dict)
-                    else None
-                )
-                if not audio_b64:
-                    continue
-                try:
-                    ros_node.publish_audio(name, audio_b64)
-                except RuntimeError as e:
-                    await websocket.send_json({"error": str(e)})
-                    continue
-                except Exception as e:
-                    await websocket.send_json({
-                        "error": f"Failed to publish audio: {e}"
-                    })
-                    continue
-                await websocket.send_json({"published": name})
-        except (WebSocketDisconnect, RuntimeError):
-            return
+    return [WebSocketRoute(f"{API_BASE}/world/{{name}}", stream_world)]
+
+
+def build_api_app(ros_node: UINode, browser_app: Optional[Any] = None) -> Starlette:
+    """Build the application exposing the JSON / WS API.
+
+    If ``browser_app`` is given, it is mounted under ``/`` as the last route,
+    Omit it to run the API headless.
+
+    :param ros_node: The running UI node providing the declared interfaces.
+    :param browser_app: Optional FastHTML browser app to mount at ``/``.
+    :return: The Starlette API application.
+    """
+
+    async def health(request):
+        """Liveness probe for the API server."""
+        return JSONResponse({"status": "ok"})
+
+    async def interfaces(request):
+        """Discovery document: every declared input/output/service/action."""
+        return JSONResponse(build_interfaces(ros_node))
 
     routes = [
         Route(f"{API_BASE}/health", health, methods=["GET"]),
         Route(f"{API_BASE}/interfaces", interfaces, methods=["GET"]),
-        Route(f"{API_BASE}/inputs/{{name}}", publish_input, methods=["POST"]),
-        WebSocketRoute(f"{API_BASE}/inputs/{{name}}/audio", stream_audio_input),
-        Route(f"{API_BASE}/services/{{name}}", call_service, methods=["POST"]),
-        Route(f"{API_BASE}/outputs/{{name}}/latest", output_latest, methods=["GET"]),
-        WebSocketRoute(f"{API_BASE}/outputs/{{name}}", stream_output),
-        Route(f"{API_BASE}/actions/{{name}}", send_goal, methods=["POST"]),
-        Route(f"{API_BASE}/actions/{{name}}/cancel", cancel_goal, methods=["POST"]),
-        WebSocketRoute(f"{API_BASE}/actions/{{name}}/feedback", stream_action_feedback),
-        WebSocketRoute(f"{API_BASE}/world/{{name}}", stream_world),
+        *_input_routes(ros_node),
+        *_service_routes(ros_node),
+        *_output_routes(ros_node),
+        *_action_routes(ros_node),
+        *_world_routes(ros_node),
     ]
     # Mount the browser app last so the specific /api/* routes take precedence
     if browser_app is not None:

--- a/ros_sugar/ui_node/api.py
+++ b/ros_sugar/ui_node/api.py
@@ -1,16 +1,20 @@
 """JSON / WebSocket API for the UI node"""
 
 import array
+import asyncio
 import base64
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 try:
+    from starlette.applications import Starlette
     from starlette.concurrency import run_in_threadpool
     from starlette.responses import JSONResponse
+    from starlette.routing import Mount, Route, WebSocketRoute
+    from starlette.websockets import WebSocketDisconnect
 except ModuleNotFoundError as e:
     raise ModuleNotFoundError(
-        "In order to serve the recipe API, please install FastHTML "
-        "with `pip install python-fasthtml MonsterUI`"
+        "In order to serve the recipe API, please install Starlette and uvicorn "
+        "with `pip install starlette uvicorn`"
     ) from e
 
 from rosidl_runtime_py.convert import message_to_ordereddict
@@ -51,6 +55,18 @@ def _coerce(value: Any) -> Any:
 def _msg_to_jsonable(msg: Any) -> Any:
     """JSON-serializable representation of a ROS message (e.g. a service response)."""
     return _coerce(message_to_ordereddict(msg))
+
+
+def _content_to_jsonable(content: Any) -> Any:
+    """JSON-serialize cached output content.
+
+    Specialized callbacks already return JSON-native content; types without a
+    specialized ``_get_ui_content`` yield a raw ROS message, which is
+    converted here.
+    """
+    if hasattr(content, "get_fields_and_field_types"):
+        return _msg_to_jsonable(content)
+    return _coerce(content)
 
 
 async def _json_body(request) -> Any:
@@ -125,33 +141,33 @@ def build_interfaces(ros_node: UINode) -> Dict[str, Any]:
     }
 
 
-def register_api(app, ros_node: UINode) -> None:
-    """Register the JSON / WebSocket API routes on the UI app.
+def build_api_app(ros_node: UINode, browser_app: Optional[Any] = None) -> Starlette:
+    """Build the application exposing the JSON / WS API.
 
-    Called by the UI node executable after the app is built and before uvicorn
-    starts serving.
+    If ``browser_app`` is given, it is mounted under ``/`` as the last route,
+    Omit it to run the API headless.
 
-    :param app: The FastHTML application (a Starlette app).
     :param ros_node: The running UI node providing the declared interfaces.
+    :param browser_app: Optional FastHTML browser app to mount at ``/``.
+    :return: The Starlette API application.
     """
 
-    # Declared interface names - Collected once at registration time
+    # Declared interface names, collected once.
     input_names = {topic.name for topic in (ros_node.out_topics or [])}
     service_names = {client["name"] for client in ros_node.srv_clients_inputs_dicts()}
+    output_names = {topic.name for topic in (ros_node.in_topics or [])}
 
-    @app.get(f"{API_BASE}/health")
-    def _api_health():
+    async def health(request):
         """Liveness probe for the API server."""
         return JSONResponse({"status": "ok"})
 
-    @app.get(f"{API_BASE}/interfaces")
-    def _api_interfaces():
+    async def interfaces(request):
         """Discovery document: every declared input/output/service/action."""
         return JSONResponse(build_interfaces(ros_node))
 
-    @app.post(f"{API_BASE}/inputs/{{name}}")
-    async def _api_publish_input(name: str, request):
+    async def publish_input(request):
         """Publish a JSON message (matching the topic schema) to an input topic."""
+        name = request.path_params["name"]
         if name not in input_names:
             return JSONResponse(
                 {"error": f"Unknown input topic '{name}'"}, status_code=404
@@ -171,21 +187,19 @@ def register_api(app, ros_node: UINode) -> None:
             return JSONResponse({"error": f"Failed to publish: {e}"}, status_code=500)
         return JSONResponse({"published": name, "subscribers": subscribers})
 
-    @app.post(f"{API_BASE}/services/{{name}}")
-    async def _api_call_service(name: str, request):
+    async def call_service(request):
         """Call a service with a JSON request body and return its JSON response."""
+        name = request.path_params["name"]
         if name not in service_names:
-            return JSONResponse(
-                {"error": f"Unknown service '{name}'"}, status_code=404
-            )
+            return JSONResponse({"error": f"Unknown service '{name}'"}, status_code=404)
         body = await _json_body(request)
         if not isinstance(body, dict):
             return JSONResponse(
                 {"error": "Request body must be a JSON object"}, status_code=400
             )
         try:
-            # send_srv_call blocks on the ROS future, so offload it off the
-            # event loop to keep uvicorn responsive.
+            # send_srv_call blocks on the ROS future, so offload it off the event
+            # loop to keep the server responsive.
             response = await run_in_threadpool(
                 ros_node.send_srv_call, {"srv_name": name, **body}
             )
@@ -198,3 +212,78 @@ def register_api(app, ros_node: UINode) -> None:
                 {"error": f"No response from service '{name}'"}, status_code=502
             )
         return JSONResponse({"service": name, "response": _msg_to_jsonable(response)})
+
+    async def output_latest(request):
+        """Return the most recent value of an output topic as JSON."""
+        name = request.path_params["name"]
+        if name not in output_names:
+            return JSONResponse(
+                {"error": f"Unknown output topic '{name}'"}, status_code=404
+            )
+        content = ros_node.get_latest_output(name)
+        if content is None:
+            return JSONResponse(
+                {"error": f"No data received yet for '{name}'"}, status_code=404
+            )
+        return JSONResponse({"topic": name, "payload": _content_to_jsonable(content)})
+
+    async def stream_output(websocket):
+        """Stream an output topic as JSON, sampling the latest value at a rate.
+
+        The client may request a rate via ``?rate=<hz>`` (clamped to the
+        configured maximum); multiple clients can stream the same topic
+        independently because each samples the shared latest-value cache.
+        """
+        name = websocket.path_params["name"]
+        if name not in output_names:
+            await websocket.close(code=1008)  # policy violation
+            return
+        await websocket.accept()
+        try:
+            rate = float(
+                websocket.query_params.get(
+                    "rate", ros_node.config.api_stream_default_rate
+                )
+            )
+        except (TypeError, ValueError):
+            rate = ros_node.config.api_stream_default_rate
+        if rate <= 0:
+            rate = ros_node.config.api_stream_default_rate
+        period = 1.0 / min(rate, ros_node.config.api_max_stream_rate)
+
+        async def _drain():
+            # receive() raises WebSocketDisconnect when the client goes away.
+            try:
+                while True:
+                    await websocket.receive()
+            except WebSocketDisconnect:
+                pass
+
+        drain = asyncio.ensure_future(_drain())
+        try:
+            while not drain.done():
+                content = ros_node.get_latest_output(name)
+                if content is not None:
+                    await websocket.send_json({
+                        "topic": name,
+                        "payload": _content_to_jsonable(content),
+                    })
+                await asyncio.sleep(period)
+        except (WebSocketDisconnect, RuntimeError):
+            pass
+        finally:
+            drain.cancel()
+
+    routes = [
+        Route(f"{API_BASE}/health", health, methods=["GET"]),
+        Route(f"{API_BASE}/interfaces", interfaces, methods=["GET"]),
+        Route(f"{API_BASE}/inputs/{{name}}", publish_input, methods=["POST"]),
+        Route(f"{API_BASE}/services/{{name}}", call_service, methods=["POST"]),
+        Route(f"{API_BASE}/outputs/{{name}}/latest", output_latest, methods=["GET"]),
+        WebSocketRoute(f"{API_BASE}/outputs/{{name}}", stream_output),
+    ]
+    # Mount the browser app last so the specific /api/* routes take precedence
+    if browser_app is not None:
+        routes.append(Mount("/", app=browser_app))
+
+    return Starlette(routes=routes)

--- a/ros_sugar/ui_node/browser.py
+++ b/ros_sugar/ui_node/browser.py
@@ -275,6 +275,10 @@ def build_browser_app(
         for o in (ros_node.in_topics or [])
         if o.name not in _widget_output_names
     ]
+    log_topic_names = {name for name, _ in log_topics}
+    # Topics that are ALSO declared as UI inputs carry user content their
+    # subscription echo is labeled "user"
+    ui_input_names = {t.name for t in (ros_node.out_topics or [])}
 
     # Per-connection server-push tasks (log + actions)
     _conn_tasks: Dict[Any, tuple] = {}
@@ -408,14 +412,16 @@ def build_browser_app(
                         if not content or content is last_seen.get(name):
                             continue
                         last_seen[name] = content
+                        # Topics also declared as UI inputs carry user content
+                        data_src = "user" if name in ui_input_names else "robot"
                         await log_data(
-                            send, content, data_type=type_name, data_src="robot"
+                            send, content, data_type=type_name, data_src=data_src
                         )
             except (WebSocketDisconnect, RuntimeError):
                 pass
 
         def _teardown():
-            for name, _type in log_topics:
+            for name, _ in log_topics:
                 ros_node.remove_output_listener(name, _on_update)
 
         _conn_tasks[ws] = (asyncio.create_task(_log_loop()), _teardown)
@@ -425,38 +431,48 @@ def build_browser_app(
         """WS route for input/output communication with ROS UI Node"""
 
         data_type = data.get("topic_type")
+        # NOTE: If the input topic is also subscribed (in the log topics), the
+        # subscription echo displays the message once as a user line, skip
+        # the immediate log line to avoid a double entry.
+        echoed = data.get("topic_name") in log_topic_names
         if data_type == "String":
             # display in log for string data types
-            await log_data(send, data["data"], data_type=data_type, data_src="user")
+            if not echoed:
+                await log_data(
+                    send, data["data"], data_type=data_type, data_src="user"
+                )
             _publish_from_form(ros_node, data_type, data)
             # Send the robot loading dots
             return elements.update_logging_card_with_loading(fh.outputs_log)
         elif data_type in ["Point", "PointStamped"]:
             # display in log for coordinates data types
-            await log_data(
-                send,
-                f"Published to topic /{data.get('topic_name')} using coordinates: x={data['x']}, y={data['y']}, z={data['z']}",
-                data_type="String",
-                data_src="user",
-            )
+            if not echoed:
+                await log_data(
+                    send,
+                    f"Published to topic /{data.get('topic_name')} using coordinates: x={data['x']}, y={data['y']}, z={data['z']}",
+                    data_type="String",
+                    data_src="user",
+                )
             _publish_from_form(ros_node, data_type, data)
         elif data_type in ["Pose", "PoseStamped"]:
             # display in log for coordinates data types
-            await log_data(
-                send,
-                f"Published to topic /{data.get('topic_name')} using coordinates: (Position: x={data['x']}, y={data['y']}, z={data['z']}), (Orientation: w={data['ori_w'] or '1'}, x={data['ori_x'] or '0'}, y={data['ori_y'] or '0'}, z={data['ori_z'] or '0'})",
-                data_type="String",
-                data_src="user",
-            )
+            if not echoed:
+                await log_data(
+                    send,
+                    f"Published to topic /{data.get('topic_name')} using coordinates: (Position: x={data['x']}, y={data['y']}, z={data['z']}), (Orientation: w={data['ori_w'] or '1'}, x={data['ori_x'] or '0'}, y={data['ori_y'] or '0'}, z={data['ori_z'] or '0'})",
+                    data_type="String",
+                    data_src="user",
+                )
             _publish_from_form(ros_node, data_type, data)
         elif data_type == "Bool":
             # display in log for coordinates data types
-            await log_data(
-                send,
-                f"Published to topic /{data.get('topic_name')}: {data.get('data', 'off')}",
-                data_type="String",
-                data_src="user",
-            )
+            if not echoed:
+                await log_data(
+                    send,
+                    f"Published to topic /{data.get('topic_name')}: {data.get('data', 'off')}",
+                    data_type="String",
+                    data_src="user",
+                )
             _publish_from_form(ros_node, data_type, data)
         else:
             _publish_from_form(ros_node, data_type, data)

--- a/ros_sugar/ui_node/browser.py
+++ b/ros_sugar/ui_node/browser.py
@@ -1,58 +1,15 @@
 """FastHTML browser UI for the UI node"""
 
-import array
-import base64
-from functools import partial
-from typing import Dict
+import asyncio
+from typing import Any, Dict
 
-import numpy as np
-from rosidl_runtime_py.convert import message_to_ordereddict
+from starlette.websockets import WebSocketDisconnect
 
 from fasthtml.common import *  # noqa: F401,F403 -- FT components
 
 from . import elements
 from .frontend import FHApp
 from ..supported_types import ros_msg_to_str
-from ..utils import logger
-
-
-def _marker_on_map(payload, **_):
-    """Helper callback to parse a map Maker data from point-like message"""
-    content = payload.get("payload", None)
-    if content is None:
-        return
-    msg_type = payload.get("type")
-    try:
-        if msg_type == "Path":
-            # Content data will have the filtered path points
-            return {
-                "op": "path",
-                "id": payload.get("topic", ""),
-                "frame_id": content.get("frame_id", ""),
-                "points": content.get("data"),
-            }
-        if msg_type in ["Point", "PointStamped"]:
-            # Content data will have an array of [x, y, z]
-            return {
-                "op": "overlay",
-                "id": payload.get("topic", ""),
-                "frame_id": content.get("frame_id", ""),
-                "x": content.get("data")[0],
-                "y": content.get("data")[1],
-            }
-        if msg_type in ["Pose", "PoseStamped", "Odometry"]:
-            # Content data will have an array of [x, y, z, heading] for Pose, PoseStamped
-            # and [x, y, z, heading] for Odometry
-            return {
-                "op": "overlay",
-                "id": payload.get("topic", ""),
-                "frame_id": content.get("frame_id", ""),
-                "x": content.get("data")[0],
-                "y": content.get("data")[1],
-                "theta": content.get("data")[3],
-            }
-    except Exception:
-        logger.error(f"Error parsing UI input from topic type {msg_type}")
 
 
 def _form_to_schema(msg_type: str, form: Dict) -> Dict:
@@ -207,17 +164,30 @@ def build_browser_app(
             data_type="String",
             data_src="user",
         )
-        result_code, result = ros_node.send_srv_call(data_dict)
-        if not result_code:
-            fh.toasting(result, session, "error", duration=100000)
-        else:
+        try:
+            response = ros_node.send_srv_call(data_dict)
+        except RuntimeError as e:
+            fh.toasting(str(e), session, "error", duration=100000)
+            return fh.get_main_page()
+        if response is None:
             fh.toasting(
-                f"Service returned response: {result}", session, "info", duration=100000
+                "No response received from the service",
+                session,
+                "error",
+                duration=100000,
             )
+            return fh.get_main_page()
+        response_str = ros_msg_to_str(response)
+        fh.toasting(
+            f"Service returned response: {response_str}",
+            session,
+            "info",
+            duration=100000,
+        )
         # Add response to logging card
         elements.update_logging_card(
             fh.outputs_log,
-            f"Service returned response: '{result}'",
+            f"Service returned response: '{response_str}'",
             data_type="String",
             data_src="robot",
         )
@@ -240,11 +210,20 @@ def build_browser_app(
                 duration=100000,
             )
             return fh.get_main_page()
-        result_code, result = ros_node.send_action_goal(data_dict)
-        if not result_code:
-            fh.toasting(result, session, "error", duration=100000)
+        try:
+            accepted = ros_node.send_action_goal(data_dict)
+        except RuntimeError as e:
+            fh.toasting(str(e), session, "error", duration=100000)
+            return fh.get_main_page()
+        if not accepted:
+            fh.toasting(
+                f"Action server rejected the goal for '{action_name}'",
+                session,
+                "error",
+                duration=100000,
+            )
         else:
-            fh.toasting(f"Task sent: {result}", session, "info", duration=100000)
+            fh.toasting(f"Task sent to '{action_name}'", session, "info", duration=100000)
             fh.action_clients_ft[action_name].update(
                 status="accepted",
                 duration=0,
@@ -266,7 +245,11 @@ def build_browser_app(
         form_data = await request.form()
         data_dict = dict(form_data.items())
         action_name = data_dict.get("action_name")
-        result_code, result = ros_node.cancel_action(action_name)
+        try:
+            result_code, result = ros_node.cancel_action(action_name)
+        except RuntimeError as e:
+            fh.toasting(str(e), session, "error", duration=100000)
+            return fh.get_main_page()
         if not result_code:
             fh.toasting(result, session, "error", duration=100000)
         else:
@@ -279,6 +262,22 @@ def build_browser_app(
                 data_src="user",
             )
         return fh.get_main_page()
+
+    # NOTE: Output topics shown in the running log: everything NOT routed to a
+    # dedicated video/map widget, and not a map overlay.
+    _widget_output_names = (
+        {name for name, _ in fh.get_all_stream_outputs()}
+        | {name for name, _ in fh.get_all_map_outputs()}
+        | {name for name, _ in fh.get_all_map_overlay_outputs()}
+    )
+    log_topics = [
+        (o.name, o.msg_type.__name__)
+        for o in (ros_node.in_topics or [])
+        if o.name not in _widget_output_names
+    ]
+
+    # Per-connection server-push tasks (log + actions)
+    _conn_tasks: Dict[Any, tuple] = {}
 
     # -- WS handling --
     async def log_data(send, data: str, data_type: str, data_src: str):
@@ -293,143 +292,82 @@ def build_browser_app(
             )
         )
 
-    async def on_disconn(session):
-        """Message for disconnection"""
+    async def on_disconn(ws, session):
+        """Cancel this connection's server-push task and warn the client."""
+        entry = _conn_tasks.pop(ws, None)
+        if entry is not None:
+            task, teardown = entry
+            task.cancel()
+            teardown()
         fh.toasting(
             "Disconnected from the robot. Check if the recipe is running or refresh the page",
             session,
             toast_type="error",
         )
 
-    async def on_conn_stream(ws, send, topic_type: str):
-        """When a client connects, register its callback."""
+    async def on_conn_action(ws, send):
+        """Push action task-card updates to the client as feedback arrives."""
+        loop = asyncio.get_running_loop()
+        updated = asyncio.Event()
 
-        # Callback function for ROS node
-        async def stream_callback(data: Dict, **_):
-            if data["type"] == "error":
-                await log_data(
-                    send, data["payload"], data_type=data["type"], data_src=data["type"]
-                )
-            else:
-                await ws.send_json(data)
+        def _on_update():  # fired in the ROS executor thread on each feedback
+            loop.call_soon_threadsafe(updated.set)
 
-        ros_node.attach_websocket_callback(stream_callback, topic_type)
+        names = [c["name"] for c in ros_node.action_clients_inputs_dicts()]
+        registered = [
+            n for n in names if ros_node.add_action_feedback_listener(n, _on_update)
+        ]
 
-    async def on_conn_map(ws, _, map_topic_type: str):
-        """When a client connects, register its callback."""
+        last_seen: Dict[str, tuple] = {}
 
-        # Callback function for ROS node
-        async def map_callback(payload, msg):
-            # --- CASE 1: Incoming marker data ----
-            # If the incoming data is for a marker
-            if payload.get("type", None) != "OccupancyGrid":
-                response = _marker_on_map(payload)
-                if response:
-                    await ws.send_json(response)
-                return
-
-            # --- CASE 2: Incoming MAP data ----
-            # Convert ROS message to a JSON-serializable dict
-            # Convert header and info normally (they are small)
-            msg_dict = {
-                "header": message_to_ordereddict(msg.header),
-                "info": message_to_ordereddict(msg.info),
-            }
-
-            # FAST CONVERSION of data field
-            # 'data' is typically a list of int8. We want a Base64 string.
-            data_field = msg.data
-            raw_bytes = b""
-
-            if isinstance(data_field, list):
-                # 'b' is signed char (int8), matches ROS int8[]
-                raw_bytes = array.array("b", data_field).tobytes()
-            elif isinstance(data_field, array.array):
-                raw_bytes = data_field.tobytes()
-            elif isinstance(data_field, bytes):
-                raw_bytes = data_field
-            elif isinstance(data_field, np.ndarray):
-                raw_bytes = data_field.tobytes()
-            else:
-                # Fallback (slowest)
-                raw_bytes = bytes(data_field)
-
-            msg_dict["data"] = base64.b64encode(raw_bytes).decode("utf-8")
-
-            response = {"op": "publish", "msg": msg_dict}
-            await ws.send_json(response)
-
-        ros_node.attach_websocket_callback(map_callback, map_topic_type)
-
-        # Add all point outputs to the map websocket callback
-        for _, topic_type in fh.get_all_map_overlay_outputs():
-            ros_node.attach_websocket_callback(map_callback, topic_type)
-
-    async def on_conn_action(_, send):
-        """When a client connects, register feedback callbacks for all action clients."""
-
-        for clients_config in ros_node.action_clients_inputs_dicts():
-            _action_name = clients_config["name"]
-
-            async def feedback_callback(data: Dict, *, _name=_action_name, **_):
-                """Updates an action client with new feedback from the server
-
-                :param data: UI data dict (status, feedback, etc.)
-                :type data: Dict
-                """
-                feedback = (
-                    ros_msg_to_str(data["feedback"]) if data["feedback"] else None
-                )
-                fh.action_clients_ft[_name].update(
-                    status=data["status"],
-                    feedback=feedback,
-                    duration=data["duration_secs"],
-                    timestep=data["timestep"],
-                )
-                await send(fh.action_clients_ft[_name].card)
-
-                if data["status"] in ["aborted", "completed", "canceled"]:
-                    # display action aborted as an error on the main logging card
-                    if data["status"] == "aborted":
-                        await log_data(
-                            send,
-                            f"Task '{_name}' aborted: {feedback}"
-                            if feedback
-                            else f"Task '{_name}' aborted",
-                            data_type="String",
-                            data_src="error",
+        async def _feedback_loop():
+            try:
+                while True:
+                    await updated.wait()
+                    updated.clear()
+                    for name in names:
+                        fb = ros_node.get_action_feedback(name)
+                        if fb is None:
+                            continue
+                        key = (fb["status"], fb["timestep"], fb["duration_secs"])
+                        if key == last_seen.get(name):
+                            continue
+                        last_seen[name] = key
+                        feedback = (
+                            ros_msg_to_str(fb["feedback"]) if fb["feedback"] else None
                         )
-                    ros_node.cleanup_action(action_name=_name)
-                    fh.action_clients_ft[_name].cleanup()
+                        fh.action_clients_ft[name].update(
+                            status=fb["status"],
+                            feedback=feedback,
+                            duration=fb["duration_secs"],
+                            timestep=fb["timestep"],
+                        )
+                        await send(fh.action_clients_ft[name].card)
 
-            ros_node.attach_client_feedback_callback(feedback_callback, _action_name)
+                        if fb["status"] in ("aborted", "completed", "canceled"):
+                            # display action aborted as an error on the main logging card
+                            if fb["status"] == "aborted":
+                                await log_data(
+                                    send,
+                                    f"Task '{name}' aborted: {feedback}"
+                                    if feedback
+                                    else f"Task '{name}' aborted",
+                                    data_type="String",
+                                    data_src="error",
+                                )
+                            fh.action_clients_ft[name].cleanup()
+            except (WebSocketDisconnect, RuntimeError):
+                pass
 
-    # Create websockets for streaming output topics
-    for topic_name, topic_type in fh.get_all_stream_outputs():
+        def _teardown():
+            for name in registered:
+                ros_node.remove_action_feedback_listener(name, _on_update)
 
-        @app.ws(
-            f"/ws_{topic_name}",
-            conn=partial(on_conn_stream, topic_type=topic_type),
-            disconn=on_disconn,
-        )
-        async def _():
-            pass
+        _conn_tasks[ws] = (asyncio.create_task(_feedback_loop()), _teardown)
 
-    # Create websockets for map output topics
-    for map_topic_name, map_topic_type in fh.get_all_map_outputs():
-        logger.debug(f"Starting ws for {map_topic_name}, {map_topic_type}...")
-
-        @app.ws(
-            f"/ws_{map_topic_name}",
-            conn=partial(on_conn_map, map_topic_type=map_topic_type),
-            disconn=on_disconn,
-        )
-        async def _(_, data):
-            # Map websockets send back clicked points (Point, Pose, etc.)
-            # The actual point data is in data.data, but it is expected in the ui node directly in data.x, etc.
-            if message := data.pop("data", None):
-                data.update(message)
-                _publish_from_form(ros_node, data.get("topic_type"), data)
+    # NOTE: Video (images) and maps stream over the API: video_manager.js
+    # connects to WS /api/outputs/<topic>, ros_maps.js to WS /api/world/<grid>
+    # and POST /api/inputs/<topic> (click-to-publish).
 
     if ros_node.action_clients_inputs_dicts():
 
@@ -442,48 +380,45 @@ def build_browser_app(
             """WS route for sending action feedback to ROS UI Node"""
             pass
 
-    @app.ws("/ws_audio", disconn=on_disconn)
-    async def _(data, send):
-        """WS route for sending audio to ROS UI Node"""
-        # Only handle audio data
-        if data["type"] == "audio" and len(data["payload"]) > 0:
+    async def on_conn(ws, send):
+        """Push new output messages to the running log as they arrive.
+
+        Registers a per-message listener on the log-eligible output topics
+        (event push); each message wakes the loop, which renders the latest
+        content and appends it to the log card.
+        """
+        loop = asyncio.get_running_loop()
+        updated = asyncio.Event()
+
+        def _on_update():  # fired in the ROS executor thread on each message
+            loop.call_soon_threadsafe(updated.set)
+
+        for name, _type in log_topics:
+            ros_node.add_output_listener(name, _on_update)
+
+        last_seen: Dict[str, Any] = {}
+
+        async def _log_loop():
             try:
-                await log_data(
-                    send, data["payload"], data_type="Audio", data_src="user"
-                )
-                # NOTE: Audio uses the dedicated base64 -> Audio path,
-                # not the schema-shaped publish_data.
-                ros_node.publish_audio(data["topic_name"], data["payload"])
-            except RuntimeError:
-                logger.warning("Runtime error when sending audio")
+                while True:
+                    await updated.wait()
+                    updated.clear()
+                    for name, type_name in log_topics:
+                        content = ros_node.get_latest_output(name)
+                        if not content or content is last_seen.get(name):
+                            continue
+                        last_seen[name] = content
+                        await log_data(
+                            send, content, data_type=type_name, data_src="robot"
+                        )
+            except (WebSocketDisconnect, RuntimeError):
+                pass
 
-            # Send the robot loading dots
-            return elements.update_logging_card_with_loading(fh.outputs_log)
+        def _teardown():
+            for name, _type in log_topics:
+                ros_node.remove_output_listener(name, _on_update)
 
-    async def on_conn(send):
-        """When a client connects, register its callback."""
-
-        # NOTE: Types that will be routed to the map websocket once it attaches.
-        # They are dropped from the default log callback to avoid a brief
-        # flash in the log during the startup window between the main /ws
-        # connecting and /ws_map attaching its per-type callbacks.
-        map_overlay_types = (
-            {t for _, t in fh.get_all_map_overlay_outputs()}
-            if fh.get_all_map_outputs()
-            else set()
-        )
-
-        # Callback function for ROS node
-        async def websocket_callback(data: Dict, **_):
-            # Recieve json style data from node and pass to UI with send
-            if data.get("type") in map_overlay_types:
-                return
-            if len(data["payload"]) > 0:
-                await log_data(
-                    send, data["payload"], data_type=data["type"], data_src="robot"
-                )
-
-        ros_node.attach_websocket_callback(websocket_callback)
+        _conn_tasks[ws] = (asyncio.create_task(_log_loop()), _teardown)
 
     @app.ws("/ws", conn=on_conn, disconn=on_disconn)
     async def _(data, send):

--- a/ros_sugar/ui_node/browser.py
+++ b/ros_sugar/ui_node/browser.py
@@ -55,6 +55,51 @@ def _marker_on_map(payload, **_):
         logger.error(f"Error parsing UI input from topic type {msg_type}")
 
 
+def _form_to_schema(msg_type: str, form: Dict) -> Dict:
+    """Translate a flat UI-form field dict into a schema-shaped dict for specific types
+
+    :param msg_type: The declared topic's message type name (e.g. ``"Pose"``).
+    :param form: The flat field dict submitted by the widget.
+    :return: A dict shaped for ``set_ros_msg_from_dict`` (no ``topic_name``).
+    """
+    if msg_type == "Bool":
+        return {"data": form.get("data") in ("on", "1", "true", True)}
+    if msg_type in ("Float32", "Float64"):
+        return {"data": float(form.get("data") or 0.0)}
+    if msg_type in ("Point", "PointStamped"):
+        point = {
+            "x": float(form.get("x") or 0.0),
+            "y": float(form.get("y") or 0.0),
+            "z": float(form.get("z") or 0.0),
+        }
+        return point if msg_type == "Point" else {"point": point}
+    if msg_type in ("Pose", "PoseStamped"):
+        pose = {
+            "position": {
+                "x": float(form.get("x") or 0.0),
+                "y": float(form.get("y") or 0.0),
+                "z": float(form.get("z") or 0.0),
+            },
+            "orientation": {
+                "w": float(form.get("ori_w") or 1.0),
+                "x": float(form.get("ori_x") or 0.0),
+                "y": float(form.get("ori_y") or 0.0),
+                "z": float(form.get("ori_z") or 0.0),
+            },
+        }
+        return pose if msg_type == "Pose" else {"pose": pose}
+    # String and any other single data field type
+    return {"data": form.get("data", "")}
+
+
+def _publish_from_form(ros_node, msg_type: str, form: Dict) -> None:
+    """Publish a widget form on its declared input topic."""
+    ros_node.publish_data({
+        "topic_name": form["topic_name"],
+        **_form_to_schema(msg_type, form),
+    })
+
+
 def build_browser_app(
     ros_node,
     additional_input_elements=None,
@@ -384,7 +429,7 @@ def build_browser_app(
             # The actual point data is in data.data, but it is expected in the ui node directly in data.x, etc.
             if message := data.pop("data", None):
                 data.update(message)
-                ros_node.publish_data(data)
+                _publish_from_form(ros_node, data.get("topic_type"), data)
 
     if ros_node.action_clients_inputs_dicts():
 
@@ -406,11 +451,9 @@ def build_browser_app(
                 await log_data(
                     send, data["payload"], data_type="Audio", data_src="user"
                 )
-                ros_node.publish_data({
-                    "topic_name": data["topic_name"],
-                    "topic_type": "Audio",
-                    "data": data["payload"],
-                })
+                # NOTE: Audio uses the dedicated base64 -> Audio path,
+                # not the schema-shaped publish_data.
+                ros_node.publish_audio(data["topic_name"], data["payload"])
             except RuntimeError:
                 logger.warning("Runtime error when sending audio")
 
@@ -446,13 +489,14 @@ def build_browser_app(
     async def _(data, send):
         """WS route for input/output communication with ROS UI Node"""
 
-        if (data_type := data.get("topic_type")) == "String":
+        data_type = data.get("topic_type")
+        if data_type == "String":
             # display in log for string data types
             await log_data(send, data["data"], data_type=data_type, data_src="user")
-            ros_node.publish_data(data=data)
+            _publish_from_form(ros_node, data_type, data)
             # Send the robot loading dots
             return elements.update_logging_card_with_loading(fh.outputs_log)
-        elif data.get("topic_type") in ["Point", "PointStamped"]:
+        elif data_type in ["Point", "PointStamped"]:
             # display in log for coordinates data types
             await log_data(
                 send,
@@ -460,8 +504,8 @@ def build_browser_app(
                 data_type="String",
                 data_src="user",
             )
-            ros_node.publish_data(data=data)
-        elif data.get("topic_type") in ["Pose", "PoseStamped"]:
+            _publish_from_form(ros_node, data_type, data)
+        elif data_type in ["Pose", "PoseStamped"]:
             # display in log for coordinates data types
             await log_data(
                 send,
@@ -469,8 +513,8 @@ def build_browser_app(
                 data_type="String",
                 data_src="user",
             )
-            ros_node.publish_data(data=data)
-        elif data.get("topic_type") == "Bool":
+            _publish_from_form(ros_node, data_type, data)
+        elif data_type == "Bool":
             # display in log for coordinates data types
             await log_data(
                 send,
@@ -478,8 +522,8 @@ def build_browser_app(
                 data_type="String",
                 data_src="user",
             )
-            ros_node.publish_data(data=data)
+            _publish_from_form(ros_node, data_type, data)
         else:
-            ros_node.publish_data(data=data)
+            _publish_from_form(ros_node, data_type, data)
 
     return app

--- a/ros_sugar/ui_node/browser.py
+++ b/ros_sugar/ui_node/browser.py
@@ -1,0 +1,485 @@
+"""FastHTML browser UI for the UI node"""
+
+import array
+import base64
+from functools import partial
+from typing import Dict
+
+import numpy as np
+from rosidl_runtime_py.convert import message_to_ordereddict
+
+from fasthtml.common import *  # noqa: F401,F403 -- FT components
+
+from . import elements
+from .frontend import FHApp
+from ..supported_types import ros_msg_to_str
+from ..utils import logger
+
+
+def _marker_on_map(payload, **_):
+    """Helper callback to parse a map Maker data from point-like message"""
+    content = payload.get("payload", None)
+    if content is None:
+        return
+    msg_type = payload.get("type")
+    try:
+        if msg_type == "Path":
+            # Content data will have the filtered path points
+            return {
+                "op": "path",
+                "id": payload.get("topic", ""),
+                "frame_id": content.get("frame_id", ""),
+                "points": content.get("data"),
+            }
+        if msg_type in ["Point", "PointStamped"]:
+            # Content data will have an array of [x, y, z]
+            return {
+                "op": "overlay",
+                "id": payload.get("topic", ""),
+                "frame_id": content.get("frame_id", ""),
+                "x": content.get("data")[0],
+                "y": content.get("data")[1],
+            }
+        if msg_type in ["Pose", "PoseStamped", "Odometry"]:
+            # Content data will have an array of [x, y, z, heading] for Pose, PoseStamped
+            # and [x, y, z, heading] for Odometry
+            return {
+                "op": "overlay",
+                "id": payload.get("topic", ""),
+                "frame_id": content.get("frame_id", ""),
+                "x": content.get("data")[0],
+                "y": content.get("data")[1],
+                "theta": content.get("data")[3],
+            }
+    except Exception:
+        logger.error(f"Error parsing UI input from topic type {msg_type}")
+
+
+def build_browser_app(
+    ros_node,
+    additional_input_elements=None,
+    additional_output_elements=None,
+    system_info=None,
+):
+    """Build the FastHTML browser app for the UI node.
+
+    :param ros_node: The running UI node.
+    :param additional_input_elements: UI input elements from derived packages.
+    :param additional_output_elements: UI output elements from derived packages.
+    :param system_info: System metadata for the visualization page.
+    :return: The FastHTML application (a Starlette app) to mount under ``/``.
+    """
+    ros_node_config = ros_node.config
+
+    fh = FHApp(
+        ros_node_config.components,
+        ros_node.out_topics,  # Inputs from the client to the ros node
+        ros_node.in_topics,  # Outputs to the client from the ros node
+        srv_clients_configs=ros_node.srv_clients_inputs_dicts(),
+        action_clients_configs=ros_node.action_clients_inputs_dicts(),
+        additional_input_elements=additional_input_elements,  # Additional UI input elements from derived packages
+        additional_output_elements=additional_output_elements,  # Additional UI output elements from derived packages
+        hide_settings_panel=ros_node_config.hide_settings,
+        system_info=system_info,
+    )  # inputs and outputs are reversed
+    app, _ = fh.get_app()
+
+    # Routes for the app backend
+    @app.get("/")
+    def _():
+        """Serves the main application page."""
+        fh.toggle_settings = False
+        fh.toggle_system = False
+        return fh.get_main_page()
+
+    @app.get("/settings/show")
+    def _():
+        """Show the settings tabs"""
+        fh.toggle_system = False
+        fh.toggle_settings = not fh.toggle_settings
+        return fh.get_main_page()
+
+    @app.get("/system/show")
+    def _():
+        """Show the system visualization"""
+        fh.toggle_settings = False
+        fh.toggle_system = not fh.toggle_system
+        return fh.get_main_page()
+
+    @app.get("/system/component/{name}")
+    def _(name: str):
+        """Return detail panel for a specific component"""
+        comp_meta = (
+            fh.system_info.get("components", {}).get(name, {}) if fh.system_info else {}
+        )
+        return elements.system_component_detail(
+            name,
+            comp_meta,
+            fh.configs.get(name, {}),
+            fh.system_info,
+        )
+
+    @app.get("/system/event/{event_short_id}")
+    def _(event_short_id: str):
+        """Return detail panel for a specific event"""
+        if not fh.system_info:
+            return Div("No system data available")
+        for ev in fh.system_info.get("events", []):
+            if ev["id"][:8] == event_short_id:
+                return elements.system_event_detail(ev)
+        return Div(f"Event '{event_short_id}' not found")
+
+    @app.post("/settings/submit")
+    async def _(request, session):
+        """Update Settings"""
+        # update config
+        # update UI
+        form_data = await request.form()
+        result = ros_node.update_configs(dict(form_data.items()))
+        success = all(result.success)
+        if not success:
+            item_names = list(form_data.keys())
+            error_msg = "Error in updating the following settings values: \n"
+            for key in range(len(result.success)):
+                if not result.success[key]:
+                    error_msg += f"{item_names[key + 1]}: {result.error_msg[key]}\n"
+            fh.toasting(error_msg, session, "error", duration=100000)
+        else:
+            fh.toasting("Settings changed successfully", session, "success")
+            # Persist the new configuration
+            fh.update_configs_from_data(dict(form_data.items()))
+        return fh.get_main_page()
+
+    @app.post("/service/call")
+    async def _(request, session):
+        """Send a ROS2 service call from the client"""
+        form_data = await request.form()
+        data_dict = dict(form_data.items())
+        # Add request to logging card
+        elements.update_logging_card(
+            fh.outputs_log,
+            f"Sending service call: '{data_dict}'",
+            data_type="String",
+            data_src="user",
+        )
+        result_code, result = ros_node.send_srv_call(data_dict)
+        if not result_code:
+            fh.toasting(result, session, "error", duration=100000)
+        else:
+            fh.toasting(
+                f"Service returned response: {result}", session, "info", duration=100000
+            )
+        # Add response to logging card
+        elements.update_logging_card(
+            fh.outputs_log,
+            f"Service returned response: '{result}'",
+            data_type="String",
+            data_src="robot",
+        )
+        return fh.get_main_page()
+
+    @app.post("/action/goal")
+    async def _(request, session):
+        """Send a ROS2 action goal from the client"""
+        form_data = await request.form()
+        data_dict = dict(form_data.items())
+        action_name = data_dict.get("action_name", "")
+        if (
+            action_name in fh.action_clients_ft
+            and fh.action_clients_ft[action_name].is_active()
+        ):
+            fh.toasting(
+                "Cannot send a new goal while the current goal is still active. Cancel ongoing goal first.",
+                session,
+                "error",
+                duration=100000,
+            )
+            return fh.get_main_page()
+        result_code, result = ros_node.send_action_goal(data_dict)
+        if not result_code:
+            fh.toasting(result, session, "error", duration=100000)
+        else:
+            fh.toasting(f"Task sent: {result}", session, "info", duration=100000)
+            fh.action_clients_ft[action_name].update(
+                status="accepted",
+                duration=0,
+            )
+            fh.action_clients_ft[action_name].total_calls += 1
+            # display the action on the main logging card
+            goal_payload = {k: v for k, v in data_dict.items() if k != "action_name"}
+            elements.update_logging_card(
+                fh.outputs_log,
+                f"Start Task '{action_name}': {goal_payload}",
+                data_type="String",
+                data_src="user",
+            )
+        return fh.get_main_page()
+
+    @app.post("/action/cancel")
+    async def _(request, session):
+        """Cancel a ROS2 action goal from the client"""
+        form_data = await request.form()
+        data_dict = dict(form_data.items())
+        action_name = data_dict.get("action_name")
+        result_code, result = ros_node.cancel_action(action_name)
+        if not result_code:
+            fh.toasting(result, session, "error", duration=100000)
+        else:
+            fh.toasting(f"{result}", session, "info", duration=100000)
+            # display cancellation request on the main logging card
+            elements.update_logging_card(
+                fh.outputs_log,
+                f"Cancel Task '{action_name}'.",
+                data_type="String",
+                data_src="user",
+            )
+        return fh.get_main_page()
+
+    # -- WS handling --
+    async def log_data(send, data: str, data_type: str, data_src: str):
+        """Send data to log"""
+
+        await send(
+            elements.update_logging_card(
+                fh.outputs_log,
+                data,
+                data_type,
+                data_src,
+            )
+        )
+
+    async def on_disconn(session):
+        """Message for disconnection"""
+        fh.toasting(
+            "Disconnected from the robot. Check if the recipe is running or refresh the page",
+            session,
+            toast_type="error",
+        )
+
+    async def on_conn_stream(ws, send, topic_type: str):
+        """When a client connects, register its callback."""
+
+        # Callback function for ROS node
+        async def stream_callback(data: Dict, **_):
+            if data["type"] == "error":
+                await log_data(
+                    send, data["payload"], data_type=data["type"], data_src=data["type"]
+                )
+            else:
+                await ws.send_json(data)
+
+        ros_node.attach_websocket_callback(stream_callback, topic_type)
+
+    async def on_conn_map(ws, _, map_topic_type: str):
+        """When a client connects, register its callback."""
+
+        # Callback function for ROS node
+        async def map_callback(payload, msg):
+            # --- CASE 1: Incoming marker data ----
+            # If the incoming data is for a marker
+            if payload.get("type", None) != "OccupancyGrid":
+                response = _marker_on_map(payload)
+                if response:
+                    await ws.send_json(response)
+                return
+
+            # --- CASE 2: Incoming MAP data ----
+            # Convert ROS message to a JSON-serializable dict
+            # Convert header and info normally (they are small)
+            msg_dict = {
+                "header": message_to_ordereddict(msg.header),
+                "info": message_to_ordereddict(msg.info),
+            }
+
+            # FAST CONVERSION of data field
+            # 'data' is typically a list of int8. We want a Base64 string.
+            data_field = msg.data
+            raw_bytes = b""
+
+            if isinstance(data_field, list):
+                # 'b' is signed char (int8), matches ROS int8[]
+                raw_bytes = array.array("b", data_field).tobytes()
+            elif isinstance(data_field, array.array):
+                raw_bytes = data_field.tobytes()
+            elif isinstance(data_field, bytes):
+                raw_bytes = data_field
+            elif isinstance(data_field, np.ndarray):
+                raw_bytes = data_field.tobytes()
+            else:
+                # Fallback (slowest)
+                raw_bytes = bytes(data_field)
+
+            msg_dict["data"] = base64.b64encode(raw_bytes).decode("utf-8")
+
+            response = {"op": "publish", "msg": msg_dict}
+            await ws.send_json(response)
+
+        ros_node.attach_websocket_callback(map_callback, map_topic_type)
+
+        # Add all point outputs to the map websocket callback
+        for _, topic_type in fh.get_all_map_overlay_outputs():
+            ros_node.attach_websocket_callback(map_callback, topic_type)
+
+    async def on_conn_action(_, send):
+        """When a client connects, register feedback callbacks for all action clients."""
+
+        for clients_config in ros_node.action_clients_inputs_dicts():
+            _action_name = clients_config["name"]
+
+            async def feedback_callback(data: Dict, *, _name=_action_name, **_):
+                """Updates an action client with new feedback from the server
+
+                :param data: UI data dict (status, feedback, etc.)
+                :type data: Dict
+                """
+                feedback = (
+                    ros_msg_to_str(data["feedback"]) if data["feedback"] else None
+                )
+                fh.action_clients_ft[_name].update(
+                    status=data["status"],
+                    feedback=feedback,
+                    duration=data["duration_secs"],
+                    timestep=data["timestep"],
+                )
+                await send(fh.action_clients_ft[_name].card)
+
+                if data["status"] in ["aborted", "completed", "canceled"]:
+                    # display action aborted as an error on the main logging card
+                    if data["status"] == "aborted":
+                        await log_data(
+                            send,
+                            f"Task '{_name}' aborted: {feedback}"
+                            if feedback
+                            else f"Task '{_name}' aborted",
+                            data_type="String",
+                            data_src="error",
+                        )
+                    ros_node.cleanup_action(action_name=_name)
+                    fh.action_clients_ft[_name].cleanup()
+
+            ros_node.attach_client_feedback_callback(feedback_callback, _action_name)
+
+    # Create websockets for streaming output topics
+    for topic_name, topic_type in fh.get_all_stream_outputs():
+
+        @app.ws(
+            f"/ws_{topic_name}",
+            conn=partial(on_conn_stream, topic_type=topic_type),
+            disconn=on_disconn,
+        )
+        async def _():
+            pass
+
+    # Create websockets for map output topics
+    for map_topic_name, map_topic_type in fh.get_all_map_outputs():
+        logger.debug(f"Starting ws for {map_topic_name}, {map_topic_type}...")
+
+        @app.ws(
+            f"/ws_{map_topic_name}",
+            conn=partial(on_conn_map, map_topic_type=map_topic_type),
+            disconn=on_disconn,
+        )
+        async def _(_, data):
+            # Map websockets send back clicked points (Point, Pose, etc.)
+            # The actual point data is in data.data, but it is expected in the ui node directly in data.x, etc.
+            if message := data.pop("data", None):
+                data.update(message)
+                ros_node.publish_data(data)
+
+    if ros_node.action_clients_inputs_dicts():
+
+        @app.ws(
+            "/ws_actions",
+            conn=on_conn_action,
+            disconn=on_disconn,
+        )
+        async def _():
+            """WS route for sending action feedback to ROS UI Node"""
+            pass
+
+    @app.ws("/ws_audio", disconn=on_disconn)
+    async def _(data, send):
+        """WS route for sending audio to ROS UI Node"""
+        # Only handle audio data
+        if data["type"] == "audio" and len(data["payload"]) > 0:
+            try:
+                await log_data(
+                    send, data["payload"], data_type="Audio", data_src="user"
+                )
+                ros_node.publish_data({
+                    "topic_name": data["topic_name"],
+                    "topic_type": "Audio",
+                    "data": data["payload"],
+                })
+            except RuntimeError:
+                logger.warning("Runtime error when sending audio")
+
+            # Send the robot loading dots
+            return elements.update_logging_card_with_loading(fh.outputs_log)
+
+    async def on_conn(send):
+        """When a client connects, register its callback."""
+
+        # NOTE: Types that will be routed to the map websocket once it attaches.
+        # They are dropped from the default log callback to avoid a brief
+        # flash in the log during the startup window between the main /ws
+        # connecting and /ws_map attaching its per-type callbacks.
+        map_overlay_types = (
+            {t for _, t in fh.get_all_map_overlay_outputs()}
+            if fh.get_all_map_outputs()
+            else set()
+        )
+
+        # Callback function for ROS node
+        async def websocket_callback(data: Dict, **_):
+            # Recieve json style data from node and pass to UI with send
+            if data.get("type") in map_overlay_types:
+                return
+            if len(data["payload"]) > 0:
+                await log_data(
+                    send, data["payload"], data_type=data["type"], data_src="robot"
+                )
+
+        ros_node.attach_websocket_callback(websocket_callback)
+
+    @app.ws("/ws", conn=on_conn, disconn=on_disconn)
+    async def _(data, send):
+        """WS route for input/output communication with ROS UI Node"""
+
+        if (data_type := data.get("topic_type")) == "String":
+            # display in log for string data types
+            await log_data(send, data["data"], data_type=data_type, data_src="user")
+            ros_node.publish_data(data=data)
+            # Send the robot loading dots
+            return elements.update_logging_card_with_loading(fh.outputs_log)
+        elif data.get("topic_type") in ["Point", "PointStamped"]:
+            # display in log for coordinates data types
+            await log_data(
+                send,
+                f"Published to topic /{data.get('topic_name')} using coordinates: x={data['x']}, y={data['y']}, z={data['z']}",
+                data_type="String",
+                data_src="user",
+            )
+            ros_node.publish_data(data=data)
+        elif data.get("topic_type") in ["Pose", "PoseStamped"]:
+            # display in log for coordinates data types
+            await log_data(
+                send,
+                f"Published to topic /{data.get('topic_name')} using coordinates: (Position: x={data['x']}, y={data['y']}, z={data['z']}), (Orientation: w={data['ori_w'] or '1'}, x={data['ori_x'] or '0'}, y={data['ori_y'] or '0'}, z={data['ori_z'] or '0'})",
+                data_type="String",
+                data_src="user",
+            )
+            ros_node.publish_data(data=data)
+        elif data.get("topic_type") == "Bool":
+            # display in log for coordinates data types
+            await log_data(
+                send,
+                f"Published to topic /{data.get('topic_name')}: {data.get('data', 'off')}",
+                data_type="String",
+                data_src="user",
+            )
+            ros_node.publish_data(data=data)
+        else:
+            ros_node.publish_data(data=data)
+
+    return app

--- a/ros_sugar/ui_node/elements.py
+++ b/ros_sugar/ui_node/elements.py
@@ -1469,7 +1469,8 @@ def augment_text_in_logging_card(
     new_txt: str,
     target_id="text",
 ):
-    """Update the inner text of a child in logging_card.children with a matching id."""
+    """Update the inner text of a child in logging_card.children with a
+    matching id. Used for streaming output whose payload is the delta."""
     children = logging_card.children
     target_child = None
     for i in range(len(children) - 1, -1, -1):
@@ -1483,6 +1484,31 @@ def augment_text_in_logging_card(
         if getattr(target_child.children[i], "id", None) == "inner-text":
             # Append the new text
             target_child.children[i](Span(f"{new_txt}"))
+            return logging_card
+    return logging_card
+
+
+def replace_text_in_logging_card(
+    logging_card,
+    new_txt: str,
+    target_id="text",
+):
+    """Replace the inner text of a child in logging_card.children with a
+    matching id, keeping its source prefix. Used for streamed entries whose
+    payload is the full text so far rather than a delta."""
+    children = logging_card.children
+    target_child = None
+    for i in range(len(children) - 1, -1, -1):
+        if getattr(children[i], "id", None) == target_id:
+            target_child = children[i]
+            break
+    if not target_child:
+        return logging_card
+    for i in range(len(target_child.children) - 1, -1, -1):
+        if getattr(target_child.children[i], "id", None) == "inner-text":
+            inner = target_child.children[i]
+            # Keep the source prefix (first child), replace the text
+            inner.children = (inner.children[0], f"{new_txt}")
             return logging_card
     return logging_card
 

--- a/ros_sugar/ui_node/elements.py
+++ b/ros_sugar/ui_node/elements.py
@@ -1455,13 +1455,15 @@ def initial_logging_card():
 
 
 def remove_child_from_logging_card(logging_card, target_id="loading-dots"):
-    """Remove the last child in logging_card.children with a matching id."""
+    """Remove and return the last child in logging_card.children with a
+    matching id (or ``None`` if not found)."""
     children = logging_card.children
 
     for i in range(len(children) - 1, -1, -1):
         if getattr(children[i], "id", None) == target_id:
             logging_card.children = children[:i] + children[i + 1 :]
-            break
+            return children[i]
+    return None
 
 
 def augment_text_in_logging_card(
@@ -1529,13 +1531,17 @@ def update_logging_card(
     :return: Updated logging card
     :rtype: FT
     """
-    # Remove any previous loading that exists on the card
-    remove_child_from_logging_card(logging_card)
     # Handle errors originating from ROS node
     if data_type == "error":
         data_type = "String"
         data_src = "error"
-    return _OUTPUT_ELEMENTS[data_type](logging_card, output, data_src)
+    # The loading indicator means "waiting for the robot": robot/error output
+    # clears it
+    dots = remove_child_from_logging_card(logging_card)
+    card = _OUTPUT_ELEMENTS[data_type](logging_card, output, data_src)
+    if data_src == "user" and dots is not None:
+        logging_card(dots)
+    return card
 
 
 def update_logging_card_with_loading(logging_card):

--- a/ros_sugar/ui_node/elements.py
+++ b/ros_sugar/ui_node/elements.py
@@ -386,10 +386,15 @@ def _map_overlay_settings_panel(map_id: str, element_id: str, overlay_type: str)
     return content
 
 
-def _map_settings_modal(map_id: str, overlays: Optional[Dict] = None):
+def _map_settings_modal(
+    map_id: str,
+    overlays: Optional[Dict] = None,
+    point_inputs: Optional[List[Tuple[str, str]]] = None,
+):
     """
     Creates a popup dialog to configure Clicked Point settings and Visuals.
     overlays: dict e.g. {'robot_pose': 'overlay', 'global_plan': 'path'}
+    point_inputs: declared point-like input topics ``(name, msg_type)``
     """
     if overlays is None:
         overlays = {}
@@ -407,30 +412,36 @@ def _map_settings_modal(map_id: str, overlays: Optional[Dict] = None):
             )
         )
 
+    # --- CLICKED POINT SETTINGS (only for declared point-like inputs) ---
+    point_settings = []
+    if point_inputs:
+        point_settings.append(
+            Card(
+                H5("Published Point Settings", cls="cool-title"),
+                LabelSelect(
+                    *[
+                        # The declared message type rides on the option so the
+                        # client publishes with the right schema
+                        Option(
+                            f"{name} ({msg_type})",
+                            value=name,
+                            data_type=msg_type,
+                            selected=(index == 0),
+                        )
+                        for index, (name, msg_type) in enumerate(point_inputs)
+                    ],
+                    label="Target Topic (declared UI inputs)",
+                    name="clicked_point_topic",
+                    cls="form-input space-y-1",
+                ),
+                cls="space-y-3 mb-4 main-card",
+            )
+        )
+
     return Div(
         Div(
             Form(
-                # --- CLICKED POINT SETTINGS ---
-                Card(
-                    H5("Published Point Settings", cls="cool-title"),
-                    LabelInput(
-                        label="Topic Name",
-                        name="clicked_point_topic",
-                        value="clicked_point",
-                        placeholder="e.g. /goal_pose",
-                        cls="form-input space-y-1",
-                    ),
-                    LabelSelect(
-                        Option("PointStamped", value="PointStamped", selected=True),
-                        Option("Point", value="Point"),
-                        Option("PoseStamped", value="PoseStamped"),
-                        Option("Pose", value="Pose"),
-                        label="Message Type",
-                        name="clicked_point_type",
-                        cls="form-input space-y-1",
-                    ),
-                    cls="space-y-3 mb-4 main-card",
-                ),
+                *point_settings,
                 Card(
                     H5("Output Visuals", cls="cool-title"),
                     # 1. The ID Selector
@@ -474,11 +485,18 @@ def _map_settings_modal(map_id: str, overlays: Optional[Dict] = None):
     )
 
 
-def _map_control_buttons(map_id: str, map_output_markers: Optional[Dict] = None):
+def _map_control_buttons(
+    map_id: str,
+    map_output_markers: Optional[Dict] = None,
+    point_inputs: Optional[List[Tuple[str, str]]] = None,
+):
     """
     Overlay buttons for Zoom In/Out and Publish Point.
+
+    The Publish Point button is only rendered when at least one point-like
+    input topic is declared in the UI.
     """
-    return DivHStacked(
+    buttons = [
         # Zoom In
         Button(
             UkIcon("plus"),
@@ -495,15 +513,21 @@ def _map_control_buttons(map_id: str, map_output_markers: Optional[Dict] = None)
             type="button",
             uk_tooltip="title: Zoom Out; pos: left",
         ),
+    ]
+    if point_inputs:
         # Publish Point Button
-        Button(
-            UkIcon("mapPin"),
-            cls="glass-icon-btn",
-            onclick="togglePublishPoint(this)",  # Calls JS function
-            id=f"{map_id}-publish-btn",
-            type="button",
-            uk_tooltip="title: Publish Clicked Point; pos: left",
-        ),
+        buttons.append(
+            Button(
+                UkIcon("mapPin"),
+                cls="glass-icon-btn",
+                onclick="togglePublishPoint(this)",  # Calls JS function
+                id=f"{map_id}-publish-btn",
+                type="button",
+                uk_tooltip="title: Publish Clicked Point; pos: left",
+            )
+        )
+    return DivHStacked(
+        *buttons,
         # Settings (Gear Icon)
         Button(
             UkIcon("settings"),
@@ -514,7 +538,7 @@ def _map_control_buttons(map_id: str, map_output_markers: Optional[Dict] = None)
             uk_tooltip="title: Settings; pos: left",
         ),
         # THE SETTINGS MODAL (Hidden by default, popped up by openMapSettings)
-        _map_settings_modal(map_id, map_output_markers),
+        _map_settings_modal(map_id, map_output_markers, point_inputs),
         cls="flex flex-row space-x-2 no-drag",
     )
 
@@ -872,12 +896,17 @@ def _out_image_element(topic_name: str, **_):
     )
 
 
-def _out_map_element(topic_name: str, map_output_markers: Optional[Dict] = None, **_):
+def _out_map_element(
+    topic_name: str,
+    map_output_markers: Optional[Dict] = None,
+    point_inputs: Optional[List[Tuple[str, str]]] = None,
+    **_,
+):
     """FastHTML element for output OccupancyGrid typ"""
     return (
         Grid(
             DivHStacked(
-                _map_control_buttons(topic_name, map_output_markers),
+                _map_control_buttons(topic_name, map_output_markers, point_inputs),
             ),
             Div(
                 id=topic_name,
@@ -1314,6 +1343,7 @@ def output_topic_card(
     topic_type: str,
     column_class: str = "",
     map_output_markers: Optional[Dict] = None,
+    point_inputs: Optional[List[Tuple[str, str]]] = None,
 ) -> FT:
     """Creates a UI element for an output topic
 
@@ -1321,11 +1351,17 @@ def output_topic_card(
     :type topic_name: str
     :param topic_type: Topic message type
     :type topic_type: str
+    :param point_inputs: Declared point-like input topics ``(name, msg_type)``
+        available as map click-to-publish targets
     :return: Output topic UI element
     """
     return Card(
         DivHStacked(H4(topic_name), _fullscreen_button(f"card-{topic_name}")),
-        _OUTPUT_ELEMENTS[topic_type](topic_name, map_output_markers=map_output_markers),
+        _OUTPUT_ELEMENTS[topic_type](
+            topic_name,
+            map_output_markers=map_output_markers,
+            point_inputs=point_inputs,
+        ),
         cls=f"m-2 {column_class} inner-main-card",
         id=f"card-{topic_name}",
     )

--- a/ros_sugar/ui_node/frontend.py
+++ b/ros_sugar/ui_node/frontend.py
@@ -86,6 +86,12 @@ class FHApp:
         # Inputs and Outputs
         self.in_topics = in_topics
         self.out_topics = out_topics
+        # Declared point-like input topics (button hidden when there are none)
+        self.point_input_topics = [
+            (t.name, t.msg_type.__name__)
+            for t in (in_topics or [])
+            if t.msg_type.__name__ in ("Point", "PointStamped", "Pose", "PoseStamped")
+        ]
         self.outputs = self._create_output_topics_ui(out_topics) if out_topics else None
         self.inputs = self._create_input_topics_ui(in_topics) if in_topics else None
 
@@ -272,6 +278,7 @@ class FHApp:
                     out.msg_type.__name__,
                     outputs_columns_cls[idx],
                     map_output_markers=map_outputs,
+                    point_inputs=self.point_input_topics,
                 )
             )
         return outputs_container(output_grid(*output_divs, id=grid_id))

--- a/ros_sugar/ui_node/static/audio_manager.js
+++ b/ros_sugar/ui_node/static/audio_manager.js
@@ -3,21 +3,32 @@
  * Handles Audio WebSocket connections, recording, and processing (WAV conversion).
  */
 
-// Establish WebSocket connection for audio transmission
+// Per-topic Audio WebSockets to the API. The topic name is in the URL
+// (WS /api/inputs/<topic>/audio); each recording is sent as {payload: <base64>}.
 const audioWsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-const ws_stream = new WebSocket(`${audioWsProtocol}//${window.location.host}/ws_audio`);
+const audioSockets = new Map(); // topic -> WebSocket
 
-ws_stream.onopen = () => {
-    console.log("Audio Websocket connection established");
-};
+function getAudioSocket(topic) {
+    let ws = audioSockets.get(topic);
+    if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
+        return ws;
+    }
+    ws = new WebSocket(`${audioWsProtocol}//${window.location.host}/api/inputs/${topic}/audio`);
+    ws.onclose = () => { audioSockets.delete(topic); };
+    ws.onerror = (err) => { console.error(`Audio WebSocket error [${topic}]:`, err); };
+    audioSockets.set(topic, ws);
+    return ws;
+}
 
-ws_stream.onclose = () => {
-    console.log("Audio Websocket connection closed");
-};
-
-ws_stream.onerror = (err) => {
-    console.error(`Audio WebSocket error:`, err);
-};
+function sendAudio(topic, base64Audio) {
+    const ws = getAudioSocket(topic);
+    const frame = JSON.stringify({ payload: base64Audio });
+    if (ws.readyState === WebSocket.OPEN) {
+        ws.send(frame);
+    } else {
+        ws.addEventListener("open", () => ws.send(frame), { once: true });
+    }
+}
 
 // --- Audio Recording Logic ---
 
@@ -77,8 +88,8 @@ async function startAudioRecording(button) {
                     reader.onloadend = () => {
                         const base64Audio = reader.result.split(",")[1];
                         if (base64Audio) {
-                            // topic_name matches the button ID used to trigger recording
-                            ws_stream.send(JSON.stringify({ type: "audio", payload: base64Audio, topic_name: button.id }));
+                            // topic name matches the button ID used to trigger recording
+                            sendAudio(button.id, base64Audio);
                         }
                     };
                 } catch (error) {

--- a/ros_sugar/ui_node/static/ros_maps.js
+++ b/ros_sugar/ui_node/static/ros_maps.js
@@ -108,16 +108,17 @@ function closeAllMapConnections() {
     mapConnections.clear();
 }
 
-// --- EXPORTED FUNCTIONS (Called by Python Buttons) ---
-window.zoomMap = function (topicName, zoomFactor) {
+// --- GLOBAL FUNCTIONS (called from Python-generated onclick attributes) ---
+// Top-level declarations are window globals.
+function zoomMap(topicName, zoomFactor) {
     const container = document.getElementById(topicName);
     if (!container || !container.mapViewer) return;
 
     const viewer = container.mapViewer;
     applyZoom(viewer, zoomFactor, null); // Null center means zoom to center of view
-};
+}
 
-window.togglePublishPoint = function (btn) {
+function togglePublishPoint(btn) {
     const mapElements = document.getElementsByName('map-canvas');
     if (mapElements.length === 0) {
         if (typeof UIkit !== 'undefined') {
@@ -146,7 +147,7 @@ window.togglePublishPoint = function (btn) {
 
         // If click is outside map AND outside the toggle button, turn off
         if (!isClickOnMap && !isClickOnBtn) {
-            window.togglePublishPoint(btn);
+            togglePublishPoint(btn);
         }
     };
     // ----------------------------------------
@@ -220,9 +221,9 @@ window.togglePublishPoint = function (btn) {
             }
         }
     });
-};
+}
 
-window.openMapSettings = function (topicName) {
+function openMapSettings(topicName) {
     const modal = document.getElementById(`${topicName}-settings-modal`);
     if (!modal) return;
 
@@ -256,9 +257,9 @@ window.openMapSettings = function (topicName) {
             }
         }
     }
-};
+}
 
-window.saveMapSettings = function (topicName) {
+function saveMapSettings(topicName) {
     const modal = document.getElementById(`${topicName}-settings-modal`);
     const form = document.getElementById(`${topicName}-settings-form`);
 
@@ -334,14 +335,14 @@ window.saveMapSettings = function (topicName) {
     }
 
     if (modal) modal.style.display = 'none';
-};
+}
 
 
 /**
  * Toggles the visibility of markers setting blocks in the map settings modal.
  * * @param {string} mapId - The ID of the map (e.g. 'map_1')
  */
-window.updateVisualSettingsVisibility = function (target, mapId) {
+function updateVisualSettingsVisibility(target, mapId) {
     // RETRIEVE VALUE
     // Since 'target' is the custom <uk-select> wrapper (LabelSelect), we look inside it.
     // We try the hidden input first (most reliable), then fallback to direct .value
@@ -374,14 +375,14 @@ window.updateVisualSettingsVisibility = function (target, mapId) {
             el.style.display = 'none';
         }
     });
-};
+}
 
 
 /**
  * Sets up a watcher on the selector to trigger updates automatically.
  * Call this ONCE when the modal opens.
  */
-window.initVisualSettingsObserver = function (mapId) {
+function initVisualSettingsObserver(mapId) {
     const selector = document.getElementById(`visual-selector-${mapId}`);
     if (!selector || selector._hasObserver) return; // Prevent double binding
 
@@ -404,7 +405,7 @@ window.initVisualSettingsObserver = function (mapId) {
 
     // Mark as observed so we don't attach multiple times
     selector._hasObserver = true;
-};
+}
 
 function initSingleMap(container, attempt = 0) {
     const topicName = container.id;
@@ -473,7 +474,7 @@ function initSingleMap(container, attempt = 0) {
     if (cachedMapHeader) container.mapHeader = cachedMapHeader;
 
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    const wsUrl = `${protocol}//${window.location.host}/ws_${topicName}`;
+    const wsUrl = `${protocol}//${window.location.host}/api/world/${topicName}`;
     const ws = connectMapWebSocket(container, wsUrl, mockRos, topicName, 0);
 
     setupInteractions(viewer, container);
@@ -516,28 +517,41 @@ function connectMapWebSocket(container, wsUrl, mockRos, topicName, attempt) {
             } else {
                 msgData = JSON.parse(event.data);
             }
-            let mapMessage = msgData.msg ? msgData.msg : msgData;
-
-            if (mapMessage.info && mapMessage.header) {
-                container.mapInfo = mapMessage.info;
-                container.mapHeader = mapMessage.header;
+            // --- Handle Grid ---
+            if (msgData.op === 'publish') {
+                const g = msgData.msg;
+                // Reconstruct the nested ROS OccupancyGrid shape that ROS2D and
+                // the overlay transforms expect, from the API's flat fields.
+                const info = {
+                    resolution: g.resolution,
+                    width: g.width,
+                    height: g.height,
+                    origin: {
+                        position: { x: g.origin_x, y: g.origin_y, z: 0 },
+                        orientation: {
+                            x: 0, y: 0,
+                            z: Math.sin(g.origin_yaw / 2),
+                            w: Math.cos(g.origin_yaw / 2),
+                        },
+                    },
+                };
+                const header = { frame_id: g.frame_id };
+                container.mapInfo = info;
+                container.mapHeader = header;
                 // Persist in registry so it survives DOM swaps
                 const conn = mapConnections.get(topicName);
                 if (conn) {
-                    conn.mapInfo = mapMessage.info;
-                    conn.mapHeader = mapMessage.header;
+                    conn.mapInfo = info;
+                    conn.mapHeader = header;
                 }
-            }
-
-            if (mapMessage.data && typeof mapMessage.data === 'string') {
-                const binaryString = atob(mapMessage.data);
+                // Decode base64 int8 occupancy data
+                const binaryString = atob(g.data);
                 const len = binaryString.length;
                 const bytes = new Int8Array(len);
                 for (let i = 0; i < len; i++) {
                     bytes[i] = binaryString.charCodeAt(i);
                 }
-                mapMessage.data = bytes;
-                mockRos.emit(topicName, mapMessage);
+                mockRos.emit(topicName, { info: info, header: header, data: bytes });
             }
             // --- Handle Points ---
             else if (msgData.op === 'overlay') {
@@ -1003,33 +1017,30 @@ function applyZoom(viewer, factor, center) {
  * Helper method to publish a clicked point on a map canvas
  */
 function publishPoint(container, targetTopic, rosPoint, msgType) {
-    if (!container || !container.mapWs) {
-        console.warn("Cannot publish point: Websocket or Container missing");
+    // Build the schema-shaped body the /api/inputs contract expects
+    // then POST it like any third-party client.
+    const pos = { x: rosPoint.x, y: rosPoint.y, z: rosPoint.z };
+    let body;
+    if (msgType === 'Point') {
+        body = pos;
+    } else if (msgType === 'PointStamped') {
+        body = { point: pos };
+    } else if (msgType === 'Pose' || msgType === 'PoseStamped') {
+        const pose = { position: pos, orientation: { x: 0.0, y: 0.0, z: 0.0, w: 1.0 } };
+        body = (msgType === 'Pose') ? pose : { pose: pose };
+    } else {
+        console.warn(`Cannot publish point: unsupported type ${msgType}`);
         return;
     }
 
-    // Default Orientation
-    const defaultOrientation = { ori_x: 0.0, ori_y: 0.0, ori_z: 0.0, ori_w: 1.0 };
-    let messageData = {};
-
-    // Safely get frame_id (Default to 'map' if header is missing)
-    const frameId = (container.mapHeader && container.mapHeader.frame_id) ? container.mapHeader.frame_id : 'map';
-
-    if (msgType === 'Point' || msgType === 'PointStamped') {
-        messageData = rosPoint; // {x, y, z}
-    } else if (msgType === 'Pose' || msgType === 'PoseStamped') {
-        messageData = { ...rosPoint, ...defaultOrientation };
-    }
-
-    const payload = {
-        topic_name: targetTopic,
-        frame_id: frameId,
-        topic_type: msgType,
-        data: messageData
-    };
-
-    container.mapWs.send(JSON.stringify(payload));
-    console.log(`Published [${msgType}] to [${targetTopic}]`, payload);
+    fetch(`/api/inputs/${targetTopic}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    })
+        .then((r) => { if (!r.ok) console.error(`Publish to [${targetTopic}] failed: ${r.status}`); })
+        .catch((e) => console.error(`Publish to [${targetTopic}] error:`, e));
+    console.log(`Published [${msgType}] to [${targetTopic}]`, body);
 };
 
 
@@ -1061,7 +1072,7 @@ function setupInteractions(viewer, container) {
                 }
                 publishPoint(container, targetTopic, rosPoint, msgType);
             }
-            window.togglePublishPoint(state.btn);
+            togglePublishPoint(state.btn);
             return;
         }
 

--- a/ros_sugar/ui_node/static/ros_maps.js
+++ b/ros_sugar/ui_node/static/ros_maps.js
@@ -119,9 +119,12 @@ function zoomMap(topicName, zoomFactor) {
 }
 
 function readClickedPointTarget(form) {
-    // The target topic dropdown lists declared point-like UI inputs
-    // the value may live on a hidden input (uk-select) or the native select
-    const valueEl = form.querySelector('[name="clicked_point_topic"]');
+    // The target topic dropdown lists declared point-like UI inputs. Read the
+    // LIVE control the uk-select component keeps in sync (its hidden input or
+    // the native select).
+    const valueEl = form.querySelector(
+        'input[name="clicked_point_topic"], select[name="clicked_point_topic"]'
+    );
     if (!valueEl || !valueEl.value) return null;
     const topic = valueEl.value;
     // The declared msg type rides on the selected option's data-type attribute
@@ -208,21 +211,13 @@ function togglePublishPoint(btn) {
         }
         container.style.cursor = isTurningOn ? 'crosshair' : 'default';
 
-        // Determine Settings if Turning On
-        if (isTurningOn) {
-            if (btn.id === `${topicName}-publish-btn`) {
-                const settingsForm = document.getElementById(`${topicName}-settings-form`);
-                let target = state.settings || null;
-                if (!target && settingsForm) {
-                    target = readClickedPointTarget(settingsForm);
-                    if (target) state.settings = target;
-                }
-                if (target) state[btn.id] = { topic: target.topic, type: target.type };
-            } else {
-                const customTopic = btn.getAttribute('data-topic') || 'clicked_point';
-                const customType = btn.getAttribute('data-type') || 'PointStamped';
-                state[btn.id] = { topic: customTopic, type: customType };
-            }
+        // Custom buttons carry a fixed target on data attributes. The standard
+        // publish button has NO cached target: the settings dropdown is read
+        // live at click time so a changed selection is always respected.
+        if (isTurningOn && btn.id !== `${topicName}-publish-btn`) {
+            const customTopic = btn.getAttribute('data-topic') || 'clicked_point';
+            const customType = btn.getAttribute('data-type') || 'PointStamped';
+            state[btn.id] = { topic: customTopic, type: customType };
         }
     });
 }
@@ -234,24 +229,9 @@ function openMapSettings(topicName) {
     // Show Modal
     modal.style.display = 'grid';
 
-    // Restore Saved Values (if they exist)
-    const state = mapInteractionState[topicName];
-    if (state && state.settings) {
-        const form = document.getElementById(`${topicName}-settings-form`);
-        if (form) {
-            // Restore the target-topic dropdown (custom uk-select or native).
-            // Must find the HIDDEN NATIVE SELECT inside the custom component
-            const selectContainer = form.querySelector(`uk-select[name="clicked_point_topic"]`);
-            const nativeSelect = selectContainer
-                ? selectContainer.querySelector('select')
-                : form.querySelector(`select[name="clicked_point_topic"]`);
-            if (nativeSelect) {
-                nativeSelect.value = state.settings.topic;
-                // Dispatch change event so the Custom UI updates its text
-                nativeSelect.dispatchEvent(new Event('change', { bubbles: true }));
-            }
-        }
-    }
+    // NOTE: The target-topic dropdown needs no restore: the modal is only
+    // hidden/shown, so the DOM select keeps the user's selection, and the
+    // publish flow reads it live at click time.
 }
 
 function saveMapSettings(topicName) {
@@ -261,14 +241,6 @@ function saveMapSettings(topicName) {
     if (form) {
         // Initialize State
         if (!mapInteractionState[topicName]) mapInteractionState[topicName] = {};
-
-        // Save Publishing Settings (the section only exists when point-like
-        // inputs are declared in the UI)
-        const target = readClickedPointTarget(form);
-        if (target) {
-            mapInteractionState[topicName].settings = target;
-        }
-
         // Save Visual Settings
         if (!mapInteractionState[topicName].visuals) mapInteractionState[topicName].visuals = {};
 
@@ -1022,14 +994,17 @@ function publishPoint(container, targetTopic, rosPoint, msgType) {
     // Build the schema-shaped body the /api/inputs contract expects
     // then POST it like any third-party client.
     const pos = { x: rosPoint.x, y: rosPoint.y, z: rosPoint.z };
+    // Stamped messages carry the map's frame (the clicked coordinates are in
+    // it); the server fills the timestamp on publish.
+    const header = { frame_id: (container.mapHeader && container.mapHeader.frame_id) || '' };
     let body;
     if (msgType === 'Point') {
         body = pos;
     } else if (msgType === 'PointStamped') {
-        body = { point: pos };
+        body = { header: header, point: pos };
     } else if (msgType === 'Pose' || msgType === 'PoseStamped') {
         const pose = { position: pos, orientation: { x: 0.0, y: 0.0, z: 0.0, w: 1.0 } };
-        body = (msgType === 'Pose') ? pose : { pose: pose };
+        body = (msgType === 'Pose') ? pose : { header: header, pose: pose };
     } else {
         console.warn(`Cannot publish point: unsupported type ${msgType}`);
         return;
@@ -1075,13 +1050,21 @@ function setupInteractions(viewer, container) {
             const rosPoint = transformScreenToRos(container, mouseX, mouseY);
 
             if (rosPoint) {
-                let targetTopic = 'clicked_point';
-                let msgType = 'PointStamped';
-                if (state.btn && state[state.btn.id]) {
-                    targetTopic = state[state.btn.id].topic;
-                    msgType = state[state.btn.id].type;
+                // Standard button reads the settings dropdown LIVE so the
+                // latest selection always wins. Custom buttons keep their
+                // fixed data-attribute target.
+                let target = null;
+                if (state.btn && state.btn.id === `${topicName}-publish-btn`) {
+                    const form = document.getElementById(`${topicName}-settings-form`);
+                    if (form) target = readClickedPointTarget(form);
+                } else if (state.btn && state[state.btn.id]) {
+                    target = state[state.btn.id];
                 }
-                publishPoint(container, targetTopic, rosPoint, msgType);
+                if (target) {
+                    publishPoint(container, target.topic, rosPoint, target.type);
+                } else {
+                    notifyMapPublishError(topicName, 'no target topic selected in map settings');
+                }
             }
             togglePublishPoint(state.btn);
             return;

--- a/ros_sugar/ui_node/static/ros_maps.js
+++ b/ros_sugar/ui_node/static/ros_maps.js
@@ -118,6 +118,20 @@ function zoomMap(topicName, zoomFactor) {
     applyZoom(viewer, zoomFactor, null); // Null center means zoom to center of view
 }
 
+function readClickedPointTarget(form) {
+    // The target topic dropdown lists declared point-like UI inputs
+    // the value may live on a hidden input (uk-select) or the native select
+    const valueEl = form.querySelector('[name="clicked_point_topic"]');
+    if (!valueEl || !valueEl.value) return null;
+    const topic = valueEl.value;
+    // The declared msg type rides on the selected option's data-type attribute
+    let type = 'PointStamped';
+    for (const opt of form.querySelectorAll('option[data-type]')) {
+        if (opt.value === topic) { type = opt.dataset.type; break; }
+    }
+    return { topic: topic, type: type };
+}
+
 function togglePublishPoint(btn) {
     const mapElements = document.getElementsByName('map-canvas');
     if (mapElements.length === 0) {
@@ -198,22 +212,12 @@ function togglePublishPoint(btn) {
         if (isTurningOn) {
             if (btn.id === `${topicName}-publish-btn`) {
                 const settingsForm = document.getElementById(`${topicName}-settings-form`);
-                let targetTopic = 'clicked_point';
-                let msgType = 'PointStamped';
-
-                if (state.settings) {
-                    targetTopic = state.settings.topic;
-                    msgType = state.settings.type;
-                } else if (settingsForm) {
-                    const tInput = settingsForm.querySelector('[name="clicked_point_topic"]');
-                    let mInput = settingsForm.querySelector('input[name="clicked_point_type"]');
-                    if (!mInput) mInput = settingsForm.querySelector('select[name="clicked_point_type"]');
-
-                    if (tInput && tInput.value) targetTopic = tInput.value;
-                    if (mInput && mInput.value) msgType = mInput.value;
-                    state.settings = { topic: targetTopic, type: msgType };
+                let target = state.settings || null;
+                if (!target && settingsForm) {
+                    target = readClickedPointTarget(settingsForm);
+                    if (target) state.settings = target;
                 }
-                state[btn.id] = { topic: targetTopic, type: msgType };
+                if (target) state[btn.id] = { topic: target.topic, type: target.type };
             } else {
                 const customTopic = btn.getAttribute('data-topic') || 'clicked_point';
                 const customType = btn.getAttribute('data-type') || 'PointStamped';
@@ -235,25 +239,16 @@ function openMapSettings(topicName) {
     if (state && state.settings) {
         const form = document.getElementById(`${topicName}-settings-form`);
         if (form) {
-            // A. Restore Text Input
-            const tInput = form.querySelector('input[name="clicked_point_topic"]');
-            if (tInput) tInput.value = state.settings.topic;
-
-            // B. Restore Dropdown (Complex Component)
-            // We must find the HIDDEN NATIVE SELECT inside the custom component to update the UI
-            // Selector: Find the uk-select with this name, then find the native select inside it
-            const selectContainer = form.querySelector(`uk-select[name="clicked_point_type"]`);
-            if (selectContainer) {
-                const nativeSelect = selectContainer.querySelector('select');
-                if (nativeSelect) {
-                    nativeSelect.value = state.settings.type;
-                    // Dispatch change event so the Custom UI updates its text
-                    nativeSelect.dispatchEvent(new Event('change', { bubbles: true }));
-                }
-            } else {
-                // Fallback: try finding any select with that name
-                const simpleSelect = form.querySelector(`select[name="clicked_point_type"]`);
-                if (simpleSelect) simpleSelect.value = state.settings.type;
+            // Restore the target-topic dropdown (custom uk-select or native).
+            // Must find the HIDDEN NATIVE SELECT inside the custom component
+            const selectContainer = form.querySelector(`uk-select[name="clicked_point_topic"]`);
+            const nativeSelect = selectContainer
+                ? selectContainer.querySelector('select')
+                : form.querySelector(`select[name="clicked_point_topic"]`);
+            if (nativeSelect) {
+                nativeSelect.value = state.settings.topic;
+                // Dispatch change event so the Custom UI updates its text
+                nativeSelect.dispatchEvent(new Event('change', { bubbles: true }));
             }
         }
     }
@@ -267,20 +262,12 @@ function saveMapSettings(topicName) {
         // Initialize State
         if (!mapInteractionState[topicName]) mapInteractionState[topicName] = {};
 
-        // Save Publishing Settings
-        const pubTopic = form.querySelector('[name="clicked_point_topic"]').value;
-
-        // Handle Custom Select for Message Type
-        let typeValue = 'PointStamped';
-        const mInput = form.querySelector('input[name="clicked_point_type"]');
-        if (mInput) {
-            typeValue = mInput.value;
-        } else {
-            const sInput = form.querySelector('select[name="clicked_point_type"]');
-            if (sInput) typeValue = sInput.value;
+        // Save Publishing Settings (the section only exists when point-like
+        // inputs are declared in the UI)
+        const target = readClickedPointTarget(form);
+        if (target) {
+            mapInteractionState[topicName].settings = target;
         }
-
-        mapInteractionState[topicName].settings = { topic: pubTopic, type: typeValue };
 
         // Save Visual Settings
         if (!mapInteractionState[topicName].visuals) mapInteractionState[topicName].visuals = {};

--- a/ros_sugar/ui_node/static/ros_maps.js
+++ b/ros_sugar/ui_node/static/ros_maps.js
@@ -1016,6 +1016,21 @@ function applyZoom(viewer, factor, center) {
 /**
  * Helper method to publish a clicked point on a map canvas
  */
+function notifyMapPublishError(topic, detail) {
+    // Surface publish failures in the UI
+    const message = `Failed to publish map point to '${topic}': ${detail}`;
+    if (typeof UIkit !== 'undefined') {
+        UIkit.notification({
+            message: `<span uk-icon='icon: warning'></span> ${message}`,
+            status: 'danger',
+            pos: 'top-center',
+            timeout: 6000
+        });
+    } else {
+        console.error(message);
+    }
+}
+
 function publishPoint(container, targetTopic, rosPoint, msgType) {
     // Build the schema-shaped body the /api/inputs contract expects
     // then POST it like any third-party client.
@@ -1038,9 +1053,18 @@ function publishPoint(container, targetTopic, rosPoint, msgType) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
     })
-        .then((r) => { if (!r.ok) console.error(`Publish to [${targetTopic}] failed: ${r.status}`); })
-        .catch((e) => console.error(`Publish to [${targetTopic}] error:`, e));
-    console.log(`Published [${msgType}] to [${targetTopic}]`, body);
+        .then(async (r) => {
+            if (r.ok) {
+                console.log(`Published [${msgType}] to [${targetTopic}]`, body);
+                return;
+            }
+            let detail = `HTTP ${r.status}`;
+            try {
+                detail = (await r.json()).error || detail;
+            } catch (e) { /* keep the status text */ }
+            notifyMapPublishError(targetTopic, detail);
+        })
+        .catch((e) => notifyMapPublishError(targetTopic, e.message || 'network error'));
 };
 
 

--- a/ros_sugar/ui_node/static/video_manager.js
+++ b/ros_sugar/ui_node/static/video_manager.js
@@ -76,7 +76,7 @@ document.addEventListener("DOMContentLoaded", () => {
         frames.forEach((img) => {
             if (!img.id) return;
             if (!wsConnections.has(img.id)) {
-                const wsUrl = `${videoWsProtocol}//${window.location.host}/ws_${img.id}`;
+                const wsUrl = `${videoWsProtocol}//${window.location.host}/api/outputs/${img.id}`;
                 const conn = connectImageWebSocket(img, wsUrl, 0);
                 wsConnections.set(img.id, conn);
             }

--- a/ros_sugar/ui_node/ui_node.py
+++ b/ros_sugar/ui_node/ui_node.py
@@ -9,7 +9,7 @@ from functools import partial
 
 from ..config.base_attrs import BaseAttrs
 from ..config.base_validators import in_range
-from ..core.component import BaseComponent, BaseComponentConfig, Publisher
+from ..core.component import BaseComponent, BaseComponentConfig
 from .. import base_clients
 from ..io.callbacks import GenericCallback
 from ..io.topic import Topic
@@ -372,38 +372,21 @@ class UINode(BaseComponent):
         if self._ros_action_clients.get(action_name, None):
             self._ros_action_clients_feedback_callbacks[action_name] = ws_callback
 
-    def send_srv_call(self, srv_call_data: Dict) -> Tuple[bool, Any]:
-        """
-        Send a service call using the service request form data
+    def send_srv_call(self, srv_call_data: Dict) -> Any:
+        """Call a declared service client and return the raw ROS response.
+
+        ``srv_call_data`` must contain ``srv_name``; the remaining keys are the
+        request fields. The raw ROS response object or None is returned.
+
+        :param srv_call_data: ``{"srv_name": <name>, **request_fields}``.
+        :raises RuntimeError: If the service client is not ready.
+        :return: The raw ROS response message, or ``None``.
         """
         srv_name = srv_call_data.pop("srv_name")
-        if srv_name not in self._ros_service_clients:
-            return (False, f'Service client "{srv_name}" not found!')
-
-        try:
-            output = self._ros_service_clients[srv_name].send_request_from_dict(
-                request_fields=srv_call_data
-            )
-        except Exception as e:
-            return (
-                False,
-                f'Error occurred when sending service request to "{srv_name}": {e}',
-            )
-
-        if output:
-            # Parse response to display on UI
-            response_fields = self._ros_service_clients[
-                srv_name
-            ].client.srv_type.Response.get_fields_and_field_types()
-            # Format a response string with fields dictionary keys and actual response values
-            response_str = ""
-            for key in response_fields.keys():
-                response_str += f"{key} = {getattr(output, key)}, "
-            return (True, response_str)
-        return (
-            False,
-            f'Server Error - Service "{srv_name}" request send but no service response received',
-        )
+        client = self._ros_service_clients.get(srv_name)
+        if client is None:
+            raise RuntimeError(f"Service client '{srv_name}' is not ready")
+        return client.send_request_from_dict(request_fields=srv_call_data)
 
     def send_action_goal(self, action_goal_data: Dict) -> Tuple[bool, Any]:
         """
@@ -452,9 +435,7 @@ class UINode(BaseComponent):
             action_name, None
         ):
             # await feedback_func(feedback_data)
-            asyncio.run_coroutine_threadsafe(
-                feedback_func(feedback_data), self.loop
-            )
+            asyncio.run_coroutine_threadsafe(feedback_func(feedback_data), self.loop)
 
     def cancel_action(self, action_name: str) -> Tuple[bool, str]:
         """Cancel ongoing action goal
@@ -479,71 +460,34 @@ class UINode(BaseComponent):
         """
         self.destroy_timer(self._ros_action_clients_feedback_timers[action_name])
 
-    def publish_data(self, data: Any):
-        """
-        Publish data to input topics if any
+    def publish_data(self, data: Dict) -> int:
+        """Publish a message on a declared input topic from a field dict.
+
+        ``data`` must contain ``topic_name``; the remaining keys are message
+        fields matching the topic's ROS message schema (as advertised by the
+        API discovery document)
+
+        :param data: ``{"topic_name": <name>, **message_fields}``.
+        :raises RuntimeError: If the publisher for the topic is not ready.
+        :raises ValueError: If the fields cannot be converted to the message.
+        :return: The current number of subscribers on the topic.
         """
         topic_name = data.pop("topic_name")
-        topic_type_str = data.pop("topic_type")
-        frame_id = data.pop("frame_id", None)
-        topic_type = getattr(supported_types, topic_type_str, None)
-
-        if not topic_type:
-            return self._return_error(
-                f'Data type "{topic_type_str}" not found in supported types. Make sure the UI element is created correctly'
-            )
-
-        if self.count_subscribers(topic_name) == 0:
-            return self._return_error(
-                f'No subscribers found for the topic "{topic_name}". Please check the topic name and re-send data'
-            )
-
+        data.pop("topic_type", None)  # type comes from the declared publisher
+        publisher = self.publishers_dict.get(topic_name)
+        if publisher is None or publisher._publisher is None:
+            raise RuntimeError(f"Publisher for input topic '{topic_name}' is not ready")
         try:
-            output = topic_type.convert_ui_dict(
-                data
-            )  # Convert to publisher compatible data
-        except NotImplementedError:
-            return self._return_error(
-                f'Data type "{topic_type_str}" does not implement a converter'
+            msg = supported_types.set_ros_msg_from_dict(
+                publisher.output_topic.ros_msg_type, data
             )
         except Exception as e:
-            return self._return_error(
-                f'Error occurred when converting {data} to Sugar type "{topic_type_str}": {e}'
-            )
-        kwargs = {"output": output}
-
-        # Add the data frame_id if it is sent
-        if frame_id:
-            kwargs["frame_id"] = frame_id
-
-        try:
-            if publisher := self.publishers_dict.get(topic_name, None):
-                # Confirm that the topic type was not updated dynamically in the UI
-                if publisher.output_topic.msg_type.__name__ == topic_type_str:
-                    publisher.publish(**kwargs)
-                    return
-                else:
-                    # Destroy the old publisher to create a new one
-                    self.destroy_publisher(publisher._publisher)
-                    self.get_logger().debug(
-                        f"Destroying old publisher for {topic_name} of type {publisher.output_topic.msg_type.__name__}"
-                    )
-            # Handle creating publishers for dynamically added or modified outputs in the UI
-            self.publishers_dict[topic_name] = Publisher(
-                Topic(name=topic_name, msg_type=topic_type_str),
-                node_name=self.node_name,
-            )
-            self.publishers_dict[topic_name].set_node_name(self.node_name)
-            # Set ROS publisher for each output publisher
-            self.publishers_dict[topic_name].set_publisher(
-                self._add_ros_publisher(self.publishers_dict[topic_name])
-            )
-            self.publishers_dict[topic_name].publish(**kwargs)
-            return
-        except Exception as e:
-            self.get_logger().error(
-                f"Error publishing UI input data to topic {topic_name}: {e}"
-            )
+            raise ValueError(
+                f"Cannot build a {publisher.output_topic.msg_type.__name__} "
+                f"message from {data}: {e}"
+            ) from e
+        publisher._publisher.publish(msg)
+        return self.count_subscribers(topic_name)
 
     def _execution_step(self):
         """

--- a/ros_sugar/ui_node/ui_node.py
+++ b/ros_sugar/ui_node/ui_node.py
@@ -5,7 +5,6 @@ import os
 from attr import define, field, Factory
 import json
 import importlib
-from functools import partial
 
 from ..config.base_attrs import BaseAttrs
 from ..config.base_validators import in_range
@@ -165,6 +164,38 @@ class UINode(BaseComponent):
     def get_latest_output(self, topic_name: str) -> Any:
         """Return the most recent UI content for an output topic, or ``None``."""
         return self._latest_output.get(topic_name)
+
+    def get_action_feedback(self, action_name: str) -> Optional[Dict]:
+        """Return the latest UI elements for an action client, or ``None``.
+
+        The returned dict has ``status``, ``feedback`` (a raw ROS message or
+        ``None``), ``timestep``, ``feedback_timeout`` and ``duration_secs``
+        """
+        client = self._ros_action_clients.get(action_name)
+        if client is None:
+            return None
+        return client.get_ui_elements()
+
+    def add_action_feedback_listener(
+        self, action_name: str, listener: Callable[[], None]
+    ) -> bool:
+        """Register a zero-arg ``listener`` for action feedback.
+
+        :return: ``False`` if the action client is not ready.
+        """
+        client = self._ros_action_clients.get(action_name)
+        if client is None:
+            return False
+        client.add_feedback_listener(listener)
+        return True
+
+    def remove_action_feedback_listener(
+        self, action_name: str, listener: Callable[[], None]
+    ) -> None:
+        """Remove a previously registered action feedback listener."""
+        client = self._ros_action_clients.get(action_name)
+        if client is not None:
+            client.remove_feedback_listener(listener)
 
     @property
     def _client_inputs_json(self) -> str:
@@ -388,69 +419,35 @@ class UINode(BaseComponent):
             raise RuntimeError(f"Service client '{srv_name}' is not ready")
         return client.send_request_from_dict(request_fields=srv_call_data)
 
-    def send_action_goal(self, action_goal_data: Dict) -> Tuple[bool, Any]:
-        """
-        Send a service call using the service request form data
+    def send_action_goal(self, action_goal_data: Dict) -> Optional[bool]:
+        """Send a goal to a declared action client.
+
+        ``action_goal_data`` must contain ``action_name``; the remaining keys
+        are the goal fields.
+
+        :param action_goal_data: ``{"action_name": <name>, **goal_fields}``.
+        :raises RuntimeError: If the action client is not ready.
+        :return: True if the goal was accepted by the action server.
         """
         action_name = action_goal_data.pop("action_name")
-        if action_name not in self._ros_action_clients:
-            return (False, f'Action client "{action_name}" not found!')
-
-        try:
-            sent_done = self._ros_action_clients[action_name].send_request_from_dict(
-                request_fields=action_goal_data, wait_until_first_feedback=False
-            )
-        except Exception as e:
-            return (
-                False,
-                f'Error occurred when sending service request to "{action_name}": {e}',
-            )
-
-        if sent_done:
-            # If goal is sent, start a timer to send the feedback to the websocket
-            self._ros_action_clients_feedback_timers[action_name] = self.create_timer(
-                timer_period_sec=self.config.feedback_update_period,
-                callback=partial(
-                    self._action_feedback_callback, action_name=action_name
-                ),
-            )
-            return (True, f"Starting requested action {action_name}...")
-        return (
-            False,
-            f'Server Error - Was not able to send goal for action "{action_name}"',
+        client = self._ros_action_clients.get(action_name)
+        if client is None:
+            raise RuntimeError(f"Action client '{action_name}' is not ready")
+        return client.send_request_from_dict(
+            request_fields=action_goal_data, wait_until_first_feedback=False
         )
 
-    def _action_feedback_callback(self, action_name: str):
-        """Get feedback message from action (if available)
-
-        :param action_name: Action name
-        :type action_name: str
-        :return: Feedback Info
-        :rtype: Optional[str]
-        """
-        if action_name not in self._ros_action_clients:
-            return
-        feedback_data = self._ros_action_clients[action_name].get_ui_elements()
-        if feedback_func := self._ros_action_clients_feedback_callbacks.get(
-            action_name, None
-        ):
-            # await feedback_func(feedback_data)
-            asyncio.run_coroutine_threadsafe(feedback_func(feedback_data), self.loop)
-
     def cancel_action(self, action_name: str) -> Tuple[bool, str]:
-        """Cancel ongoing action goal
+        """Cancel the ongoing goal of a declared action client.
 
-        :param action_name: Action name
-        :type action_name: str
-        :return: If action is cancelled, Log message
-        :rtype: (bool, str)
+        :param action_name: Action name.
+        :raises RuntimeError: If the action client is not ready.
+        :return: ``(cancelled, message)``.
         """
-        if action_name not in self._ros_action_clients:
-            return (
-                True,
-                f"Action cancellation is not possible: '{action_name}' is not found",
-            )
-        return self._ros_action_clients[action_name].cancel_request()
+        client = self._ros_action_clients.get(action_name)
+        if client is None:
+            raise RuntimeError(f"Action client '{action_name}' is not ready")
+        return client.cancel_request()
 
     def cleanup_action(self, action_name: str) -> None:
         """Destroy the action feedback timer. Called when the action has completed or aborted

--- a/ros_sugar/ui_node/ui_node.py
+++ b/ros_sugar/ui_node/ui_node.py
@@ -465,6 +465,20 @@ class UINode(BaseComponent):
         publisher._publisher.publish(msg)
         return self.count_subscribers(topic_name)
 
+    def publish_audio(self, topic_name: str, audio_b64: str) -> int:
+        """Publish base64-encoded audio to a declared Audio input topic.
+
+        :param topic_name: Name of a declared Audio input topic.
+        :param audio_b64: Base64-encoded audio bytes.
+        :raises RuntimeError: If the publisher for the topic is not ready.
+        :return: The current number of subscribers on the topic.
+        """
+        publisher = self.publishers_dict.get(topic_name)
+        if publisher is None or publisher._publisher is None:
+            raise RuntimeError(f"Publisher for input topic '{topic_name}' is not ready")
+        publisher.publish(output=audio_b64)
+        return self.count_subscribers(topic_name)
+
     def _execution_step(self):
         """
         Main execution of the component, executed at each timer tick with rate 'loop_rate' from config

--- a/ros_sugar/ui_node/ui_node.py
+++ b/ros_sugar/ui_node/ui_node.py
@@ -10,7 +10,6 @@ from ..config.base_attrs import BaseAttrs
 from ..config.base_validators import in_range
 from ..core.component import BaseComponent, BaseComponentConfig
 from .. import base_clients
-from ..io.callbacks import GenericCallback
 from ..io.topic import Topic
 from ..base_clients import (
     ServiceClientHandler,
@@ -22,7 +21,6 @@ from ..io import supported_types
 from automatika_ros_sugar.srv import ChangeParameters
 
 from rclpy.logging import get_logger
-from std_msgs.msg import Header
 
 
 @define
@@ -113,10 +111,10 @@ class UINode(BaseComponent):
         self._ros_action_clients_feedback_callbacks: Dict[str, Callable] = {}
         self._ros_action_clients_feedback_timers: Dict = {}
 
-        # Latest UI content per output topic name. The API streams outputs by
-        # sampling this (which lets multiple clients consume the same topic at
-        # independent rates)
-        self._latest_output: Dict[str, Any] = {}
+        # Memoized UI content per output topic: name -> (source msg, ui content).
+        # Computed lazily from the topic's callback (self.callbacks[name]) only
+        # when a client consumes it.
+        self._output_memo: Dict[str, Any] = {}
 
         self.config: UINodeConfig
 
@@ -162,8 +160,27 @@ class UINode(BaseComponent):
         return self._ros_action_clients
 
     def get_latest_output(self, topic_name: str) -> Any:
-        """Return the most recent UI content for an output topic, or ``None``."""
-        return self._latest_output.get(topic_name)
+        """Return UI content for an output topic's latest message, or ``None``.
+
+        Asks the topic's callback (which already holds the latest message) for
+        its UI content on demand, and memoizes the result per message so
+        expensive conversions only run when a client is consuming the topic.
+        """
+        callback = self.callbacks.get(topic_name)
+        if callback is None or callback.msg is None:
+            return None
+        cached_msg, cached_content = self._output_memo.get(topic_name, (None, None))
+        if cached_msg is callback.msg:
+            return cached_content
+        try:
+            content = callback._get_ui_content()
+        except Exception as e:
+            get_logger(self.node_name).error(
+                f"Error computing UI content for '{topic_name}': {e}"
+            )
+            return None
+        self._output_memo[topic_name] = (callback.msg, content)
+        return content
 
     def get_action_feedback(self, action_name: str) -> Optional[Dict]:
         """Return the latest UI elements for an action client, or ``None``.
@@ -288,44 +305,6 @@ class UINode(BaseComponent):
                 get_logger(self.node_name).warning(
                     f"Error parsing action clients inputs: {e}"
                 )
-
-    def _return_error(self, error_msg: str):
-        """Return error msg to the UI"""
-        self.get_logger().error(error_msg)
-        payload = {"type": "error", "payload": error_msg}
-        asyncio.run_coroutine_threadsafe(
-            self.default_websocket_callback(payload), self.loop
-        )
-
-    def _add_ros_subscriber(self, callback: GenericCallback):
-        """Override subscriber creation to cache the latest UI content per
-        output topic, which the API streams to clients.
-        :param callback:
-        :type callback: GenericCallback
-        """
-
-        def _ui_callback(msg) -> None:
-            callback.msg = msg
-            if hasattr(msg, "header") and isinstance(msg.header, Header):
-                callback._frame_id = msg.header.frame_id
-            try:
-                ui_content = callback._get_ui_content()
-            except Exception as e:
-                return self._return_error(f"Topic callback error: {e}")
-            # Cache the latest content for the API's rate-sampled streaming.
-            self._latest_output[callback.input_topic.name] = ui_content
-
-        _subscriber = self.create_subscription(
-            msg_type=callback.input_topic.ros_msg_type,
-            topic=callback.input_topic.name,
-            qos_profile=callback.input_topic.qos_profile.to_ros(),
-            callback=_ui_callback,
-            callback_group=self.callback_group,
-        )
-        self.get_logger().debug(
-            f"Started subscriber to topic: {callback.input_topic.name} of type {callback.input_topic.msg_type.__name__}"
-        )
-        return _subscriber
 
     def custom_on_activate(self):
         """Custom activation configuration"""

--- a/ros_sugar/ui_node/ui_node.py
+++ b/ros_sugar/ui_node/ui_node.py
@@ -1,6 +1,4 @@
 from typing import Dict, Optional, Sequence, Any, Callable, Union, Tuple, List
-import threading
-import asyncio
 import os
 from attr import define, field, Factory
 import json
@@ -69,20 +67,6 @@ class UINode(BaseComponent):
             str, base_clients.ServiceClientHandler
         ] = {}
 
-        # Initialize websocket callbacks
-        self.default_websocket_callback: Callable = lambda *args, **kwargs: (
-            asyncio.sleep(0)
-        )
-
-        try:
-            self.loop = asyncio.get_running_loop()
-        except RuntimeError:
-            self.loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(self.loop)
-            self.loop_thread = threading.Thread(
-                target=self.loop.run_forever, daemon=True
-            )
-
         topic_inputs = (
             [inp for inp in inputs if isinstance(inp, Topic)] if inputs else []
         )
@@ -107,14 +91,15 @@ class UINode(BaseComponent):
 
         self._ros_service_clients: Dict[str, ServiceClientHandler] = {}
         self._ros_action_clients: Dict[str, ActionClientHandler] = {}
-        # Used to store callbacks for active clients
-        self._ros_action_clients_feedback_callbacks: Dict[str, Callable] = {}
-        self._ros_action_clients_feedback_timers: Dict = {}
 
         # Memoized UI content per output topic: name -> (source msg, ui content).
-        # Computed lazily from the topic's callback (self.callbacks[name]) only
-        # when a client consumes it.
+        # Computed lazily from the topic's callback only when a client
+        # consumes it.
         self._output_memo: Dict[str, Any] = {}
+
+        # Per-output-topic message listeners: name -> set of zero-arg callables
+        # fired on each received message (used to push updates to clients).
+        self._output_listeners: Dict[str, set] = {}
 
         self.config: UINodeConfig
 
@@ -155,9 +140,6 @@ class UINode(BaseComponent):
             }
             clients_configs_dicts.append(config_dict)
         return clients_configs_dicts
-
-    def get_active_action_clients(self) -> Dict[str, ActionClientHandler]:
-        return self._ros_action_clients
 
     def get_latest_output(self, topic_name: str) -> Any:
         """Return UI content for an output topic's latest message, or ``None``.
@@ -213,6 +195,49 @@ class UINode(BaseComponent):
         client = self._ros_action_clients.get(action_name)
         if client is not None:
             client.remove_feedback_listener(listener)
+
+    def _notify_output_listeners(self, topic_name: str) -> None:
+        """Fan out a new message on ``topic_name`` to its registered listeners."""
+        for listener in list(self._output_listeners.get(topic_name, ())):
+            try:
+                listener()
+            except Exception:
+                pass
+
+    def add_output_listener(
+        self, topic_name: str, listener: Callable[[], None]
+    ) -> bool:
+        """Register a zero-arg ``listener`` fired on every message received on
+        an output topic.
+
+        :return: ``False`` if the output topic has no callback.
+        """
+        callback = self.callbacks.get(topic_name)
+        if callback is None:
+            return False
+        listeners = self._output_listeners.setdefault(topic_name, set())
+        if not listeners:
+            # First listener for this topic: wire the callback's message hook.
+            callback.on_callback_execute(
+                lambda **_: self._notify_output_listeners(topic_name),
+                get_processed=False,
+            )
+        listeners.add(listener)
+        return True
+
+    def remove_output_listener(
+        self, topic_name: str, listener: Callable[[], None]
+    ) -> None:
+        """Remove a previously registered output message listener."""
+        listeners = self._output_listeners.get(topic_name)
+        if not listeners:
+            return
+        listeners.discard(listener)
+        if not listeners:
+            # No listeners left: unwire the callback's message hook.
+            callback = self.callbacks.get(topic_name)
+            if callback is not None:
+                callback.on_callback_execute(None)
 
     @property
     def _client_inputs_json(self) -> str:
@@ -331,10 +356,6 @@ class UINode(BaseComponent):
                 client_node=self, config=inp
             )
 
-        # Start loop thread if necessary
-        if hasattr(self, "loop_thread"):
-            self.loop_thread.start()
-
         return super().custom_on_activate()
 
     def custom_on_deactivate(self):
@@ -355,15 +376,6 @@ class UINode(BaseComponent):
 
         return super().custom_on_deactivate()
 
-    def attach_websocket_callback(
-        self, ws_callback: Callable, topic_type: Optional[str] = None
-    ):
-        """Adds websocket callback to listeners of outputs"""
-        if topic_type:
-            setattr(self, f"{topic_type}_callback", ws_callback)
-        else:
-            self.default_websocket_callback = ws_callback
-
     def update_configs(self, new_configs: Dict):
         self.get_logger().debug("Updating configs")
         component_name = new_configs.pop("component_name")
@@ -377,10 +389,6 @@ class UINode(BaseComponent):
             req_msg=srv_request
         )
         return result
-
-    def attach_client_feedback_callback(self, ws_callback, action_name: str):
-        if self._ros_action_clients.get(action_name, None):
-            self._ros_action_clients_feedback_callbacks[action_name] = ws_callback
 
     def send_srv_call(self, srv_call_data: Dict) -> Any:
         """Call a declared service client and return the raw ROS response.
@@ -427,14 +435,6 @@ class UINode(BaseComponent):
         if client is None:
             raise RuntimeError(f"Action client '{action_name}' is not ready")
         return client.cancel_request()
-
-    def cleanup_action(self, action_name: str) -> None:
-        """Destroy the action feedback timer. Called when the action has completed or aborted
-
-        :param action_name: _description_
-        :type action_name: str
-        """
-        self.destroy_timer(self._ros_action_clients_feedback_timers[action_name])
 
     def publish_data(self, data: Dict) -> int:
         """Publish a message on a declared input topic from a field dict.

--- a/ros_sugar/ui_node/ui_node.py
+++ b/ros_sugar/ui_node/ui_node.py
@@ -36,6 +36,15 @@ class UINodeConfig(BaseComponentConfig):
     feedback_update_period: float = field(
         default=1.0, validator=in_range(min_value=1e-3, max_value=1e3)
     )  # 1 second ui feedback update rate
+    # Default rate (Hz) at which the JSON API streams output topics to a
+    # connected client when it does not request one explicitly.
+    api_stream_default_rate: float = field(
+        default=10.0, validator=in_range(min_value=1e-3, max_value=1e3)
+    )
+    # Hard upper bound (Hz) for a client-requested API stream rate.
+    api_max_stream_rate: float = field(
+        default=30.0, validator=in_range(min_value=1e-3, max_value=1e3)
+    )
 
 
 class UINode(BaseComponent):

--- a/ros_sugar/ui_node/ui_node.py
+++ b/ros_sugar/ui_node/ui_node.py
@@ -114,6 +114,11 @@ class UINode(BaseComponent):
         self._ros_action_clients_feedback_callbacks: Dict[str, Callable] = {}
         self._ros_action_clients_feedback_timers: Dict = {}
 
+        # Latest UI content per output topic name. The API streams outputs by
+        # sampling this (which lets multiple clients consume the same topic at
+        # independent rates)
+        self._latest_output: Dict[str, Any] = {}
+
         self.config: UINodeConfig
 
     def srv_clients_inputs_dicts(self) -> List[Dict]:
@@ -156,6 +161,10 @@ class UINode(BaseComponent):
 
     def get_active_action_clients(self) -> Dict[str, ActionClientHandler]:
         return self._ros_action_clients
+
+    def get_latest_output(self, topic_name: str) -> Any:
+        """Return the most recent UI content for an output topic, or ``None``."""
+        return self._latest_output.get(topic_name)
 
     @property
     def _client_inputs_json(self) -> str:
@@ -258,31 +267,22 @@ class UINode(BaseComponent):
         )
 
     def _add_ros_subscriber(self, callback: GenericCallback):
-        """Overrides creating subscribers to run the ui callback instead of the main callback
+        """Override subscriber creation to cache the latest UI content per
+        output topic, which the API streams to clients.
         :param callback:
         :type callback: GenericCallback
         """
-        payload = {
-            "type": callback.input_topic.msg_type.__name__,
-            "topic": callback.input_topic.name,
-        }
-
-        setattr(self, f"{payload['type']}_callback", None)
 
         def _ui_callback(msg) -> None:
-            ws_callback = (
-                getattr(self, f"{payload['type']}_callback")
-                or self.default_websocket_callback
-            )
             callback.msg = msg
             if hasattr(msg, "header") and isinstance(msg.header, Header):
                 callback._frame_id = msg.header.frame_id
             try:
                 ui_content = callback._get_ui_content()
-                payload["payload"] = ui_content
             except Exception as e:
                 return self._return_error(f"Topic callback error: {e}")
-            asyncio.run_coroutine_threadsafe(ws_callback(payload, msg=msg), self.loop)
+            # Cache the latest content for the API's rate-sampled streaming.
+            self._latest_output[callback.input_topic.name] = ui_content
 
         _subscriber = self.create_subscription(
             msg_type=callback.input_topic.ros_msg_type,

--- a/ros_sugar/ui_node/ui_node.py
+++ b/ros_sugar/ui_node/ui_node.py
@@ -462,6 +462,13 @@ class UINode(BaseComponent):
                 f"Cannot build a {publisher.output_topic.msg_type.__name__} "
                 f"message from {data}: {e}"
             ) from e
+        # Stamp headers the client left unset because clients cant know ROS time
+        if (
+            hasattr(msg, "header")
+            and msg.header.stamp.sec == 0
+            and msg.header.stamp.nanosec == 0
+        ):
+            msg.header.stamp = self.get_clock().now().to_msg()
         publisher._publisher.publish(msg)
         return self.count_subscribers(topic_name)
 

--- a/scripts/ui_node_executable
+++ b/scripts/ui_node_executable
@@ -10,6 +10,7 @@ from ros_sugar.launch.executable import setup_component, run_component
 
 from ros_sugar.ui_node import UINode, UINodeConfig
 from ros_sugar.ui_node.frontend import FHApp
+from ros_sugar.ui_node.api import register_api
 import ros_sugar.ui_node.elements as elements
 from ros_sugar.utils import logger
 from ros_sugar.supported_types import ros_msg_to_str
@@ -508,6 +509,9 @@ def main():
             ros_node.publish_data(data=data)
         else:
             ros_node.publish_data(data=data)
+
+    # Register a JSON / WebSocket API on the same app
+    register_api(app, ros_node)
 
     # Check if SSL certificates exist
     if not (

--- a/scripts/ui_node_executable
+++ b/scripts/ui_node_executable
@@ -1,69 +1,22 @@
 #!/usr/bin/env python3
-import json
-from typing import Dict
-from pathlib import Path
-from functools import partial
 import argparse
+import json
 import threading
+from pathlib import Path
+
 import uvicorn
+
 from ros_sugar.launch.executable import setup_component, run_component
-
 from ros_sugar.ui_node import UINode, UINodeConfig
-from ros_sugar.ui_node.frontend import FHApp
-from ros_sugar.ui_node.api import register_api
-import ros_sugar.ui_node.elements as elements
+from ros_sugar.ui_node.api import build_api_app
 from ros_sugar.utils import logger
-from ros_sugar.supported_types import ros_msg_to_str
-
-import base64
-import array
-import numpy as np
-from rosidl_runtime_py.convert import message_to_ordereddict
-
-
-def _marker_on_map(payload, **_):
-    """Helper callback to parse a map Maker data from point-like message"""
-    content = payload.get("payload", None)
-    if content is None:
-        return
-    msg_type = payload.get("type")
-    try:
-        if msg_type == "Path":
-            # Content data will have the filtered path points
-            return {
-                "op": "path",
-                "id": payload.get("topic", ""),
-                "frame_id": content.get("frame_id", ""),
-                "points": content.get("data"),
-            }
-        if msg_type in ["Point", "PointStamped"]:
-            # Content data will have an array of [x, y, z]
-            return {
-                "op": "overlay",
-                "id": payload.get("topic", ""),
-                "frame_id": content.get("frame_id", ""),
-                "x": content.get("data")[0],
-                "y": content.get("data")[1],
-            }
-        if msg_type in ["Pose", "PoseStamped", "Odometry"]:
-            # Content data will have an array of [x, y, z, heading] for Pose, PoseStamped
-            # and [x, y, z, heading] for Odometry
-            return {
-                "op": "overlay",
-                "id": payload.get("topic", ""),
-                "frame_id": content.get("frame_id", ""),
-                "x": content.get("data")[0],
-                "y": content.get("data")[1],
-                "theta": content.get("data")[3],
-            }
-    except Exception:
-        logger.error(f"Error parsing UI input from topic type {msg_type}")
 
 
 def main():
     """
-    Executable to run a component as a ros node.
-    Used to start a node using Launcher
+    Run the UI node: a ROS node plus the JSON/WebSocket API server.
+
+    Optionally run the FastHTML browser UI if dependencies installed.
     """
     logger.info("Starting UI Node executable")
 
@@ -92,19 +45,7 @@ def main():
 
     system_info = json.loads(args.system_info) if args.system_info else None
 
-    fh = FHApp(
-        ros_node_config.components,
-        ros_node.out_topics,  # Inputs from the client to the ros node
-        ros_node.in_topics,  # Outputs to the client from the ros node
-        srv_clients_configs=ros_node.srv_clients_inputs_dicts(),
-        action_clients_configs=ros_node.action_clients_inputs_dicts(),
-        additional_input_elements=additional_input_elements,  # Additional UI input elements from derived packages
-        additional_output_elements=additional_output_elements,  # Additional UI output elements from derived packages
-        hide_settings_panel=ros_node_config.hide_settings,
-        system_info=system_info,
-    )  # inputs and outputs are reversed
-    app, _ = fh.get_app()
-
+    # Spin the ROS node in a background thread
     ros_thread = threading.Thread(
         target=run_component,
         args=[ros_node],
@@ -112,406 +53,27 @@ def main():
     )
     ros_thread.start()
 
-    # Routes for the app backend
-    @app.get("/")
-    def _():
-        """Serves the main application page."""
-        fh.toggle_settings = False
-        fh.toggle_system = False
-        return fh.get_main_page()
+    # Build the optional FastHTML browser app. Mounts under "/"
+    try:
+        from ros_sugar.ui_node.browser import build_browser_app
 
-    @app.get("/settings/show")
-    def _():
-        """Show the settings tabs"""
-        fh.toggle_system = False
-        fh.toggle_settings = not fh.toggle_settings
-        return fh.get_main_page()
-
-    @app.get("/system/show")
-    def _():
-        """Show the system visualization"""
-        fh.toggle_settings = False
-        fh.toggle_system = not fh.toggle_system
-        return fh.get_main_page()
-
-    @app.get("/system/component/{name}")
-    def _(name: str):
-        """Return detail panel for a specific component"""
-        comp_meta = (
-            fh.system_info.get("components", {}).get(name, {}) if fh.system_info else {}
+        browser_app = build_browser_app(
+            ros_node,
+            additional_input_elements=additional_input_elements,
+            additional_output_elements=additional_output_elements,
+            system_info=system_info,
         )
-        return elements.system_component_detail(
-            name,
-            comp_meta,
-            fh.configs.get(name, {}),
-            fh.system_info,
+    except ModuleNotFoundError as e:
+        logger.warning(
+            f"Browser UI dependencies not installed ({e}). "
+            "Serving the JSON/WebSocket API only. "
+            " For browser UI please install FastHTML and MonsterUI with: "
+            "`pip install python-fasthtml monsterui`"
         )
+        browser_app = None
 
-    @app.get("/system/event/{event_short_id}")
-    def _(event_short_id: str):
-        """Return detail panel for a specific event"""
-        if not fh.system_info:
-            return Div("No system data available")
-        for ev in fh.system_info.get("events", []):
-            if ev["id"][:8] == event_short_id:
-                return elements.system_event_detail(ev)
-        return Div(f"Event '{event_short_id}' not found")
-
-    @app.post("/settings/submit")
-    async def _(request, session):
-        """Update Settings"""
-        # update config
-        # update UI
-        form_data = await request.form()
-        result = ros_node.update_configs(dict(form_data.items()))
-        success = all(result.success)
-        if not success:
-            item_names = list(form_data.keys())
-            error_msg = "Error in updating the following settings values: \n"
-            for key in range(len(result.success)):
-                if not result.success[key]:
-                    error_msg += f"{item_names[key + 1]}: {result.error_msg[key]}\n"
-            fh.toasting(error_msg, session, "error", duration=100000)
-        else:
-            fh.toasting("Settings changed successfully", session, "success")
-            # Persist the new configuration
-            fh.update_configs_from_data(dict(form_data.items()))
-        return fh.get_main_page()
-
-    @app.post("/service/call")
-    async def _(request, session):
-        """Send a ROS2 service call from the client"""
-        form_data = await request.form()
-        data_dict = dict(form_data.items())
-        # Add request to logging card
-        elements.update_logging_card(
-            fh.outputs_log,
-            f"Sending service call: '{data_dict}'",
-            data_type="String",
-            data_src="user",
-        )
-        result_code, result = ros_node.send_srv_call(data_dict)
-        if not result_code:
-            fh.toasting(result, session, "error", duration=100000)
-        else:
-            fh.toasting(
-                f"Service returned response: {result}", session, "info", duration=100000
-            )
-        # Add response to logging card
-        elements.update_logging_card(
-            fh.outputs_log,
-            f"Service returned response: '{result}'",
-            data_type="String",
-            data_src="robot",
-        )
-        return fh.get_main_page()
-
-    @app.post("/action/goal")
-    async def _(request, session):
-        """Send a ROS2 action goal from the client"""
-        form_data = await request.form()
-        data_dict = dict(form_data.items())
-        action_name = data_dict.get("action_name", "")
-        if (
-            action_name in fh.action_clients_ft
-            and fh.action_clients_ft[action_name].is_active()
-        ):
-            fh.toasting(
-                "Cannot send a new goal while the current goal is still active. Cancel ongoing goal first.",
-                session,
-                "error",
-                duration=100000,
-            )
-            return fh.get_main_page()
-        result_code, result = ros_node.send_action_goal(data_dict)
-        if not result_code:
-            fh.toasting(result, session, "error", duration=100000)
-        else:
-            fh.toasting(f"Task sent: {result}", session, "info", duration=100000)
-            fh.action_clients_ft[action_name].update(
-                status="accepted",
-                duration=0,
-            )
-            fh.action_clients_ft[action_name].total_calls += 1
-            # display the action on the main logging card
-            goal_payload = {k: v for k, v in data_dict.items() if k != "action_name"}
-            elements.update_logging_card(
-                fh.outputs_log,
-                f"Start Task '{action_name}': {goal_payload}",
-                data_type="String",
-                data_src="user",
-            )
-        return fh.get_main_page()
-
-    @app.post("/action/cancel")
-    async def _(request, session):
-        """Cancel a ROS2 action goal from the client"""
-        form_data = await request.form()
-        data_dict = dict(form_data.items())
-        action_name = data_dict.get("action_name")
-        result_code, result = ros_node.cancel_action(action_name)
-        if not result_code:
-            fh.toasting(result, session, "error", duration=100000)
-        else:
-            fh.toasting(f"{result}", session, "info", duration=100000)
-            # display cancellation request on the main logging card
-            elements.update_logging_card(
-                fh.outputs_log,
-                f"Cancel Task '{action_name}'.",
-                data_type="String",
-                data_src="user",
-            )
-        return fh.get_main_page()
-
-    # -- WS handling --
-    async def log_data(send, data: str, data_type: str, data_src: str):
-        """Send data to log"""
-
-        await send(
-            elements.update_logging_card(
-                fh.outputs_log,
-                data,
-                data_type,
-                data_src,
-            )
-        )
-
-    async def on_disconn(session):
-        """Message for disconnection"""
-        fh.toasting(
-            "Disconnected from the robot. Check if the recipe is running or refresh the page",
-            session,
-            toast_type="error",
-        )
-
-    async def on_conn_stream(ws, send, topic_type: str):
-        """When a client connects, register its callback."""
-
-        # Callback function for ROS node
-        async def stream_callback(data: Dict, **_):
-            if data["type"] == "error":
-                await log_data(
-                    send, data["payload"], data_type=data["type"], data_src=data["type"]
-                )
-            else:
-                await ws.send_json(data)
-
-        ros_node.attach_websocket_callback(stream_callback, topic_type)
-
-    async def on_conn_map(ws, _, map_topic_type: str):
-        """When a client connects, register its callback."""
-
-        # Callback function for ROS node
-        async def map_callback(payload, msg):
-            # --- CASE 1: Incoming marker data ----
-            # If the incoming data is for a marker
-            if payload.get("type", None) != "OccupancyGrid":
-                response = _marker_on_map(payload)
-                if response:
-                    await ws.send_json(response)
-                return
-
-            # --- CASE 2: Incoming MAP data ----
-            # Convert ROS message to a JSON-serializable dict
-            # Convert header and info normally (they are small)
-            msg_dict = {
-                "header": message_to_ordereddict(msg.header),
-                "info": message_to_ordereddict(msg.info),
-            }
-
-            # FAST CONVERSION of data field
-            # 'data' is typically a list of int8. We want a Base64 string.
-            data_field = msg.data
-            raw_bytes = b""
-
-            if isinstance(data_field, list):
-                # 'b' is signed char (int8), matches ROS int8[]
-                raw_bytes = array.array("b", data_field).tobytes()
-            elif isinstance(data_field, array.array):
-                raw_bytes = data_field.tobytes()
-            elif isinstance(data_field, bytes):
-                raw_bytes = data_field
-            elif isinstance(data_field, np.ndarray):
-                raw_bytes = data_field.tobytes()
-            else:
-                # Fallback (slowest)
-                raw_bytes = bytes(data_field)
-
-            msg_dict["data"] = base64.b64encode(raw_bytes).decode("utf-8")
-
-            response = {"op": "publish", "msg": msg_dict}
-            await ws.send_json(response)
-
-        ros_node.attach_websocket_callback(map_callback, map_topic_type)
-
-        # Add all point outputs to the map websocket callback
-        for _, topic_type in fh.get_all_map_overlay_outputs():
-            ros_node.attach_websocket_callback(map_callback, topic_type)
-
-    async def on_conn_action(_, send):
-        """When a client connects, register feedback callbacks for all action clients."""
-
-        for clients_config in ros_node.action_clients_inputs_dicts():
-            _action_name = clients_config["name"]
-
-            async def feedback_callback(data: Dict, *, _name=_action_name, **_):
-                """Updates an action client with new feedback from the server
-
-                :param data: UI data dict (status, feedback, etc.)
-                :type data: Dict
-                """
-                feedback = (
-                    ros_msg_to_str(data["feedback"]) if data["feedback"] else None
-                )
-                fh.action_clients_ft[_name].update(
-                    status=data["status"],
-                    feedback=feedback,
-                    duration=data["duration_secs"],
-                    timestep=data["timestep"],
-                )
-                await send(fh.action_clients_ft[_name].card)
-
-                if data["status"] in ["aborted", "completed", "canceled"]:
-                    # display action aborted as an error on the main logging card
-                    if data["status"] == "aborted":
-                        await log_data(
-                            send,
-                            f"Task '{_name}' aborted: {feedback}"
-                            if feedback
-                            else f"Task '{_name}' aborted",
-                            data_type="String",
-                            data_src="error",
-                        )
-                    ros_node.cleanup_action(action_name=_name)
-                    fh.action_clients_ft[_name].cleanup()
-
-            ros_node.attach_client_feedback_callback(feedback_callback, _action_name)
-
-    # Create websockets for streaming output topics
-    for topic_name, topic_type in fh.get_all_stream_outputs():
-
-        @app.ws(
-            f"/ws_{topic_name}",
-            conn=partial(on_conn_stream, topic_type=topic_type),
-            disconn=on_disconn,
-        )
-        async def _():
-            pass
-
-    # Create websockets for map output topics
-    for map_topic_name, map_topic_type in fh.get_all_map_outputs():
-        logger.debug(f"Starting ws for {map_topic_name}, {map_topic_type}...")
-
-        @app.ws(
-            f"/ws_{map_topic_name}",
-            conn=partial(on_conn_map, map_topic_type=map_topic_type),
-            disconn=on_disconn,
-        )
-        async def _(_, data):
-            # Map websockets send back clicked points (Point, Pose, etc.)
-            # The actual point data is in data.data, but it is expected in the ui node directly in data.x, etc.
-            if message := data.pop("data", None):
-                data.update(message)
-                ros_node.publish_data(data)
-
-    if ros_node.action_clients_inputs_dicts():
-
-        @app.ws(
-            "/ws_actions",
-            conn=on_conn_action,
-            disconn=on_disconn,
-        )
-        async def _():
-            """WS route for sending action feedback to ROS UI Node"""
-            pass
-
-    @app.ws("/ws_audio", disconn=on_disconn)
-    async def _(data, send):
-        """WS route for sending audio to ROS UI Node"""
-        # Only handle audio data
-        if data["type"] == "audio" and len(data["payload"]) > 0:
-            try:
-                await log_data(
-                    send, data["payload"], data_type="Audio", data_src="user"
-                )
-                ros_node.publish_data({
-                    "topic_name": data["topic_name"],
-                    "topic_type": "Audio",
-                    "data": data["payload"],
-                })
-            except RuntimeError:
-                logger.warning("Runtime error when sending audio")
-
-            # Send the robot loading dots
-            return elements.update_logging_card_with_loading(fh.outputs_log)
-
-    async def on_conn(send):
-        """When a client connects, register its callback."""
-
-        # NOTE: Types that will be routed to the map websocket once it attaches.
-        # They are dropped from the default log callback to avoid a brief
-        # flash in the log during the startup window between the main /ws
-        # connecting and /ws_map attaching its per-type callbacks.
-        map_overlay_types = (
-            {t for _, t in fh.get_all_map_overlay_outputs()}
-            if fh.get_all_map_outputs()
-            else set()
-        )
-
-        # Callback function for ROS node
-        async def websocket_callback(data: Dict, **_):
-            # Recieve json style data from node and pass to UI with send
-            if data.get("type") in map_overlay_types:
-                return
-            if len(data["payload"]) > 0:
-                await log_data(
-                    send, data["payload"], data_type=data["type"], data_src="robot"
-                )
-
-        ros_node.attach_websocket_callback(websocket_callback)
-
-    @app.ws("/ws", conn=on_conn, disconn=on_disconn)
-    async def _(data, send):
-        """WS route for input/output communication with ROS UI Node"""
-
-        if (data_type := data.get("topic_type")) == "String":
-            # display in log for string data types
-            await log_data(send, data["data"], data_type=data_type, data_src="user")
-            ros_node.publish_data(data=data)
-            # Send the robot loading dots
-            return elements.update_logging_card_with_loading(fh.outputs_log)
-        elif data.get("topic_type") in ["Point", "PointStamped"]:
-            # display in log for coordinates data types
-            await log_data(
-                send,
-                f"Published to topic /{data.get('topic_name')} using coordinates: x={data['x']}, y={data['y']}, z={data['z']}",
-                data_type="String",
-                data_src="user",
-            )
-            ros_node.publish_data(data=data)
-        elif data.get("topic_type") in ["Pose", "PoseStamped"]:
-            # display in log for coordinates data types
-            await log_data(
-                send,
-                f"Published to topic /{data.get('topic_name')} using coordinates: (Position: x={data['x']}, y={data['y']}, z={data['z']}), (Orientation: w={data['ori_w'] or '1'}, x={data['ori_x'] or '0'}, y={data['ori_y'] or '0'}, z={data['ori_z'] or '0'})",
-                data_type="String",
-                data_src="user",
-            )
-            ros_node.publish_data(data=data)
-        elif data.get("topic_type") == "Bool":
-            # display in log for coordinates data types
-            await log_data(
-                send,
-                f"Published to topic /{data.get('topic_name')}: {data.get('data', 'off')}",
-                data_type="String",
-                data_src="user",
-            )
-            ros_node.publish_data(data=data)
-        else:
-            ros_node.publish_data(data=data)
-
-    # Register a JSON / WebSocket API on the same app
-    register_api(app, ros_node)
+    # Create the JSON/WebSocket API is the server host, server host
+    api_app = build_api_app(ros_node, browser_app=browser_app)
 
     # Check if SSL certificates exist
     if not (
@@ -546,7 +108,7 @@ def main():
         f"Access the recipe UI at: {protocol}://<IP_ADDRESS_OF_THE_ROBOT>:{ros_node_config.port}"
     )
     uvicorn.run(
-        app,
+        api_app,
         host="0.0.0.0",
         port=ros_node_config.port,
         ssl_keyfile=key_file,

--- a/test/ui_api_test.py
+++ b/test/ui_api_test.py
@@ -95,10 +95,10 @@ def test_build_interfaces_document():
     assert [i["name"] for i in doc["inputs"]] == ["cmd_vel"]
     assert doc["inputs"][0]["publish"] == "POST /api/inputs/cmd_vel"
 
-    # Outputs (robot -> client) come from in_topics; Image is a binary stream
+    # Outputs (robot -> client) come from in_topics; Image samples, Odometry pushes
     outputs = {o["name"]: o for o in doc["outputs"]}
-    assert outputs["odom"]["binary"] is False
-    assert outputs["cam"]["binary"] is True
+    assert outputs["odom"]["mode"] == "push"
+    assert outputs["cam"]["mode"] == "sampled"
     assert outputs["odom"]["stream"] == "WS /api/outputs/odom"
     assert outputs["odom"]["latest"] == "GET /api/outputs/odom/latest"
 
@@ -160,14 +160,22 @@ class _ApiNode:
     """Fake UINode exposing just the surface the API routes use."""
 
     def __init__(self):
-        self.in_topics = [Topic(name="odom", msg_type="Odometry")]
-        self.out_topics = [Topic(name="cmd_vel", msg_type="Twist")]
+        self.in_topics = [
+            Topic(name="odom", msg_type="Odometry"),
+            Topic(name="map", msg_type="OccupancyGrid"),
+            Topic(name="plan", msg_type="Path"),
+        ]
+        self.out_topics = [
+            Topic(name="cmd_vel", msg_type="Twist"),
+            Topic(name="speech", msg_type="Audio"),
+        ]
         self.config = _FakeConfig()
         self.published = []
+        self.audio_published = []  # (name, base64) recorded by publish_audio
         self.publish_error = None  # exception to raise from publish_data
         self.service_response = None  # raw ROS response to return
         self.service_error = None  # exception to raise from send_srv_call
-        self.latest = {}  # topic_name -> cached _get_ui_content result
+        self.latest = {}  # topic_name -> get_latest_output result
         self.goals = []  # recorded action goals
         self.goal_accepted = True  # send_action_goal return value
         self.goal_error = None  # exception to raise from send_action_goal
@@ -176,6 +184,8 @@ class _ApiNode:
         self.feedback = None  # get_action_feedback return value
         self.feedback_ready = True  # add_action_feedback_listener return value
         self.feedback_listeners = {}  # action_name -> set of push listeners
+        self.output_ready = True  # add_output_listener return value
+        self.output_listeners = {}  # topic_name -> set of push listeners
 
     def srv_clients_inputs_dicts(self):
         return [{"name": "reset", "type": "Trigger", "fields": {}}]
@@ -191,6 +201,10 @@ class _ApiNode:
             raise self.publish_error
         self.published.append(data)
         return 2
+
+    def publish_audio(self, name, audio_b64):
+        self.audio_published.append((name, audio_b64))
+        return 1
 
     def send_srv_call(self, data):
         if self.service_error is not None:
@@ -225,6 +239,22 @@ class _ApiNode:
     def fire_action_feedback(self, name):
         """Simulate feedback arriving (invoke listeners, as the ROS thread would)."""
         for listener in list(self.feedback_listeners.get(name, ())):
+            listener()
+
+    def add_output_listener(self, name, listener):
+        if not self.output_ready:
+            return False
+        self.output_listeners.setdefault(name, set()).add(listener)
+        return True
+
+    def remove_output_listener(self, name, listener):
+        listeners = self.output_listeners.get(name)
+        if listeners:
+            listeners.discard(listener)
+
+    def fire_output(self, name):
+        """Simulate a message arriving on an output topic (invoke push listeners)."""
+        for listener in list(self.output_listeners.get(name, ())):
             listener()
 
 
@@ -353,6 +383,67 @@ def test_output_stream_unknown_closes():
     with pytest.raises(WebSocketDisconnect):
         with client.websocket_connect("/api/outputs/nope") as ws:
             ws.receive_json()
+
+
+def test_output_stream_default_push_for_light_type():
+    """A light type (Odometry) defaults to lossless event push -- no ?rate needed."""
+    node = _ApiNode()
+    node.latest["odom"] = {"frame_id": "odom", "data": [1.0]}
+    client = _make_client(node)
+    with client.websocket_connect("/api/outputs/odom") as ws:
+        # current value on connect
+        assert ws.receive_json() == {
+            "topic": "odom",
+            "payload": {"frame_id": "odom", "data": [1.0]},
+        }
+        assert node.output_listeners.get("odom")  # push path registered a listener
+        # a new message arrives -> pushed immediately (no poll wait)
+        node.latest["odom"] = {"frame_id": "odom", "data": [2.0]}
+        node.fire_output("odom")
+        assert ws.receive_json() == {
+            "topic": "odom",
+            "payload": {"frame_id": "odom", "data": [2.0]},
+        }
+
+
+def test_output_stream_visual_type_samples_by_default():
+    """A continuous/heavy type (OccupancyGrid) is rate-sampled by default (no push listener)."""
+    node = _ApiNode()
+    node.latest["map"] = {"frame_id": "map", "data": "AAAA"}
+    client = _make_client(node)
+    with client.websocket_connect("/api/outputs/map") as ws:
+        assert ws.receive_json()["topic"] == "map"  # latest sent on connect
+        assert not node.output_listeners.get("map")  # sampled path -> no listener
+
+
+def test_output_stream_rate_overrides_to_sample():
+    """?rate=<hz> forces sampling even for a push-by-default type (no push listener)."""
+    node = _ApiNode()
+    node.latest["odom"] = {"frame_id": "odom", "data": [1.0]}
+    client = _make_client(node)
+    with client.websocket_connect("/api/outputs/odom?rate=50") as ws:
+        assert ws.receive_json()["topic"] == "odom"
+        assert not node.output_listeners.get("odom")  # sampled path -> no listener
+
+
+def test_output_stream_push_not_ready_closes():
+    from starlette.websockets import WebSocketDisconnect
+
+    node = _ApiNode()
+    node.output_ready = False  # no callback for this topic yet
+    client = _make_client(node)
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect("/api/outputs/odom") as ws:  # default push
+            ws.receive_json()
+
+
+def test_interfaces_advertises_stream_mode():
+    node = _ApiNode()
+    client = _make_client(node)
+    outputs = {o["name"]: o for o in client.get("/api/interfaces").json()["outputs"]}
+    assert outputs["odom"]["stream"] == "WS /api/outputs/odom"
+    assert outputs["odom"]["mode"] == "push"  # light type -> push default
+    assert outputs["map"]["mode"] == "sampled"  # OccupancyGrid -> sampled default
 
 
 def test_content_to_jsonable_passes_through_and_converts():
@@ -507,4 +598,118 @@ def test_action_feedback_unknown_closes():
     client = _make_client(_ApiNode())
     with pytest.raises(WebSocketDisconnect):
         with client.websocket_connect("/api/actions/nope/feedback") as ws:
+            ws.receive_json()
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: /api/world composable map stream
+# ---------------------------------------------------------------------------
+def test_interfaces_includes_worlds():
+    doc = _make_client(_ApiNode()).get("/api/interfaces").json()
+    worlds = {w["name"]: w for w in doc["worlds"]}
+    assert "map" in worlds
+    assert worlds["map"]["stream"] == "WS /api/world/map"
+    overlay_names = {o["name"] for o in worlds["map"]["overlays"]}
+    assert {"odom", "plan"} <= overlay_names
+
+
+def test_world_stream_emits_grid_and_markers():
+    node = _ApiNode()
+    # The grid's UI content is the flat map metadata + data the callback now
+    # produces; the world wraps it in a publish op.
+    node.latest["map"] = {
+        "frame_id": "map",
+        "resolution": 0.5,
+        "width": 2,
+        "height": 2,
+        "origin_x": 0.0,
+        "origin_y": 0.0,
+        "origin_yaw": 0.0,
+        "data": "AAECAw==",
+    }
+    node.latest["odom"] = {"frame_id": "odom", "data": [1.0, 2.0, 0.0, 0.5, 0.0]}
+    node.latest["plan"] = {"frame_id": "map", "data": [0.0, 0.0, 1.0, 1.0]}
+
+    client = _make_client(node)
+    with client.websocket_connect("/api/world/map") as ws:
+        frames = [ws.receive_json() for _ in range(3)]
+
+    by_op = {}
+    for frame in frames:
+        by_op.setdefault(frame["op"], []).append(frame)
+
+    grid_msg = by_op["publish"][0]["msg"]
+    assert grid_msg["width"] == 2
+    assert grid_msg["data"] == "AAECAw=="  # raw occupancy data, never a JPEG
+
+    overlays = {m["id"]: m for m in by_op.get("overlay", [])}
+    paths = {m["id"]: m for m in by_op.get("path", [])}
+    assert overlays["odom"]["x"] == 1.0 and overlays["odom"]["theta"] == 0.5
+    assert paths["plan"]["points"] == [0.0, 0.0, 1.0, 1.0]
+
+
+def test_occupancy_grid_ui_content_is_raw_grid_not_jpeg():
+    import array as _array
+    import base64
+
+    from nav_msgs.msg import OccupancyGrid
+
+    from ros_sugar.io.callbacks import OccupancyGridCallback
+
+    grid = OccupancyGrid()
+    grid.header.frame_id = "map"
+    grid.info.width = 2
+    grid.info.height = 2
+    grid.info.resolution = 0.5
+    grid.data = [0, 100, -1, 0]
+
+    cb = OccupancyGridCallback(Topic(name="map", msg_type="OccupancyGrid"))
+    cb.callback(grid)  # sets msg + frame_id (from header), as in production
+    content = cb._get_ui_content()
+
+    assert content["frame_id"] == "map"
+    assert content["width"] == 2
+    assert content["resolution"] == 0.5
+    # data is the raw int8 grid, base64-encoded (not a rendered image)
+    assert list(_array.array("b", base64.b64decode(content["data"]))) == [0, 100, -1, 0]
+    json.dumps(content)  # JSON-safe
+
+
+def test_world_unknown_closes():
+    from starlette.websockets import WebSocketDisconnect
+
+    client = _make_client(_ApiNode())
+    # 'odom' is an Odometry output, not an occupancy grid -> reject.
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect("/api/world/odom") as ws:
+            ws.receive_json()
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: audio input WS
+# ---------------------------------------------------------------------------
+def test_interfaces_advertises_audio_stream():
+    doc = _make_client(_ApiNode()).get("/api/interfaces").json()
+    inputs = {i["name"]: i for i in doc["inputs"]}
+    assert inputs["speech"]["audio_stream"] == "WS /api/inputs/speech/audio"
+    assert "audio_stream" not in inputs["cmd_vel"]  # non-audio inputs don't get it
+
+
+def test_audio_input_stream_publishes():
+    node = _ApiNode()
+    client = _make_client(node)
+    with client.websocket_connect("/api/inputs/speech/audio") as ws:
+        ws.send_json({"payload": "QUJD"})  # base64 for "ABC"
+        ack = ws.receive_json()
+    assert ack == {"published": "speech"}
+    assert node.audio_published == [("speech", "QUJD")]
+
+
+def test_audio_input_unknown_closes():
+    from starlette.websockets import WebSocketDisconnect
+
+    client = _make_client(_ApiNode())
+    # 'cmd_vel' is a Twist input, not Audio -> reject.
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect("/api/inputs/cmd_vel/audio") as ws:
             ws.receive_json()

--- a/test/ui_api_test.py
+++ b/test/ui_api_test.py
@@ -446,6 +446,46 @@ def test_interfaces_advertises_stream_mode():
     assert outputs["map"]["mode"] == "sampled"  # OccupancyGrid -> sampled default
 
 
+def test_set_ros_msg_from_dict_converts_by_declared_type():
+    from std_msgs.msg import ByteMultiArray, Float32MultiArray, String as ROSString
+
+    from ros_sugar.io.supported_types import set_ros_msg_from_dict
+
+    # octet sequences become length-1 bytes elements (native-serializable)
+    msg = set_ros_msg_from_dict(ByteMultiArray, {"data": [1, 2, 255]})
+    assert msg.data == [b"\x01", b"\x02", b"\xff"]
+    # numeric sequences coerce per element
+    msg = set_ros_msg_from_dict(Float32MultiArray, {"data": [1, "2.5"]})
+    assert msg.data == pytest.approx([1.0, 2.5])
+    # scalar strings still coerce leniently
+    assert set_ros_msg_from_dict(ROSString, {"data": 42}).data == "42"
+    # nested complex sequences ('sequence<pkg/Type>') recurse correctly
+    msg = set_ros_msg_from_dict(
+        ByteMultiArray,
+        {"layout": {"dim": [{"label": "x", "size": 1, "stride": 1}], "data_offset": 0}, "data": [7]},
+    )
+    assert msg.layout.dim[0].label == "x" and msg.layout.dim[0].size == 1
+
+
+def test_set_ros_msg_from_dict_rejects_native_fatal_values():
+    """Values that would build a Python-plausible but rmw-fatal message must
+    raise ValueError (-> HTTP 400) instead of reaching the serializer."""
+    from std_msgs.msg import ByteMultiArray, Float32MultiArray
+
+    from ros_sugar.io.supported_types import set_ros_msg_from_dict
+
+    # a string is NOT a valid octet sequence (this exact payload used to
+    # crash the UI node process in the C typesupport layer)
+    with pytest.raises(ValueError, match="data"):
+        set_ros_msg_from_dict(ByteMultiArray, {"data": "zzz"})
+    # a scalar is not a sequence
+    with pytest.raises(ValueError, match="data"):
+        set_ros_msg_from_dict(ByteMultiArray, {"data": 42})
+    # unconvertible element
+    with pytest.raises(ValueError, match="data"):
+        set_ros_msg_from_dict(Float32MultiArray, {"data": ["abc"]})
+
+
 def test_content_to_jsonable_passes_through_and_converts():
     pytest.importorskip("starlette")
     from sensor_msgs.msg import LaserScan

--- a/test/ui_api_test.py
+++ b/test/ui_api_test.py
@@ -446,6 +446,41 @@ def test_interfaces_advertises_stream_mode():
     assert outputs["map"]["mode"] == "sampled"  # OccupancyGrid -> sampled default
 
 
+def test_namespaced_topic_names_are_addressable():
+    """Topics with interior slashes (ns/topic) resolve through the {name:path}
+    routes; a leading slash in the URL is normalized like Topic names."""
+    node = _ApiNode()
+    node.out_topics.append(Topic(name="/ns/cmd", msg_type="String"))  # -> "ns/cmd"
+    node.in_topics.append(Topic(name="ns/status", msg_type="String"))
+    client = _make_client(node)
+
+    resp = client.post("/api/inputs/ns/cmd", json={"data": "hi"})
+    assert resp.status_code == 200
+    assert node.published[-1]["topic_name"] == "ns/cmd"
+
+    # A client that naively prepends the ROS-style leading slash still resolves
+    resp = client.post("/api/inputs//ns/cmd", json={"data": "again"})
+    assert resp.status_code == 200
+    assert node.published[-1]["topic_name"] == "ns/cmd"
+
+    node.latest["ns/status"] = "ok"
+    resp = client.get("/api/outputs/ns/status/latest")
+    assert resp.status_code == 200
+    assert resp.json() == {"topic": "ns/status", "payload": "ok"}
+    with client.websocket_connect("/api/outputs/ns/status?rate=50") as ws:
+        assert ws.receive_json()["topic"] == "ns/status"
+
+
+def test_action_cancel_not_swallowed_by_goal_route():
+    """/actions/{name:path} is greedy: the cancel route must win for .../cancel."""
+    node = _ApiNode()
+    client = _make_client(node)
+    resp = client.post("/api/actions/navigate/cancel")
+    assert resp.status_code == 200
+    assert resp.json()["cancelled"] is True
+    assert node.goals == []  # the goal handler never ran
+
+
 def test_set_ros_msg_from_dict_converts_by_declared_type():
     from std_msgs.msg import ByteMultiArray, Float32MultiArray, String as ROSString
 

--- a/test/ui_api_test.py
+++ b/test/ui_api_test.py
@@ -1,0 +1,177 @@
+"""Tests for the front-end-agnostic UI API (issue #54), Phase 0.
+
+Covers:
+* ``ros_sugar.io.json_utils`` -- faithful ROS-message -> JSON coercion.
+* the ``_get_ui_content`` source fix -- specialized callbacks must return
+  JSON-serializable content (no numpy arrays).
+* ``ros_sugar.ui_node.api.build_interfaces`` -- the discovery document.
+* the optional-dependency import boundary -- importing the main package must
+  not pull in the web stack (fasthtml/starlette/uvicorn).
+"""
+
+import json
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+from ros_sugar.io.topic import Topic
+
+
+# ---------------------------------------------------------------------------
+# json_utils: faithful ROS message -> JSON
+# ---------------------------------------------------------------------------
+def test_ros_msg_to_jsonable_is_json_serializable():
+    """A message with array/nested fields serializes cleanly to JSON."""
+    from sensor_msgs.msg import LaserScan
+
+    from ros_sugar.io.json_utils import ros_msg_to_jsonable
+
+    scan = LaserScan()
+    scan.angle_min = -1.5
+    scan.angle_max = 1.5
+    scan.ranges = [0.1, 0.2, 0.3]  # float32[] -> array.array internally
+
+    jsonable = ros_msg_to_jsonable(scan)
+    # Must round-trip through json without raising
+    dumped = json.dumps(jsonable)
+    assert "ranges" in jsonable
+    assert json.loads(dumped)["ranges"] == [
+        pytest.approx(0.1),
+        pytest.approx(0.2),
+        pytest.approx(0.3),
+    ]
+
+
+def test_coerce_handles_bytes_and_arrays():
+    """bytes -> base64 string, array.array -> list, recursively."""
+    import array
+
+    from ros_sugar.io.json_utils import _coerce
+
+    out = _coerce({"blob": b"\x00\x01", "nums": array.array("i", [1, 2]), "n": [3, 4]})
+    assert isinstance(out["blob"], str)  # base64 string
+    assert out["nums"] == [1, 2]
+    assert out["n"] == [3, 4]
+    json.dumps(out)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# _get_ui_content source fix: no numpy in the UI payloads
+# ---------------------------------------------------------------------------
+def test_geometry_callbacks_return_jsonable_ui_content():
+    """Point/Pose/Odom/MultiArray ``_get_ui_content`` must be JSON-safe."""
+    from geometry_msgs.msg import Point as ROSPoint, Pose as ROSPose
+    from std_msgs.msg import Float64MultiArray
+
+    from ros_sugar.io.callbacks import (
+        PointCallback,
+        PoseCallback,
+        StdMsgArrayCallback,
+    )
+
+    point_cb = PointCallback(Topic(name="p", msg_type="Point"))
+    point_cb.msg = ROSPoint(x=1.0, y=2.0, z=3.0)
+    point_content = point_cb._get_ui_content()
+    assert point_content["data"] == [1.0, 2.0, 3.0]
+    assert not isinstance(point_content["data"], np.ndarray)
+    json.dumps(point_content)
+
+    pose_cb = PoseCallback(Topic(name="po", msg_type="Pose"))
+    pose_cb.msg = ROSPose()
+    pose_content = pose_cb._get_ui_content()
+    assert isinstance(pose_content["data"], list)
+    json.dumps(pose_content)
+
+    arr_cb = StdMsgArrayCallback(Topic(name="a", msg_type="Float64MultiArray"))
+    msg = Float64MultiArray()
+    msg.data = [1.0, 2.0, 3.0]
+    arr_cb.msg = msg
+    arr_content = arr_cb._get_ui_content()
+    assert isinstance(arr_content, list)
+    json.dumps(arr_content)
+
+
+# ---------------------------------------------------------------------------
+# Discovery document
+# ---------------------------------------------------------------------------
+class _FakeConfig:
+    api_stream_default_rate = 10.0
+    api_max_stream_rate = 30.0
+
+
+class _FakeNode:
+    """Minimal stand-in for a UINode for testing build_interfaces."""
+
+    def __init__(self, in_topics, out_topics, srv=None, act=None):
+        self.in_topics = in_topics  # API outputs (robot -> client)
+        self.out_topics = out_topics  # API inputs (client -> robot)
+        self._srv = srv or []
+        self._act = act or []
+        self.config = _FakeConfig()
+
+    def srv_clients_inputs_dicts(self):
+        return self._srv
+
+    def action_clients_inputs_dicts(self):
+        return self._act
+
+
+def test_build_interfaces_document():
+    pytest.importorskip("starlette")
+    from ros_sugar.ui_node.api import build_interfaces
+
+    node = _FakeNode(
+        in_topics=[Topic(name="odom", msg_type="Odometry"), Topic(name="cam", msg_type="Image")],
+        out_topics=[Topic(name="cmd_vel", msg_type="Twist")],
+        srv=[{"name": "dock", "type": "Trigger", "fields": {}}],
+        act=[{"name": "move", "type": "NavigateToPose", "fields": {"x": "float"}}],
+    )
+    doc = build_interfaces(node)
+
+    # Inputs (client -> robot) come from out_topics
+    assert [i["name"] for i in doc["inputs"]] == ["cmd_vel"]
+    assert doc["inputs"][0]["publish"] == "POST /api/inputs/cmd_vel"
+
+    # Outputs (robot -> client) come from in_topics; Image is a binary stream
+    outputs = {o["name"]: o for o in doc["outputs"]}
+    assert outputs["odom"]["binary"] is False
+    assert outputs["cam"]["binary"] is True
+    assert outputs["odom"]["stream"] == "WS /api/outputs/odom"
+    assert outputs["odom"]["latest"] == "GET /api/outputs/odom/latest"
+
+    # Services / actions
+    assert doc["services"][0]["call"] == "POST /api/services/dock"
+    assert doc["actions"][0]["feedback"] == "WS /api/actions/move/feedback"
+    assert doc["actions"][0]["goal_schema"] == {"x": "float"}
+
+    # Stream rates surface the config
+    assert doc["stream"] == {"default_rate": 10.0, "max_rate": 30.0}
+
+    # The whole document must be JSON-serializable
+    json.dumps(doc)
+
+
+# ---------------------------------------------------------------------------
+# Optional-dependency import boundary
+# ---------------------------------------------------------------------------
+def test_main_import_does_not_pull_web_stack():
+    """Importing the main package must not require fasthtml/starlette/uvicorn.
+
+    These remain optional so ``ros_sugar`` runs on systems (e.g. Python 3.8)
+    where the web UI stack is unavailable. Only the UI node executable and the
+    guarded web-tier modules (frontend/elements/api) may import them.
+    """
+    code = (
+        "import sys\n"
+        "import ros_sugar\n"
+        "import ros_sugar.ui_node\n"
+        "import ros_sugar.launch.launcher\n"
+        "import ros_sugar.io.json_utils\n"
+        "import ros_sugar.io.callbacks\n"
+        "leaked = [m for m in ('fasthtml', 'monsterui', 'starlette', 'uvicorn')\n"
+        "          if m in sys.modules]\n"
+        "assert not leaked, f'web stack leaked into main import path: {leaked}'\n"
+    )
+    subprocess.check_call([sys.executable, "-c", code])

--- a/test/ui_api_test.py
+++ b/test/ui_api_test.py
@@ -168,12 +168,20 @@ class _ApiNode:
         self.service_response = None  # raw ROS response to return
         self.service_error = None  # exception to raise from send_srv_call
         self.latest = {}  # topic_name -> cached _get_ui_content result
+        self.goals = []  # recorded action goals
+        self.goal_accepted = True  # send_action_goal return value
+        self.goal_error = None  # exception to raise from send_action_goal
+        self.cancel_result = (True, "Action goal cancelled successfully")
+        self.cancel_error = None  # exception to raise from cancel_action
+        self.feedback = None  # get_action_feedback return value
+        self.feedback_ready = True  # add_action_feedback_listener return value
+        self.feedback_listeners = {}  # action_name -> set of push listeners
 
     def srv_clients_inputs_dicts(self):
         return [{"name": "reset", "type": "Trigger", "fields": {}}]
 
     def action_clients_inputs_dicts(self):
-        return []
+        return [{"name": "navigate", "type": "NavigateToPose", "fields": {}}]
 
     def get_latest_output(self, name):
         return self.latest.get(name)
@@ -188,6 +196,36 @@ class _ApiNode:
         if self.service_error is not None:
             raise self.service_error
         return self.service_response
+
+    def send_action_goal(self, data):
+        if self.goal_error is not None:
+            raise self.goal_error
+        self.goals.append(data)
+        return self.goal_accepted
+
+    def cancel_action(self, name):
+        if self.cancel_error is not None:
+            raise self.cancel_error
+        return self.cancel_result
+
+    def get_action_feedback(self, name):
+        return self.feedback
+
+    def add_action_feedback_listener(self, name, listener):
+        if not self.feedback_ready:
+            return False
+        self.feedback_listeners.setdefault(name, set()).add(listener)
+        return True
+
+    def remove_action_feedback_listener(self, name, listener):
+        listeners = self.feedback_listeners.get(name)
+        if listeners:
+            listeners.discard(listener)
+
+    def fire_action_feedback(self, name):
+        """Simulate feedback arriving (invoke listeners, as the ROS thread would)."""
+        for listener in list(self.feedback_listeners.get(name, ())):
+            listener()
 
 
 def _make_client(node):
@@ -331,3 +369,142 @@ def test_content_to_jsonable_passes_through_and_converts():
     out = _content_to_jsonable(scan)
     assert out["ranges"] == [pytest.approx(0.5)]
     json.dumps(out)
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: actions
+# ---------------------------------------------------------------------------
+def test_send_goal_accepted_202():
+    node = _ApiNode()
+    client = _make_client(node)
+    resp = client.post("/api/actions/navigate", json={"x": 1.0})
+    assert resp.status_code == 202
+    assert resp.json() == {
+        "accepted": True,
+        "action": "navigate",
+        "feedback": "/api/actions/navigate/feedback",
+    }
+    assert node.goals == [{"action_name": "navigate", "x": 1.0}]
+
+
+def test_send_goal_unknown_404():
+    client = _make_client(_ApiNode())
+    resp = client.post("/api/actions/nope", json={})
+    assert resp.status_code == 404
+
+
+def test_send_goal_not_ready_503():
+    node = _ApiNode()
+    node.goal_error = RuntimeError("Action client 'navigate' is not ready")
+    client = _make_client(node)
+    resp = client.post("/api/actions/navigate", json={})
+    assert resp.status_code == 503
+
+
+def test_send_goal_rejected_502():
+    node = _ApiNode()
+    node.goal_accepted = False
+    client = _make_client(node)
+    resp = client.post("/api/actions/navigate", json={})
+    assert resp.status_code == 502
+
+
+def test_cancel_goal_ok():
+    node = _ApiNode()
+    node.cancel_result = (True, "Action goal cancelled successfully")
+    client = _make_client(node)
+    resp = client.post("/api/actions/navigate/cancel")
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "cancelled": True,
+        "message": "Action goal cancelled successfully",
+    }
+
+
+def test_cancel_goal_unknown_404():
+    client = _make_client(_ApiNode())
+    resp = client.post("/api/actions/nope/cancel")
+    assert resp.status_code == 404
+
+
+def test_action_feedback_emits_current_state_on_connect():
+    from geometry_msgs.msg import Point as ROSPoint
+
+    node = _ApiNode()
+    node.feedback = {
+        "status": "running",
+        "feedback": ROSPoint(x=1.0, y=2.0, z=3.0),  # a raw ROS message
+        "timestep": 5,
+        "feedback_timeout": False,
+        "duration_secs": 2.0,
+    }
+    client = _make_client(node)
+    with client.websocket_connect("/api/actions/navigate/feedback") as ws:
+        data = ws.receive_json()
+    assert data == {
+        "status": "running",
+        "feedback": {"x": 1.0, "y": 2.0, "z": 3.0},
+        "timestep": 5,
+        "duration_secs": 2.0,
+    }
+
+
+def test_action_feedback_pushed_on_arrival():
+    """Each feedback is pushed the moment it arrives (event-driven, not polled)."""
+    from starlette.websockets import WebSocketDisconnect
+
+    node = _ApiNode()
+    node.feedback = {
+        "status": "running",
+        "feedback": None,
+        "timestep": 1,
+        "feedback_timeout": False,
+        "duration_secs": 0.5,
+    }
+    client = _make_client(node)
+    with client.websocket_connect("/api/actions/navigate/feedback") as ws:
+        assert ws.receive_json()["timestep"] == 1  # current state on connect
+
+        # New feedback arrives -> push it.
+        node.feedback = {
+            "status": "running",
+            "feedback": None,
+            "timestep": 2,
+            "feedback_timeout": False,
+            "duration_secs": 1.0,
+        }
+        node.fire_action_feedback("navigate")
+        assert ws.receive_json()["timestep"] == 2
+
+        # Terminal feedback -> push, then the server closes the stream.
+        node.feedback = {
+            "status": "completed",
+            "feedback": None,
+            "timestep": 3,
+            "feedback_timeout": False,
+            "duration_secs": 1.5,
+        }
+        node.fire_action_feedback("navigate")
+        assert ws.receive_json()["status"] == "completed"
+        with pytest.raises(WebSocketDisconnect):
+            ws.receive_json()
+
+
+def test_action_feedback_not_ready_closes():
+    from starlette.websockets import WebSocketDisconnect
+
+    node = _ApiNode()
+    node.feedback_ready = False  # action client not initialized yet
+    client = _make_client(node)
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect("/api/actions/navigate/feedback") as ws:
+            ws.receive_json()
+
+
+def test_action_feedback_unknown_closes():
+    from starlette.websockets import WebSocketDisconnect
+
+    client = _make_client(_ApiNode())
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect("/api/actions/nope/feedback") as ws:
+            ws.receive_json()

--- a/test/ui_api_test.py
+++ b/test/ui_api_test.py
@@ -1,7 +1,6 @@
 """Tests for the front-end-agnostic UI API (issue #54), Phase 0.
 
 Covers:
-* ``ros_sugar.io.json_utils`` -- faithful ROS-message -> JSON coercion.
 * the ``_get_ui_content`` source fix -- specialized callbacks must return
   JSON-serializable content (no numpy arrays).
 * ``ros_sugar.ui_node.api.build_interfaces`` -- the discovery document.
@@ -17,44 +16,6 @@ import numpy as np
 import pytest
 
 from ros_sugar.io.topic import Topic
-
-
-# ---------------------------------------------------------------------------
-# json_utils: faithful ROS message -> JSON
-# ---------------------------------------------------------------------------
-def test_ros_msg_to_jsonable_is_json_serializable():
-    """A message with array/nested fields serializes cleanly to JSON."""
-    from sensor_msgs.msg import LaserScan
-
-    from ros_sugar.io.json_utils import ros_msg_to_jsonable
-
-    scan = LaserScan()
-    scan.angle_min = -1.5
-    scan.angle_max = 1.5
-    scan.ranges = [0.1, 0.2, 0.3]  # float32[] -> array.array internally
-
-    jsonable = ros_msg_to_jsonable(scan)
-    # Must round-trip through json without raising
-    dumped = json.dumps(jsonable)
-    assert "ranges" in jsonable
-    assert json.loads(dumped)["ranges"] == [
-        pytest.approx(0.1),
-        pytest.approx(0.2),
-        pytest.approx(0.3),
-    ]
-
-
-def test_coerce_handles_bytes_and_arrays():
-    """bytes -> base64 string, array.array -> list, recursively."""
-    import array
-
-    from ros_sugar.io.json_utils import _coerce
-
-    out = _coerce({"blob": b"\x00\x01", "nums": array.array("i", [1, 2]), "n": [3, 4]})
-    assert isinstance(out["blob"], str)  # base64 string
-    assert out["nums"] == [1, 2]
-    assert out["n"] == [3, 4]
-    json.dumps(out)  # must not raise
 
 
 # ---------------------------------------------------------------------------
@@ -168,10 +129,129 @@ def test_main_import_does_not_pull_web_stack():
         "import ros_sugar\n"
         "import ros_sugar.ui_node\n"
         "import ros_sugar.launch.launcher\n"
-        "import ros_sugar.io.json_utils\n"
         "import ros_sugar.io.callbacks\n"
         "leaked = [m for m in ('fasthtml', 'monsterui', 'starlette', 'uvicorn')\n"
         "          if m in sys.modules]\n"
         "assert not leaked, f'web stack leaked into main import path: {leaked}'\n"
     )
     subprocess.check_call([sys.executable, "-c", code])
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: inputs + services REST endpoints
+# ---------------------------------------------------------------------------
+class _ApiNode:
+    """Fake UINode exposing just the surface the API routes use."""
+
+    def __init__(self):
+        self.in_topics = [Topic(name="odom", msg_type="Odometry")]
+        self.out_topics = [Topic(name="cmd_vel", msg_type="Twist")]
+        self.config = _FakeConfig()
+        self.published = []
+        self.publish_error = None  # exception to raise from publish_data
+        self.service_response = None  # raw ROS response to return
+        self.service_error = None  # exception to raise from send_srv_call
+
+    def srv_clients_inputs_dicts(self):
+        return [{"name": "reset", "type": "Trigger", "fields": {}}]
+
+    def action_clients_inputs_dicts(self):
+        return []
+
+    def publish_data(self, data):
+        if self.publish_error is not None:
+            raise self.publish_error
+        self.published.append(data)
+        return 2
+
+    def send_srv_call(self, data):
+        if self.service_error is not None:
+            raise self.service_error
+        return self.service_response
+
+
+def _make_client(node):
+    pytest.importorskip("httpx")
+    pytest.importorskip("fasthtml")
+    from fasthtml.common import fast_app
+    from starlette.testclient import TestClient
+
+    from ros_sugar.ui_node.api import register_api
+
+    app, _ = fast_app()
+    register_api(app, node)
+    return TestClient(app)
+
+
+def test_publish_input_ok():
+    node = _ApiNode()
+    client = _make_client(node)
+    resp = client.post("/api/inputs/cmd_vel", json={"linear": {"x": 1.0}})
+    assert resp.status_code == 200
+    assert resp.json() == {"published": "cmd_vel", "subscribers": 2}
+    # publish_data receives the topic name folded into the field dict
+    assert node.published == [{"topic_name": "cmd_vel", "linear": {"x": 1.0}}]
+
+
+def test_publish_input_unknown_topic_404():
+    client = _make_client(_ApiNode())
+    resp = client.post("/api/inputs/nope", json={})
+    assert resp.status_code == 404
+
+
+def test_publish_input_not_ready_503():
+    node = _ApiNode()
+    node.publish_error = RuntimeError("Publisher for input topic 'cmd_vel' is not ready")
+    client = _make_client(node)
+    resp = client.post("/api/inputs/cmd_vel", json={})
+    assert resp.status_code == 503
+
+
+def test_publish_input_bad_fields_400():
+    node = _ApiNode()
+    node.publish_error = ValueError("Cannot build a Twist message")
+    client = _make_client(node)
+    resp = client.post("/api/inputs/cmd_vel", json={"bogus": 1})
+    assert resp.status_code == 400
+
+
+def test_call_service_ok():
+    from std_srvs.srv import Trigger
+
+    node = _ApiNode()
+    response = Trigger.Response()
+    response.success = True
+    response.message = "ok"
+    node.service_response = response
+    client = _make_client(node)
+
+    resp = client.post("/api/services/reset", json={})
+    assert resp.status_code == 200
+    assert resp.json() == {"service": "reset", "response": {"success": True, "message": "ok"}}
+
+
+def test_call_service_unknown_404():
+    client = _make_client(_ApiNode())
+    resp = client.post("/api/services/nope", json={})
+    assert resp.status_code == 404
+
+
+def test_call_service_no_response_502():
+    node = _ApiNode()
+    node.service_response = None  # simulates no response received
+    client = _make_client(node)
+    resp = client.post("/api/services/reset", json={})
+    assert resp.status_code == 502
+
+
+def test_msg_to_jsonable_handles_arrays():
+    pytest.importorskip("starlette")
+    from sensor_msgs.msg import LaserScan
+
+    from ros_sugar.ui_node.api import _msg_to_jsonable
+
+    scan = LaserScan()
+    scan.ranges = [0.1, 0.2, 0.3]  # float32[] -> array.array internally
+    out = _msg_to_jsonable(scan)
+    assert out["ranges"] == [pytest.approx(0.1), pytest.approx(0.2), pytest.approx(0.3)]
+    json.dumps(out)  # must not raise

--- a/test/ui_api_test.py
+++ b/test/ui_api_test.py
@@ -137,6 +137,22 @@ def test_main_import_does_not_pull_web_stack():
     subprocess.check_call([sys.executable, "-c", code])
 
 
+def test_api_module_does_not_pull_fasthtml():
+    """The API tier depends on Starlette, never on the browser stack.
+
+    Importing ``ros_sugar.ui_node.api`` must not pull in fasthtml/monsterui, so
+    the API can run on systems where only Starlette + uvicorn are installed.
+    """
+    pytest.importorskip("starlette")
+    code = (
+        "import sys\n"
+        "import ros_sugar.ui_node.api\n"
+        "leaked = [m for m in ('fasthtml', 'monsterui') if m in sys.modules]\n"
+        "assert not leaked, f'browser stack leaked into the API module: {leaked}'\n"
+    )
+    subprocess.check_call([sys.executable, "-c", code])
+
+
 # ---------------------------------------------------------------------------
 # Phase 1: inputs + services REST endpoints
 # ---------------------------------------------------------------------------
@@ -151,12 +167,16 @@ class _ApiNode:
         self.publish_error = None  # exception to raise from publish_data
         self.service_response = None  # raw ROS response to return
         self.service_error = None  # exception to raise from send_srv_call
+        self.latest = {}  # topic_name -> cached _get_ui_content result
 
     def srv_clients_inputs_dicts(self):
         return [{"name": "reset", "type": "Trigger", "fields": {}}]
 
     def action_clients_inputs_dicts(self):
         return []
+
+    def get_latest_output(self, name):
+        return self.latest.get(name)
 
     def publish_data(self, data):
         if self.publish_error is not None:
@@ -171,16 +191,14 @@ class _ApiNode:
 
 
 def _make_client(node):
+    # The API is a standalone Starlette app -- no FastHTML needed to test it.
     pytest.importorskip("httpx")
-    pytest.importorskip("fasthtml")
-    from fasthtml.common import fast_app
+    pytest.importorskip("starlette")
     from starlette.testclient import TestClient
 
-    from ros_sugar.ui_node.api import register_api
+    from ros_sugar.ui_node.api import build_api_app
 
-    app, _ = fast_app()
-    register_api(app, node)
-    return TestClient(app)
+    return TestClient(build_api_app(node))
 
 
 def test_publish_input_ok():
@@ -255,3 +273,61 @@ def test_msg_to_jsonable_handles_arrays():
     out = _msg_to_jsonable(scan)
     assert out["ranges"] == [pytest.approx(0.1), pytest.approx(0.2), pytest.approx(0.3)]
     json.dumps(out)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: output streaming + latest value
+# ---------------------------------------------------------------------------
+def test_output_latest_ok():
+    node = _ApiNode()
+    node.latest["odom"] = {"frame_id": "odom", "data": [1.0, 2.0, 3.0]}
+    client = _make_client(node)
+    resp = client.get("/api/outputs/odom/latest")
+    assert resp.status_code == 200
+    assert resp.json() == {"topic": "odom", "payload": {"frame_id": "odom", "data": [1.0, 2.0, 3.0]}}
+
+
+def test_output_latest_unknown_404():
+    client = _make_client(_ApiNode())
+    resp = client.get("/api/outputs/nope/latest")
+    assert resp.status_code == 404
+
+
+def test_output_latest_no_data_404():
+    client = _make_client(_ApiNode())  # latest is empty
+    resp = client.get("/api/outputs/odom/latest")
+    assert resp.status_code == 404
+
+
+def test_output_stream_ok():
+    node = _ApiNode()
+    node.latest["odom"] = {"frame_id": "odom", "data": [1.0, 2.0, 3.0]}
+    client = _make_client(node)
+    with client.websocket_connect("/api/outputs/odom?rate=50") as ws:
+        data = ws.receive_json()
+    assert data == {"topic": "odom", "payload": {"frame_id": "odom", "data": [1.0, 2.0, 3.0]}}
+
+
+def test_output_stream_unknown_closes():
+    from starlette.websockets import WebSocketDisconnect
+
+    client = _make_client(_ApiNode())
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect("/api/outputs/nope") as ws:
+            ws.receive_json()
+
+
+def test_content_to_jsonable_passes_through_and_converts():
+    pytest.importorskip("starlette")
+    from sensor_msgs.msg import LaserScan
+
+    from ros_sugar.ui_node.api import _content_to_jsonable
+
+    # JSON-native content (from a specialized _get_ui_content) passes through
+    assert _content_to_jsonable({"data": [1.0, 2.0]}) == {"data": [1.0, 2.0]}
+    # A raw ROS message (unspecialized type) is faithfully converted
+    scan = LaserScan()
+    scan.ranges = [0.5]
+    out = _content_to_jsonable(scan)
+    assert out["ranges"] == [pytest.approx(0.5)]
+    json.dumps(out)


### PR DESCRIPTION
Closes #54

When a recipe declares topics/services/actions via `Launcher.enable_ui(...)`, they are now automatically exposed over a documented, stable JSON + WebSocket API — consumable by any third-party front end, not just the bundled browser UI. The bundled FastHTML browser has been migrated to consume the same contract.

## API surface

All routes are namespaced under `/api` and always registered; undeclared names return `404` (HTTP) or close `1008` (WS). `GET /api/interfaces` is the discovery document listing every declared interface, its message schema, endpoints and stream mode.

| Interface | Endpoints |
|---|---|
| Health / discovery | `GET /api/health`, `GET /api/interfaces` |
| Inputs (client → robot) | `POST /api/inputs/{name}` (schema-shaped JSON), `WS /api/inputs/{name}/audio` (base64 frames) |
| Services | `POST /api/services/{name}` → raw response as JSON |
| Outputs (robot → client) | `WS /api/outputs/{name}` (stream), `GET /api/outputs/{name}/latest` |
| Actions | `POST /api/actions/{name}`, `POST /api/actions/{name}/cancel`, `WS /api/actions/{name}/feedback` (event push, ends on terminal state) |
| World (composed map) | `WS /api/world/{grid_topic}` — occupancy grid (rate-capped) + overlay/path markers (change-detect) on one socket |

## Output transport: push vs rate-sampled

The default transport is declared per type by `SupportedType._ui_rate_sampled`:

- **Event push (default)** — every message, the moment it arrives (listener-driven, lossless for low-frequency data): String, Bool, numerics, geometry, Path, Audio, …
- **Rate-sampled** — continuous high-bandwidth types (`Image`, `CompressedImage`, `OccupancyGrid`): latest value at `?rate=<hz>` (default/cap from `UINodeConfig.api_stream_default_rate` / `api_max_stream_rate`).

Clients override per connection: `?rate=<hz>` forces sampling, `?rate=0` forces push. Daughter packages mark their own heavy types with `_ui_rate_sampled = True`.

Action feedback is always event push, via a listener set on `ActionClientHandler`.

## Architecture

- `ros_sugar/ui_node/api.py` is a pure **Starlette** app and the uvicorn host; the FastHTML browser app (`browser.py`) is optional and mounted under `/`. FastHTML/MonsterUI remain optional dependencies — the API runs headless without them, and core `ros_sugar` still imports without any web stack (enforced by tests).
- Output UI content is computed **lazily and memoized per message** (`UINode.get_latest_output` asks the topic callback on demand) — expensive conversions run only when a client is consuming. The eager per-message `_ui_callback` push machinery was removed.
- `UINode.publish_data` is schema-shaped (`set_ros_msg_from_dict`); the per-type `convert_ui_dict` form converters were removed from `supported_types` — UI-form→schema translation now lives in the browser tier (`_form_to_schema`).
- Audio input uses a dedicated `UINode.publish_audio` (base64 → `Audio.convert`), as base64 doesn't fit the schema path.

## Browser migration

The browser remains server-rendered FastHTML/HTMX and now rides the same primitives as the API:

- Log pane and action task cards are fed by the same event-push listeners (`add_output_listener` / `add_action_feedback_listener`).
- Canvas/binary widgets connect straight to the API: `video_manager.js` → `WS /api/outputs/<t>`, `ros_maps.js` → `WS /api/world/<grid>` + `POST /api/inputs/<t>` (click-to-publish), `audio_manager.js` → `WS /api/inputs/<t>/audio`.
- Removed the per-topic `/ws_<topic>` and `/ws_audio` routes and the orphaned UINode push machinery (`attach_websocket_callback`, feedback callback/timer dicts, background asyncio loop).

## Notes for daughter packages

- Set `_ui_rate_sampled = True` on heavy streaming `SupportedType`s.
- `elements.replace_text_in_logging_card` added for streamed log entries whose payload is the full text so far (see the matching embodied-agents branch).
- Breaking: `send_srv_call` returns the raw ROS response; `send_action_goal` returns an accept `bool`; both raise `RuntimeError` when the client isn't ready.
