### PR TITLE
Upstream LaserScan/PointCloud datatypes and add API-only UI mode for minimal deployments

### DIFF
--- a/ros_sugar/io/__init__.py
+++ b/ros_sugar/io/__init__.py
@@ -7,6 +7,7 @@ from .topic import (
     get_all_msg_types,
     get_msg_type,
 )
+from .datatypes import LaserScanData, PointCloudData
 from .callbacks import *
 
 
@@ -16,4 +17,6 @@ __all__ = [
     "AllowedTopics",
     "get_all_msg_types",
     "get_msg_type",
+    "LaserScanData",
+    "PointCloudData",
 ]

--- a/ros_sugar/io/callbacks.py
+++ b/ros_sugar/io/callbacks.py
@@ -12,12 +12,18 @@ import numpy as np
 from geometry_msgs.msg import Pose
 from jinja2.environment import Template
 from nav_msgs.msg import OccupancyGrid, Odometry
+from sensor_msgs.msg import LaserScan
 from std_msgs.msg import Header
 from rclpy.logging import get_logger
 from rclpy.subscription import Subscription
 from tf2_ros import TransformStamped
 
 from . import utils
+from .datatypes import (
+    LaserScanData,
+    PointCloudData,
+    _get_laserscan_transformed_polar_coordinates,
+)
 
 
 class GenericCallback:
@@ -761,6 +767,56 @@ class PoseStampedCallback(PoseCallback):
         return {"frame_id": self.frame_id, "data": output.tolist() if output is not None else None}
 
 
+class PoseArrayCallback(GenericCallback):
+    """
+    Ros PoseArray Callback Handler to get a set of poses as a numpy array
+    """
+
+    def __init__(
+        self,
+        input_topic,
+        node_name: str = "",
+    ) -> None:
+        super().__init__(input_topic, node_name)
+
+    def _get_output(self, **_) -> Optional[np.ndarray]:
+        """
+        Gets the PoseArray message as a numpy array with one row per pose.
+        The coordinates frame of the poses is available in the callback
+        `frame_id`
+
+        :returns:   Nx4 array of [x, y, z, heading] rows
+        :rtype:     Optional[np.ndarray]
+        """
+        if not self.msg:
+            return None
+
+        return np.array(
+            [
+                [
+                    pose.position.x,
+                    pose.position.y,
+                    pose.position.z,
+                    2 * np.arctan2(pose.orientation.z, pose.orientation.w),
+                ]
+                for pose in self.msg.poses
+            ]
+        )
+
+    def _get_ui_content(self, **_) -> Dict:
+        """
+        Utility method to get UI compatible content.
+        To be used with external callbacks in UI Node
+        :returns:   Topic content
+        :rtype:     Any
+        """
+        output = self.get_output()
+        return {
+            "frame_id": self.frame_id,
+            "data": output.tolist() if output is not None else None,
+        }
+
+
 class PathCallback(GenericCallback):
     """
     Ros PoseStamped Callback Handler to get the robot state in 2D
@@ -925,4 +981,213 @@ class OccupancyGridCallback(GenericCallback):
             "frame_id": self.frame_id,
             **self._get_output(get_metadata=True),
             "data": base64.b64encode(raw_bytes).decode("ascii"),
+        }
+
+
+class LaserScanCallback(GenericCallback):
+    """ROS2 LaserScan Callback Handler to process and transform sensor_msgs/LaserScan data"""
+
+    def __init__(
+        self,
+        input_topic,
+        node_name: str = "",
+        transformation: Optional[TransformStamped] = None,
+    ) -> None:
+        super().__init__(input_topic, node_name)
+        self.__tf = transformation
+
+    @property
+    def transformation(self) -> Optional[TransformStamped]:
+        """Getter of the laserscan transformation
+
+        :return: Detected transform from source to desired goal frame
+        :rtype: Optional[TransformStamped]
+        """
+        return self.__tf
+
+    @transformation.setter
+    def transformation(self, transform: TransformStamped) -> None:
+        """
+        Sets a new transformation value
+
+        :param transform: Detected transform from source to desired goal frame
+        :type transform: TransformStamped
+        """
+        self.__tf = transform
+
+    def _get_output(
+        self,
+        transformation: Optional[TransformStamped] = None,
+        **_,
+    ) -> Optional[LaserScanData]:
+        """
+        Gets the laserscan data by applying the transformation if given.
+
+        :returns:   Topic content
+        :rtype:     Optional[LaserScanData]
+        """
+        if not self.msg:
+            return None
+        if transformation or self.transformation:
+            laser_scan_data = self._transform(
+                self.msg, transformation or self.transformation
+            )
+        else:
+            laser_scan_data = self._process(self.msg)
+
+        laser_scan_data.frame_id = self.msg.header.frame_id
+        laser_scan_data.timestamp = (
+            self.msg.header.stamp.sec + self.msg.header.stamp.nanosec * 1e-9
+        )
+        return laser_scan_data
+
+    def __clipped_ranges(self, msg: LaserScan) -> np.ndarray:
+        """Replaces NaN values and clips the ranges of a scan to [0, range_max]
+
+        :param msg: Input ROS LaserScan message
+        :type msg: LaserScan
+        :rtype: np.ndarray
+        """
+        _no_nan_ranges = np.nan_to_num(msg.ranges, nan=msg.range_max)
+        return _no_nan_ranges.clip(min=0.0, max=msg.range_max)
+
+    def _process(self, msg: LaserScan) -> LaserScanData:
+        """
+        Takes LaserScan ROS message and converts it to LaserScanData
+        :return: LaserScanData
+        """
+        return LaserScanData(
+            angle_min=msg.angle_min,
+            angle_max=msg.angle_max,
+            angle_increment=msg.angle_increment,
+            time_increment=msg.time_increment,
+            scan_time=msg.scan_time,
+            range_min=msg.range_min,
+            range_max=max(msg.range_max, 1e-3),
+            ranges=self.__clipped_ranges(msg),
+            intensities=np.array(msg.intensities),
+        )
+
+    def _transform(self, msg: LaserScan, transform: TransformStamped) -> LaserScanData:
+        """
+        Applies a transform to a given LaserScan message and converts it to LaserScanData
+
+        :param msg: LaserScan message in source frame
+        :type msg: LaserScan
+        :param transform: LaserScan transform from current to goal frame
+        :type transform: TransformStamped
+
+        :return: LaserScanData in goal frame
+        :rtype: LaserScanData
+        """
+        trans = transform.transform.translation
+        quat = transform.transform.rotation
+
+        # Get the transformed laser scan data
+        laserscan_transformed = _get_laserscan_transformed_polar_coordinates(
+            angle_min=msg.angle_min,
+            angle_max=msg.angle_max,
+            angle_increment=msg.angle_increment,
+            laser_scan_ranges=self.__clipped_ranges(msg),
+            max_scan_range=msg.range_max,
+            translation=[trans.x, trans.y, trans.z],
+            rotation=[quat.x, quat.y, quat.z, quat.w],
+            intensities=np.array(msg.intensities),
+        )
+
+        laserscan_transformed.time_increment = msg.time_increment
+        laserscan_transformed.scan_time = msg.scan_time
+
+        return laserscan_transformed
+
+    def _get_ui_content(self, **_) -> Dict:
+        """
+        Utility method to get UI compatible content.
+        To be used with external callbacks in UI Node
+        :returns:   Topic content
+        :rtype:     Any
+        """
+        # NOTE: Only sending metadata until browser front-end has a consumer
+        if not self.msg:
+            return {"frame_id": self.frame_id, "data": None}
+        return {
+            "frame_id": self.frame_id,
+            "data": {
+                "angle_min": self.msg.angle_min,
+                "angle_max": self.msg.angle_max,
+                "num_points": len(self.msg.ranges),
+            },
+        }
+
+
+class PointCloudCallback(GenericCallback):
+    """ROS2 PointCloud2 Callback Handler to process sensor_msgs/PointCloud2 data"""
+
+    def __init__(
+        self,
+        input_topic,
+        node_name: str = "",
+    ) -> None:
+        super().__init__(input_topic, node_name)
+
+    def _get_output(self, **_) -> Optional[PointCloudData]:
+        """Gets the PointCloud2 message data as a PointCloudData container
+        with the raw buffer, layout metadata and lazy cartesian decoding.
+
+        :return: Return PointCloudData
+        :rtype: Optional[PointCloudData]
+        """
+        if not self.msg:
+            return None
+
+        # Empty clouds
+        if self.msg.width == 0 or self.msg.height == 0:
+            return None
+
+        pc = PointCloudData(
+            data=np.frombuffer(self.msg.data, dtype=np.uint8),
+            point_step=self.msg.point_step,
+            row_step=self.msg.row_step,
+            height=self.msg.height,
+            width=self.msg.width,
+            is_bigendian=self.msg.is_bigendian,
+            frame_id=self.msg.header.frame_id,
+            timestamp=self.msg.header.stamp.sec
+            + self.msg.header.stamp.nanosec * 1e-9,
+        )
+
+        for msg_field in self.msg.fields:
+            if msg_field.name == "x":
+                pc.x_offset = msg_field.offset
+                pc.x_field_datatype = msg_field.datatype
+            elif msg_field.name == "y":
+                pc.y_offset = msg_field.offset
+            elif msg_field.name == "z":
+                pc.z_offset = msg_field.offset
+
+        if pc.x_offset is None or pc.y_offset is None or pc.z_offset is None:
+            get_logger(self.node_name or "PointCloudCallback").warning(
+                "Offsets for x, y, z are not found, point cloud data is null"
+            )
+            return None
+
+        return pc
+
+    def _get_ui_content(self, **_) -> Dict:
+        """
+        Utility method to get UI compatible content.
+        To be used with external callbacks in UI Node
+        :returns:   Topic content
+        :rtype:     Any
+        """
+        # NOTE: Only sending metadata until browser front-end has a consumer
+        if not self.msg:
+            return {"frame_id": self.frame_id, "data": None}
+        return {
+            "frame_id": self.frame_id,
+            "data": {
+                "width": self.msg.width,
+                "height": self.msg.height,
+                "point_step": self.msg.point_step,
+            },
         }

--- a/ros_sugar/io/callbacks.py
+++ b/ros_sugar/io/callbacks.py
@@ -483,7 +483,7 @@ class OdomCallback(GenericCallback):
         """
         Get position data.
         """
-        if not self.msg:
+        if self.msg is None:
             return None
         # send fixed position array if it exists
         if isinstance(self.msg, np.ndarray):

--- a/ros_sugar/io/callbacks.py
+++ b/ros_sugar/io/callbacks.py
@@ -514,7 +514,7 @@ class OdomCallback(GenericCallback):
             msg.pose.pose.orientation.z, msg.pose.pose.orientation.w
         )
 
-        speed = np.sqrt(msg.twist.twist.linear.y**2 + msg.twist.twist.linear.y**2)
+        speed = np.sqrt(msg.twist.twist.linear.x**2 + msg.twist.twist.linear.y**2)
 
         position = msg.pose.pose.position
 

--- a/ros_sugar/io/datatypes.py
+++ b/ros_sugar/io/datatypes.py
@@ -1,0 +1,397 @@
+"""Data containers for ROS message payloads processed by callbacks."""
+
+import math
+from typing import List, Optional, Union
+
+import numpy as np
+from attrs import Factory, define, field
+from sensor_msgs.msg import PointField
+
+from ..config import BaseAttrs, base_validators
+
+
+# Numpy format characters for sensor_msgs/PointField datatype constants
+_POINTFIELD_NP_FORMATS = {
+    PointField.INT8: "i1",
+    PointField.UINT8: "u1",
+    PointField.INT16: "i2",
+    PointField.UINT16: "u2",
+    PointField.INT32: "i4",
+    PointField.UINT32: "u4",
+    PointField.FLOAT32: "f4",
+    PointField.FLOAT64: "f8",
+}
+
+
+@define
+class PointCloudData(BaseAttrs):
+    """Container for sensor_msgs/PointCloud2 data.
+
+    Carries the raw (undecoded) point buffer along with the layout metadata
+    needed to interpret it. Consumers that operate on the raw buffer pay no
+    decoding cost. Consumers that want cartesian points can use the lazily
+    decoded `xyz` property.
+
+    :param data: Raw point buffer as a flat uint8 array
+    :param point_step: Length of a single point in bytes
+    :param row_step: Length of a single row in bytes
+    :param height: Number of rows (1 for unorganized clouds)
+    :param width: Number of points per row
+    :param x_offset: Byte offset of the 'x' field within a point
+    :param y_offset: Byte offset of the 'y' field within a point
+    :param z_offset: Byte offset of the 'z' field within a point
+    :param x_field_datatype: Datatype of the coordinate fields as a
+        sensor_msgs/PointField datatype constant (FLOAT32 assumed if not set)
+    :param is_bigendian: Endianness of the point buffer
+    :param frame_id: Coordinates frame of the cloud
+    :param timestamp: Message timestamp in seconds
+    """
+
+    data: np.ndarray = field(eq=False)
+    point_step: int = field(validator=base_validators.gt(0))
+    row_step: int = field(validator=base_validators.gt(0))
+    height: int = field(validator=base_validators.gt(0))
+    width: int = field(validator=base_validators.gt(0))
+    x_offset: Optional[int] = field(default=None)
+    y_offset: Optional[int] = field(default=None)
+    z_offset: Optional[int] = field(default=None)
+    x_field_datatype: Optional[int] = field(default=None)
+    is_bigendian: bool = field(default=False)
+    frame_id: str = field(default="")
+    timestamp: float = field(default=0.0)
+    _xyz_cache: Optional[np.ndarray] = field(
+        default=None, init=False, repr=False, eq=False
+    )
+
+    @property
+    def xyz(self) -> Optional[np.ndarray]:
+        """Cartesian points decoded from the raw buffer, lazily and cached.
+
+        Non-finite points (NaN/inf padding in organized clouds) are dropped.
+
+        :return: Nx3 float32 array of finite points, or None if the cloud
+            has no x/y/z fields
+        :rtype: Optional[np.ndarray]
+        """
+        if self._xyz_cache is not None:
+            return self._xyz_cache
+        if self.x_offset is None or self.y_offset is None or self.z_offset is None:
+            return None
+
+        np_format = _POINTFIELD_NP_FORMATS.get(self.x_field_datatype, "f4")
+        endianness = ">" if self.is_bigendian else "<"
+        point_dtype = np.dtype(
+            {
+                "names": ["x", "y", "z"],
+                "formats": [endianness + np_format] * 3,
+                "offsets": [self.x_offset, self.y_offset, self.z_offset],
+                "itemsize": self.point_step,
+            }
+        )
+
+        raw = self.data
+        row_bytes = self.width * self.point_step
+        if self.row_step != row_bytes and self.height > 1:
+            # drop row padding to get a contiguous array of points
+            raw = np.ascontiguousarray(
+                raw[: self.height * self.row_step].reshape(self.height, self.row_step)[
+                    :, :row_bytes
+                ]
+            ).reshape(-1)
+
+        points = np.frombuffer(raw, dtype=point_dtype, count=self.height * self.width)
+        xyz = np.column_stack((points["x"], points["y"], points["z"])).astype(
+            np.float32, copy=False
+        )
+        self._xyz_cache = xyz[np.isfinite(xyz).all(axis=1)]
+        return self._xyz_cache
+
+
+def _convert_to_0_2pi(value: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+    """
+    Convert an angle or array of angles to [0, 2pi]
+
+    :param value: Input Angle(s) (rad)
+    :type value: float | np.ndarray
+    :return: Converted Angle(s) (rad)
+    :rtype: float | np.ndarray
+    """
+    value = value % (2 * math.pi)
+    if isinstance(value, np.ndarray):
+        return np.where(value < 0, value + 2 * np.pi, value)
+    return value + 2 * math.pi if value < 0 else value
+
+
+def _get_polar_transformation_vector(
+    translation_x: float, translation_y: float
+) -> List[float]:
+    """
+    Get a transformation vector in polar coordinates
+
+    :param translation_x: Translation on x-axis
+    :type translation_x: float
+    :param translation_y: Translation on y-axis
+    :type translation_y: float
+
+    :return: Polar transformation [radius, angle]
+    :rtype: list
+    """
+    r_tr = np.sqrt(translation_x**2 + translation_y**2)
+    if r_tr > 0:
+        ang_tr = np.arccos(translation_x / r_tr)
+        return [r_tr, ang_tr]
+    return [0.0, 0.0]
+
+
+def _get_transform_polar_coordinates(
+    radius: np.ndarray,
+    angle: np.ndarray,
+    transf_vec: List[float],
+    rotation_angle: float,
+) -> tuple:
+    """
+    Apply a polar transformation to the given polar coordinates
+
+    :param radius: Given radius values in polar coordinates
+    :type radius: np.ndarray
+    :param angle: Given angle values in polar coordinates
+    :type angle: np.ndarray
+    :param transf_vec: Transformation vector in polar coordinates [radius_trans, angle_trans]
+    :type transf_vec: list
+
+    :return: Transformed (radius, angle) values
+    :rtype: tuple
+    """
+    radius_transformed_sq = (
+        radius**2
+        + transf_vec[0] ** 2
+        - 2 * radius * transf_vec[0] * np.cos(angle - transf_vec[1])
+    )
+    radius_new = np.sqrt(radius_transformed_sq)
+
+    angle_new = _convert_to_0_2pi(
+        _convert_to_0_2pi(angle) + _convert_to_0_2pi(rotation_angle)
+    )
+
+    return (radius_new, angle_new)
+
+
+@define
+class LaserScanData(BaseAttrs):
+    """
+    Single scan from a planar laser range-finder (LiDAR)
+
+    attributes:
+    angle_min           float32         start angle of the scan [rad]
+    angle_max           float32         end angle of the scan [rad]
+    angle_increment     float32         angular distance between measurements [rad]
+
+    time_increment      float32         time between measurements [seconds] - if your scanner
+                                        is moving, this will be used in interpolating position of 3d points
+
+    scan_time           float32         time between scans [seconds]
+    range_min           float32         minimum range value [m]
+    range_max           float32         maximum range value [m]
+
+    ranges              List[float32]   range data [m] (Note: values < range_min or > range_max should be discarded)
+    angles              float32[]       angle of each range measurement [rad] (generated from the
+                                        angle limits and increment if not provided)
+    intensities         float32[]       intensity data [device-specific units].
+                                        If your device does not provide intensities, please leave the array empty.
+    frame_id            string          coordinates frame of the scan
+    timestamp           float           message timestamp in seconds
+    """
+
+    angle_min: float = field(
+        default=0.0,
+        validator=base_validators.in_range(
+            min_value=-2 * math.pi, max_value=2 * math.pi
+        ),
+    )
+    angle_max: float = field(
+        default=2 * math.pi,
+        validator=base_validators.in_range(
+            min_value=-2 * math.pi, max_value=2 * math.pi
+        ),
+    )
+    angle_increment: float = field(
+        default=0.01 * math.pi,
+        validator=base_validators.in_range(min_value=-math.pi, max_value=math.pi),
+    )
+    time_increment: float = field(
+        default=1e-3, validator=base_validators.in_range(min_value=0.0, max_value=1e3)
+    )
+    scan_time: float = field(
+        default=1e-3, validator=base_validators.in_range(min_value=0.0, max_value=1e3)
+    )
+    range_min: float = field(
+        default=0.0, validator=base_validators.in_range(min_value=0.0, max_value=1e3)
+    )
+    range_max: float = field(
+        default=20.0, validator=base_validators.in_range(min_value=1e-3, max_value=1e3)
+    )
+    ranges: np.ndarray = field(default=Factory(lambda: np.empty(0)), eq=False)
+    angles: np.ndarray = field(default=Factory(lambda: np.empty(0)), eq=False)
+    intensities: np.ndarray = field(default=Factory(lambda: np.empty(0)), eq=False)
+    frame_id: str = field(default="")
+    timestamp: float = field(default=0.0)
+
+    def __attrs_post_init__(self):
+        if self.angles.size == 0:
+            self.angles = np.arange(
+                self.angle_min,
+                self.angle_max + self.angle_increment,
+                self.angle_increment,
+            )
+
+        if self.ranges.size == 0:
+            # default to max range
+            self.ranges = np.full(self.angles.size, self.range_max)
+
+        if self.angles.size != self.ranges.size:
+            minimum_size = min(self.angles.size, self.ranges.size)
+            self.angles = self.angles[:minimum_size]
+            self.ranges = self.ranges[:minimum_size]
+
+    def get_ranges(
+        self,
+        right_angle: float,
+        left_angle: float,
+    ) -> np.ndarray:
+        """Get ranges values in a defined zone between a left angle and a right angle
+
+        :param right_angle: Value of the angle on the right of the ranges (rad)
+        :type right_angle: float
+        :param left_angle: Value of the angle on the left of the ranges (rad)
+        :type left_angle: float
+
+        :return: Ranges values in the specified zone
+        :rtype: np.ndarray
+        """
+        return self.ranges[self.__angles_in_zone(right_angle, left_angle)]
+
+    def get_angles(
+        self,
+        right_angle: float,
+        left_angle: float,
+    ) -> np.ndarray:
+        """Get angles values in a defined zone between a left angle and a right angle
+
+        :param right_angle: Value of the angle on the right of the ranges (rad)
+        :type right_angle: float
+        :param left_angle: Value of the angle on the left of the ranges (rad)
+        :type left_angle: float
+
+        :return: Angles values in the specified zone
+        :rtype: np.ndarray
+        """
+        return self.angles[self.__angles_in_zone(right_angle, left_angle)]
+
+    def __angles_in_zone(self, right_angle: float, left_angle: float) -> np.ndarray:
+        """Get a mask of the scan angles lying between a right and a left angle
+
+        :return: Boolean mask over the scan angles
+        :rtype: np.ndarray
+        """
+        angles = _convert_to_0_2pi(self.angles)
+        left_angle = _convert_to_0_2pi(left_angle)
+        right_angle = _convert_to_0_2pi(right_angle)
+
+        if right_angle > left_angle:
+            return (angles <= left_angle) | (angles >= right_angle)
+        return (angles <= left_angle) & (angles >= right_angle)
+
+
+def _get_laserscan_transformed_polar_coordinates(
+    angle_min: float,
+    angle_max: float,
+    angle_increment: float,
+    laser_scan_ranges: np.ndarray,
+    max_scan_range: float,
+    translation: List[float],
+    rotation: List[float],
+    intensities: Optional[np.ndarray] = None,
+) -> LaserScanData:
+    """
+    Transform list of angles and ranges to laserscan data using a given polar transformation
+
+    :param angle_min: Scan min angle (rad)
+    :type angle_min: float
+    :param angle_max: Scan max angle (rad)
+    :type angle_max: float
+    :param angle_increment: Scan angle step (rad)
+    :type angle_increment: float
+    :param laser_scan_ranges: Values of the laser scan along the angles range (m)
+    :type laser_scan_ranges: np.ndarray
+    :param max_scan_range: Max range for the scan (m)
+    :type max_scan_range: float
+    :param translation: Translation vector [x, y, z]
+    :type translation: list[float]
+    :param rotation: Rotation quaternion [x, y, z, w]
+    :type rotation: list[float]
+    :param intensities: Scan intensities along the angles range
+    :type intensities: Optional[np.ndarray]
+
+    :return: Transformed laser scan data
+    :rtype: LaserScanData
+    """
+    angles: np.ndarray = np.arange(
+        angle_min, angle_max + angle_increment, angle_increment
+    )  # create list of angles
+
+    if len(angles) < len(laser_scan_ranges):
+        raise ValueError(
+            f"Missing laser scan ranges for angles in [{angle_min}, {angle_max}], got length {len(laser_scan_ranges)} of ranges for {len(angles)} angles"
+        )
+
+    angles = angles[: len(laser_scan_ranges)]
+
+    # Handle degenerate scans without breaking the container validators
+    if angles.size == 0:
+        return LaserScanData(
+            angle_min=angle_min,
+            angle_max=angle_max,
+            angle_increment=angle_increment,
+            range_max=max(max_scan_range, 1e-3),
+        )
+
+    # Limit ranges by max value (to remove inf values)
+    r_max = max_scan_range
+    ranges: np.ndarray = np.where(
+        laser_scan_ranges != np.inf, np.minimum(laser_scan_ranges, r_max), r_max
+    )
+
+    trans_vec = _get_polar_transformation_vector(
+        translation_x=translation[0], translation_y=translation[1]
+    )
+    rotation_angle = 2 * math.atan2(rotation[2], rotation[3])
+
+    ranges_transformed, angles_transformed = _get_transform_polar_coordinates(
+        radius=ranges, angle=angles, transf_vec=trans_vec, rotation_angle=rotation_angle
+    )
+
+    # Sort values to be compatible with laserscan format
+    sorted_indices = np.argsort(angles_transformed)
+    if not isinstance(angles_transformed, np.ndarray) or not isinstance(
+        ranges_transformed, np.ndarray
+    ):
+        raise TypeError("Cannot create laser scan data with one value")
+    sorted_angles = angles_transformed[sorted_indices]
+    sorted_ranges = ranges_transformed[sorted_indices]
+
+    # Carry intensities through the transform when they cover the scan
+    if intensities is not None and intensities.size == angles.size:
+        sorted_intensities = intensities[sorted_indices]
+    else:
+        sorted_intensities = np.empty(0)
+
+    return LaserScanData(
+        angle_min=float(np.min(sorted_angles)),
+        angle_max=float(np.max(sorted_angles)),
+        angle_increment=angle_increment,
+        angles=sorted_angles,
+        range_min=float(np.min(sorted_ranges)),
+        range_max=max(float(np.max(sorted_ranges)), 1e-3),
+        ranges=sorted_ranges,
+        intensities=sorted_intensities,
+    )

--- a/ros_sugar/io/supported_types.py
+++ b/ros_sugar/io/supported_types.py
@@ -581,7 +581,7 @@ class OccupancyGrid(SupportedType):
         msg.info.width = output.shape[0]
         msg.info.height = output.shape[1]
         msg.info.resolution = resolution
-        msg.info.origin = origin if origin else Pose()
+        msg.info.origin = origin if origin else ROSPose()
 
         # flatten by column
         # index (0,0) is the lower right corner of the grid in ROS

--- a/ros_sugar/io/supported_types.py
+++ b/ros_sugar/io/supported_types.py
@@ -9,6 +9,7 @@ import importlib
 from geometry_msgs.msg import Point as ROSPoint
 from geometry_msgs.msg import PointStamped as ROSPointStamped
 from geometry_msgs.msg import Pose as ROSPose
+from geometry_msgs.msg import PoseArray as ROSPoseArray
 from geometry_msgs.msg import PoseStamped as ROSPoseStamped
 from geometry_msgs.msg import Twist as ROSTwist
 
@@ -22,6 +23,7 @@ from automatika_ros_sugar.msg import ComponentStatus as ROSComponentStatus
 # SENSOR_MSGS SUPPORTED ROS TYPES
 from sensor_msgs.msg import Image as ROSImage, CompressedImage as ROSCompressedImage
 from sensor_msgs.msg import LaserScan as ROSLaserScan
+from sensor_msgs.msg import PointCloud2 as ROSPointCloud2
 
 # STD_MSGS SUPPORTED ROS TYPES
 from std_msgs.msg import ByteMultiArray
@@ -515,7 +517,16 @@ class LaserScan(SupportedType):
     """LaserScan"""
 
     _ros_type = ROSLaserScan
-    callback = callbacks.GenericCallback
+    callback = callbacks.LaserScanCallback
+    _ui_rate_sampled = True  # dense sensor stream
+
+
+class PointCloud2(SupportedType):
+    """PointCloud2"""
+
+    _ros_type = ROSPointCloud2
+    callback = callbacks.PointCloudCallback
+    _ui_rate_sampled = True  # dense sensor stream
 
 
 class Path(SupportedType):
@@ -692,6 +703,43 @@ class PoseStamped(Pose):
             msg.pose.orientation.x = output[4]
             msg.pose.orientation.y = output[5]
             msg.pose.orientation.z = output[6]
+        return msg
+
+
+class PoseArray(SupportedType):
+    """PoseArray"""
+
+    _ros_type = ROSPoseArray
+    callback = callbacks.PoseArrayCallback
+
+    @classmethod
+    def convert(cls, output: Union[np.ndarray, List], **_) -> ROSPoseArray:
+        """ROS message converter function for datatype PoseArray.
+
+        Each element of the given set is a single pose as [x, y, z],
+        [x, y, z, heading] or [x, y, z, qw, qx, qy, qz]
+
+        :param output: Set of poses
+        :type output: Union[np.ndarray, List]
+        :param _:
+        :rtype: ROSPoseArray
+        """
+        msg = ROSPoseArray()
+        poses = []
+        for pose_data in output:
+            pose_data = np.asarray(pose_data, dtype=np.float64)
+            if pose_data.shape[0] == 4:
+                pose = ROSPose()
+                pose.position.x = pose_data[0]
+                pose.position.y = pose_data[1]
+                pose.position.z = pose_data[2]
+                # heading to quaternion around z
+                pose.orientation.z = np.sin(pose_data[3] / 2)
+                pose.orientation.w = np.cos(pose_data[3] / 2)
+            else:
+                pose = Pose.convert(pose_data)
+            poses.append(pose)
+        msg.poses = poses
         return msg
 
 

--- a/ros_sugar/io/supported_types.py
+++ b/ros_sugar/io/supported_types.py
@@ -194,7 +194,8 @@ def ros_msg_to_str(msg_object: Any) -> str:
                     lines += f"{item}, "
             lines += "]"
         else:
-            lines += f"{field_name.removeprefix('_')}: {field_value} | "
+            name = field_name[1:] if field_name.startswith("_") else field_name
+            lines += f"{name}: {field_value} | "
     return lines
 
 

--- a/ros_sugar/launch/launcher.py
+++ b/ros_sugar/launch/launcher.py
@@ -353,6 +353,9 @@ class Launcher:
         ssl_keyfile_path: str = "key.pem",
         ssl_certificate_path: str = "cert.pem",
         hide_settings_panel: bool = False,
+        serve_browser: bool = True,
+        api_stream_default_rate: float = 10.0,
+        api_max_stream_rate: float = 30.0,
     ):
         """
         Enables the user interface (UI) subsystem for recipes, initializing all UI extensions
@@ -390,13 +393,42 @@ class Launcher:
         :param hide_settings_panel:
             Disable the components settings panel in the UI.
         :type hide_settings_panel: bool, default False
+
+        :param serve_browser:
+            Serve the browser front-end alongside the JSON/WebSocket API.
+            Set to ``False`` to serve the API only, which requires just
+            ``starlette`` and ``uvicorn`` instead of the browser dependencies
+            (FastHTML/MonsterUI).
+        :type serve_browser: bool, default True
+
+        :param api_stream_default_rate:
+            Rate (Hz) at which the JSON API streams rate-sampled output topics
+            to a connected client that does not request a rate explicitly.
+        :type api_stream_default_rate: float, default 10.0
+
+        :param api_max_stream_rate:
+            Hard upper bound (Hz) for a client-requested API stream rate.
+        :type api_max_stream_rate: float, default 30.0
         """
 
         self._ui_input_elements = []
         self._ui_output_elements = []
-        for ext in UI_EXTENSIONS:
-            input_elements_dict, output_elements_dict = UI_EXTENSIONS[ext]()
-            # Additional input/output elements are used for UI elements coming from derived packages
+
+        # NOTE: UI extensions provide browser widgets. They are skipped
+        # entirely in API-only mode, and a missing browser stack degrades to
+        # API-only instead of failing the recipe
+        extensions = UI_EXTENSIONS if serve_browser else {}
+        for ext in extensions:
+            try:
+                input_elements_dict, output_elements_dict = UI_EXTENSIONS[ext]()
+            except ModuleNotFoundError as e:
+                logger.warning(
+                    f"Skipping UI extension '{ext}': browser dependencies not "
+                    f"installed ({e}). The recipe UI will serve the API only."
+                )
+                continue
+            # Additional input/output elements are used for UI elements coming
+            # from derived packages
             for key, element in input_elements_dict.items():
                 self._ui_input_elements.append((
                     f"{key.__module__}.{key.__qualname__}",
@@ -418,6 +450,9 @@ class Launcher:
             ssl_keyfile=ssl_keyfile_path,
             ssl_certificate=ssl_certificate_path,
             hide_settings=hide_settings_panel,
+            serve_browser=serve_browser,
+            api_stream_default_rate=api_stream_default_rate,
+            api_max_stream_rate=api_max_stream_rate,
         )
 
     @property

--- a/ros_sugar/launch/launcher.py
+++ b/ros_sugar/launch/launcher.py
@@ -411,22 +411,41 @@ class Launcher:
         :type api_max_stream_rate: float, default 30.0
         """
 
+        # Fail fast if dependencies of the requested UI mode are missing
+        from importlib.util import find_spec
+
+        # import name -> pip name
+        required = {"starlette": "starlette", "uvicorn": "uvicorn"}
+        if serve_browser:
+            required["fasthtml"] = "python-fasthtml"
+            required["monsterui"] = "monsterui"
+        missing = [pip for mod, pip in required.items() if find_spec(mod) is None]
+        if missing:
+            message = (
+                "enable_ui requires packages that are not installed: "
+                f"{', '.join(missing)}.\n"
+            )
+            if serve_browser:
+                message += (
+                    "Install the browser UI stack (includes starlette and "
+                    "uvicorn) with:\n"
+                    "    pip install python-fasthtml monsterui\n"
+                    "Or serve only the JSON/WebSocket API (no browser) with "
+                    "enable_ui(serve_browser=False), which requires just:\n"
+                    "    pip install starlette uvicorn"
+                )
+            else:
+                message += "Install with: pip install starlette uvicorn"
+            raise ModuleNotFoundError(message)
+
         self._ui_input_elements = []
         self._ui_output_elements = []
 
         # NOTE: UI extensions provide browser widgets. They are skipped
-        # entirely in API-only mode, and a missing browser stack degrades to
-        # API-only instead of failing the recipe
+        # entirely in API-only mode
         extensions = UI_EXTENSIONS if serve_browser else {}
         for ext in extensions:
-            try:
-                input_elements_dict, output_elements_dict = UI_EXTENSIONS[ext]()
-            except ModuleNotFoundError as e:
-                logger.warning(
-                    f"Skipping UI extension '{ext}': browser dependencies not "
-                    f"installed ({e}). The recipe UI will serve the API only."
-                )
-                continue
+            input_elements_dict, output_elements_dict = UI_EXTENSIONS[ext]()
             # Additional input/output elements are used for UI elements coming
             # from derived packages
             for key, element in input_elements_dict.items():

--- a/ros_sugar/ui_node/ui_node.py
+++ b/ros_sugar/ui_node/ui_node.py
@@ -28,9 +28,8 @@ class UINodeConfig(BaseComponentConfig):
     ssl_keyfile: str = field(default="key.pem")
     ssl_certificate: str = field(default="cert.pem")
     hide_settings: bool = field(default=False)
-    feedback_update_period: float = field(
-        default=1.0, validator=in_range(min_value=1e-3, max_value=1e3)
-    )  # 1 second ui feedback update rate
+    # Serve the browser front-end alongside the API
+    serve_browser: bool = field(default=True)
     # Default rate (Hz) at which the JSON API streams output topics to a
     # connected client when it does not request one explicitly.
     api_stream_default_rate: float = field(

--- a/scripts/ui_node_executable
+++ b/scripts/ui_node_executable
@@ -4,12 +4,14 @@ import json
 import threading
 from pathlib import Path
 
-import uvicorn
-
 from ros_sugar.launch.executable import setup_component, run_component
 from ros_sugar.ui_node import UINode, UINodeConfig
 from ros_sugar.ui_node.api import build_api_app
 from ros_sugar.utils import logger
+
+# NOTE: Imported after build_api_app so a missing web stack surfaces the
+# install hint error from api.py rather than a bare import error
+import uvicorn
 
 
 def main():
@@ -54,23 +56,27 @@ def main():
     ros_thread.start()
 
     # Build the optional FastHTML browser app. Mounts under "/"
-    try:
-        from ros_sugar.ui_node.browser import build_browser_app
-
-        browser_app = build_browser_app(
-            ros_node,
-            additional_input_elements=additional_input_elements,
-            additional_output_elements=additional_output_elements,
-            system_info=system_info,
-        )
-    except ModuleNotFoundError as e:
-        logger.warning(
-            f"Browser UI dependencies not installed ({e}). "
-            "Serving the JSON/WebSocket API only. "
-            " For browser UI please install FastHTML and MonsterUI with: "
-            "`pip install python-fasthtml monsterui`"
-        )
+    if not ros_node_config.serve_browser:
+        logger.info("Browser UI disabled. Serving the JSON/WebSocket API only.")
         browser_app = None
+    else:
+        try:
+            from ros_sugar.ui_node.browser import build_browser_app
+
+            browser_app = build_browser_app(
+                ros_node,
+                additional_input_elements=additional_input_elements,
+                additional_output_elements=additional_output_elements,
+                system_info=system_info,
+            )
+        except ModuleNotFoundError as e:
+            logger.warning(
+                f"Browser UI dependencies not installed ({e}). "
+                "Serving the JSON/WebSocket API only. "
+                " For browser UI please install FastHTML and MonsterUI with: "
+                "`pip install python-fasthtml monsterui`"
+            )
+            browser_app = None
 
     # Create the JSON/WebSocket API is the server host, server host
     api_app = build_api_app(ros_node, browser_app=browser_app)

--- a/scripts/ui_node_executable
+++ b/scripts/ui_node_executable
@@ -9,8 +9,6 @@ from ros_sugar.ui_node import UINode, UINodeConfig
 from ros_sugar.ui_node.api import build_api_app
 from ros_sugar.utils import logger
 
-# NOTE: Imported after build_api_app so a missing web stack surfaces the
-# install hint error from api.py rather than a bare import error
 import uvicorn
 
 
@@ -60,23 +58,14 @@ def main():
         logger.info("Browser UI disabled. Serving the JSON/WebSocket API only.")
         browser_app = None
     else:
-        try:
-            from ros_sugar.ui_node.browser import build_browser_app
+        from ros_sugar.ui_node.browser import build_browser_app
 
-            browser_app = build_browser_app(
-                ros_node,
-                additional_input_elements=additional_input_elements,
-                additional_output_elements=additional_output_elements,
-                system_info=system_info,
-            )
-        except ModuleNotFoundError as e:
-            logger.warning(
-                f"Browser UI dependencies not installed ({e}). "
-                "Serving the JSON/WebSocket API only. "
-                " For browser UI please install FastHTML and MonsterUI with: "
-                "`pip install python-fasthtml monsterui`"
-            )
-            browser_app = None
+        browser_app = build_browser_app(
+            ros_node,
+            additional_input_elements=additional_input_elements,
+            additional_output_elements=additional_output_elements,
+            system_info=system_info,
+        )
 
     # Create the JSON/WebSocket API is the server host, server host
     api_app = build_api_app(ros_node, browser_app=browser_app)

--- a/test/io_types_test.py
+++ b/test/io_types_test.py
@@ -1,0 +1,650 @@
+"""Tests for ros_sugar.io supported types, callbacks and data containers.
+
+Sections, one per message type:
+- PointCloud2: PointCloudCallback -> PointCloudData, lazy xyz decoding for
+  the common buffer layouts, NaN filtering, degenerate clouds
+- LaserScan: LaserScanCallback -> LaserScanData, range sanitization, polar
+  TF transform, intensity carrying, zone queries
+- PoseArray: convert formats and PoseArrayCallback numpy output
+- Odometry / PoseStamped: pose-to-array processing
+- OccupancyGrid: metadata, numpy conversion round-trip, obstacle
+  extraction in world frame, UI content
+- MultiArray: layout-driven reshaping
+- Image: raw buffer decoding
+- Path: UI downsampling
+"""
+
+from typing import List, Optional, Tuple
+
+import base64
+import numpy as np
+import pytest
+from geometry_msgs.msg import Pose as ROSPose
+from geometry_msgs.msg import PoseArray, PoseStamped, TransformStamped
+from nav_msgs.msg import Odometry, OccupancyGrid, Path
+from sensor_msgs.msg import Image, LaserScan, PointCloud2, PointField
+from std_msgs.msg import Float32MultiArray, MultiArrayDimension
+
+from ros_sugar.io import Topic, get_msg_type
+from ros_sugar.io.callbacks import (
+    ImageCallback,
+    LaserScanCallback,
+    OccupancyGridCallback,
+    OdomCallback,
+    PathCallback,
+    PointCloudCallback,
+    PoseArrayCallback,
+    PoseStampedCallback,
+    StdMsgArrayCallback,
+)
+from ros_sugar.io.datatypes import LaserScanData, PointCloudData
+from ros_sugar.io import supported_types
+
+
+def _topic(msg_type: str) -> Topic:
+    return Topic(name="test_topic", msg_type=msg_type)
+
+
+def _fed_callback(callback_class, msg_type: str, msg=None):
+    callback = callback_class(_topic(msg_type))
+    if msg is not None:
+        callback.callback(msg)
+    return callback
+
+
+# ---------------------------------------------------------------------------
+# PointCloud2
+# ---------------------------------------------------------------------------
+
+_NP_TO_PF = {
+    np.dtype(np.float32): PointField.FLOAT32,
+    np.dtype(np.float64): PointField.FLOAT64,
+}
+
+
+def _make_cloud(
+    points: List[Tuple[float, float, float]],
+    np_type: type = np.float32,
+    point_padding: int = 0,
+    height: int = 1,
+    row_padding: int = 0,
+    bigendian: bool = False,
+    drop_fields: Optional[List[str]] = None,
+    frame_id: str = "lidar_link",
+) -> PointCloud2:
+    """Build a synthetic PointCloud2 with the given layout."""
+    scalar = np.dtype(np_type).newbyteorder(">" if bigendian else "<")
+    item = scalar.itemsize
+    point_step = 3 * item + point_padding
+    drop_fields = drop_fields or []
+
+    assert len(points) % height == 0
+    width = len(points) // height
+    row_step = width * point_step + row_padding
+
+    buf = bytearray(height * row_step)
+    for i, (x, y, z) in enumerate(points):
+        row, col = divmod(i, width)
+        base = row * row_step + col * point_step
+        for j, value in enumerate((x, y, z)):
+            raw = np.array([value], dtype=scalar).tobytes()
+            buf[base + j * item : base + (j + 1) * item] = raw
+
+    msg = PointCloud2()
+    msg.header.frame_id = frame_id
+    msg.header.stamp.sec = 12
+    msg.header.stamp.nanosec = 500000000
+    msg.height = height
+    msg.width = width
+    msg.point_step = point_step
+    msg.row_step = row_step
+    msg.is_bigendian = bigendian
+    msg.data = bytes(buf)
+    msg.fields = [
+        PointField(
+            name=name, offset=j * item, datatype=_NP_TO_PF[np.dtype(np_type)], count=1
+        )
+        for j, name in enumerate(("x", "y", "z"))
+        if name not in drop_fields
+    ]
+    return msg
+
+
+def _cloud_output(msg: PointCloud2) -> Optional[PointCloudData]:
+    return _fed_callback(PointCloudCallback, "PointCloud2", msg).get_output()
+
+
+CLOUD_POINTS = [(1.0, 2.0, 3.0), (-4.5, 0.0, 7.25), (0.5, -1.5, 2.5), (10.0, 20.0, 30.0)]
+
+
+def test_cloud_basic_float32():
+    output = _cloud_output(_make_cloud(CLOUD_POINTS))
+    assert output is not None
+    assert output.frame_id == "lidar_link"
+    assert output.timestamp == pytest.approx(12.5)
+    assert output.width == 4
+    assert output.height == 1
+    assert (output.x_offset, output.y_offset, output.z_offset) == (0, 4, 8)
+    assert output.x_field_datatype == PointField.FLOAT32
+    xyz = output.xyz
+    assert xyz.dtype == np.float32
+    np.testing.assert_allclose(xyz, np.array(CLOUD_POINTS, dtype=np.float32))
+
+
+def test_cloud_point_padding():
+    # x,y,z + 4 bytes of padding per point (common lidar layout with intensity)
+    output = _cloud_output(_make_cloud(CLOUD_POINTS, point_padding=4))
+    np.testing.assert_allclose(output.xyz, np.array(CLOUD_POINTS, dtype=np.float32))
+
+
+def test_cloud_organized_with_row_padding():
+    output = _cloud_output(
+        _make_cloud(CLOUD_POINTS, height=2, point_padding=4, row_padding=8)
+    )
+    assert output.height == 2
+    assert output.width == 2
+    np.testing.assert_allclose(output.xyz, np.array(CLOUD_POINTS, dtype=np.float32))
+
+
+def test_cloud_float64():
+    output = _cloud_output(_make_cloud(CLOUD_POINTS, np_type=np.float64))
+    assert output.x_field_datatype == PointField.FLOAT64
+    xyz = output.xyz
+    assert xyz.dtype == np.float32
+    np.testing.assert_allclose(xyz, np.array(CLOUD_POINTS, dtype=np.float32))
+
+
+def test_cloud_bigendian():
+    output = _cloud_output(_make_cloud(CLOUD_POINTS, bigendian=True))
+    assert output.is_bigendian
+    np.testing.assert_allclose(output.xyz, np.array(CLOUD_POINTS, dtype=np.float32))
+
+
+def test_cloud_nan_points_filtered():
+    points = [(1.0, 2.0, 3.0), (np.nan, np.nan, np.nan), (4.0, 5.0, 6.0)]
+    output = _cloud_output(_make_cloud(points))
+    np.testing.assert_allclose(
+        output.xyz, np.array([(1.0, 2.0, 3.0), (4.0, 5.0, 6.0)], dtype=np.float32)
+    )
+
+
+def test_cloud_xyz_is_cached():
+    output = _cloud_output(_make_cloud(CLOUD_POINTS))
+    assert output.xyz is output.xyz
+
+
+def test_cloud_missing_coordinate_field_returns_none():
+    assert _cloud_output(_make_cloud(CLOUD_POINTS, drop_fields=["z"])) is None
+
+
+def test_cloud_empty_returns_none():
+    msg = PointCloud2()
+    msg.header.frame_id = "lidar_link"
+    msg.point_step = 12
+    msg.row_step = 12
+    assert _cloud_output(msg) is None
+
+
+def test_cloud_no_message_returns_none():
+    assert _fed_callback(PointCloudCallback, "PointCloud2").get_output() is None
+
+
+def test_cloud_type_registration():
+    assert get_msg_type("PointCloud2") is supported_types.PointCloud2
+    topic = _topic("PointCloud2")
+    assert topic.msg_type.get_ros_type() is PointCloud2
+    assert topic.msg_type.callback is PointCloudCallback
+
+
+def test_cloud_ui_content():
+    callback = _fed_callback(PointCloudCallback, "PointCloud2")
+    assert callback._get_ui_content() == {"frame_id": None, "data": None}
+    callback.callback(_make_cloud(CLOUD_POINTS, point_padding=4))
+    content = callback._get_ui_content()
+    assert content["frame_id"] == "lidar_link"
+    assert content["data"] == {"width": 4, "height": 1, "point_step": 16}
+
+
+# ---------------------------------------------------------------------------
+# LaserScan
+# ---------------------------------------------------------------------------
+
+
+def _make_scan(
+    ranges: List[float],
+    angle_increment: float = np.pi / 4,
+    range_max: float = 10.0,
+    intensities: Optional[List[float]] = None,
+    frame_id: str = "laser_link",
+) -> LaserScan:
+    msg = LaserScan()
+    msg.header.frame_id = frame_id
+    msg.header.stamp.sec = 5
+    msg.header.stamp.nanosec = 250000000
+    msg.angle_min = 0.0
+    msg.angle_max = angle_increment * (len(ranges) - 1) if ranges else 0.0
+    msg.angle_increment = angle_increment
+    msg.time_increment = 0.001
+    msg.scan_time = 0.1
+    msg.range_min = 0.1
+    msg.range_max = range_max
+    msg.ranges = ranges
+    msg.intensities = intensities or []
+    return msg
+
+
+def _make_transform(
+    x: float = 0.0, y: float = 0.0, yaw: float = 0.0
+) -> TransformStamped:
+    tf = TransformStamped()
+    tf.transform.translation.x = x
+    tf.transform.translation.y = y
+    tf.transform.rotation.z = np.sin(yaw / 2)
+    tf.transform.rotation.w = np.cos(yaw / 2)
+    return tf
+
+
+def _scan_callback(msg=None, transformation=None) -> LaserScanCallback:
+    callback = LaserScanCallback(_topic("LaserScan"), transformation=transformation)
+    if msg is not None:
+        callback.callback(msg)
+    return callback
+
+
+def test_scan_process_basic():
+    output = _scan_callback(
+        _make_scan([1.0, np.nan, np.inf, 2.5], intensities=[10.0, 20.0, 30.0, 40.0])
+    ).get_output()
+    assert isinstance(output, LaserScanData)
+    assert output.frame_id == "laser_link"
+    assert output.timestamp == pytest.approx(5.25)
+    assert output.range_max == pytest.approx(10.0)
+    assert output.time_increment == pytest.approx(0.001)
+    assert output.scan_time == pytest.approx(0.1)
+    # NaN and inf replaced by range_max, valid values untouched
+    np.testing.assert_allclose(output.ranges, [1.0, 10.0, 10.0, 2.5])
+    np.testing.assert_allclose(output.intensities, [10.0, 20.0, 30.0, 40.0])
+    # angles generated to match the ranges
+    np.testing.assert_allclose(output.angles, np.arange(4) * np.pi / 4, atol=1e-6)
+
+
+def test_scan_transform_identity():
+    output = _scan_callback(
+        _make_scan([1.0, 2.0, 3.0]), transformation=_make_transform()
+    ).get_output()
+    np.testing.assert_allclose(output.ranges, [1.0, 2.0, 3.0], rtol=1e-6)
+    np.testing.assert_allclose(output.angles, np.arange(3) * np.pi / 4, atol=1e-6)
+    assert output.frame_id == "laser_link"
+    assert output.time_increment == pytest.approx(0.001)
+
+
+def test_scan_transform_rotation_reorders_scan():
+    # two rays at angles [0, pi]; rotation by pi wraps the second ray to
+    # angle 0 so the scan gets reordered
+    scan = _make_scan([1.0, 2.0], angle_increment=np.pi, intensities=[10.0, 20.0])
+    output = _scan_callback(scan, transformation=_make_transform(yaw=np.pi)).get_output()
+    np.testing.assert_allclose(output.angles, [0.0, np.pi], atol=1e-6)
+    np.testing.assert_allclose(output.ranges, [2.0, 1.0], rtol=1e-6)
+    # intensities carried through the transform and reordered consistently
+    np.testing.assert_allclose(output.intensities, [20.0, 10.0])
+
+
+def test_scan_transform_translation():
+    # rays at angles [0, pi/2] with ranges [2, 3], sensor translated by x=1:
+    # radius' = sqrt(r^2 + 1 - 2 r cos(angle))
+    scan = _make_scan([2.0, 3.0], angle_increment=np.pi / 2)
+    output = _scan_callback(scan, transformation=_make_transform(x=1.0)).get_output()
+    np.testing.assert_allclose(output.ranges, [1.0, np.sqrt(10.0)], rtol=1e-6)
+    # observed limits replace the device limits after a transform
+    assert output.range_min == pytest.approx(1.0)
+    assert output.range_max == pytest.approx(np.sqrt(10.0))
+
+
+def test_scan_transform_via_get_output_kwarg():
+    callback = _scan_callback(_make_scan([1.0, 2.0, 3.0]))
+    np.testing.assert_allclose(
+        callback.get_output(transformation=_make_transform()).ranges,
+        [1.0, 2.0, 3.0],
+        rtol=1e-6,
+    )
+
+
+def test_scan_degenerate():
+    # zero range_max would violate the container validator without the guard
+    output = _scan_callback(_make_scan([0.0, 0.0], range_max=0.0)).get_output()
+    assert output.range_max == pytest.approx(1e-3)
+    # empty scan through the transform path does not raise
+    output = _scan_callback(
+        _make_scan([]), transformation=_make_transform(yaw=0.5)
+    ).get_output()
+    assert isinstance(output, LaserScanData)
+
+
+def test_scan_get_ranges_zone():
+    data = LaserScanData(
+        angle_min=0.0,
+        angle_max=2 * np.pi,
+        angle_increment=np.pi / 2,
+        ranges=np.array([1.0, 2.0, 3.0, 4.0, 5.0]),
+    )
+    # zone from -pi/4 to pi/4 selects the rays at angles 0 and 2*pi
+    np.testing.assert_allclose(
+        data.get_ranges(right_angle=-np.pi / 4, left_angle=np.pi / 4), [1.0, 5.0]
+    )
+    np.testing.assert_allclose(
+        data.get_angles(right_angle=-np.pi / 4, left_angle=np.pi / 4), [0.0, 2 * np.pi]
+    )
+
+
+def test_scan_no_message_returns_none():
+    assert _scan_callback().get_output() is None
+
+
+def test_scan_type_registration():
+    assert get_msg_type("LaserScan") is supported_types.LaserScan
+    topic = _topic("LaserScan")
+    assert topic.msg_type.get_ros_type() is LaserScan
+    assert topic.msg_type.callback is LaserScanCallback
+
+
+def test_scan_ui_content():
+    callback = _scan_callback()
+    assert callback._get_ui_content() == {"frame_id": None, "data": None}
+    callback.callback(_make_scan([1.0, 2.0, 3.0]))
+    content = callback._get_ui_content()
+    assert content["frame_id"] == "laser_link"
+    assert content["data"]["num_points"] == 3
+
+
+# ---------------------------------------------------------------------------
+# PoseArray
+# ---------------------------------------------------------------------------
+
+
+def test_pose_array_convert_positions_only():
+    positions = [(1.0, 2.0, 3.0), (-4.0, 5.5, 0.0)]
+    msg = supported_types.PoseArray.convert(positions)
+    assert isinstance(msg, PoseArray)
+    assert len(msg.poses) == 2
+    for pose, position in zip(msg.poses, positions):
+        assert (pose.position.x, pose.position.y, pose.position.z) == position
+        # identity orientation
+        assert pose.orientation.w == 1.0
+        assert pose.orientation.z == 0.0
+
+
+def test_pose_array_convert_positions_with_heading():
+    heading = np.pi / 2
+    msg = supported_types.PoseArray.convert([(1.0, 2.0, 3.0, heading)])
+    pose = msg.poses[0]
+    assert pose.orientation.z == pytest.approx(np.sin(heading / 2))
+    assert pose.orientation.w == pytest.approx(np.cos(heading / 2))
+
+
+def test_pose_array_convert_full_poses():
+    # [x, y, z, qw, qx, qy, qz] as in Pose.convert
+    msg = supported_types.PoseArray.convert(
+        np.array([[1.0, 2.0, 3.0, 0.0, 0.0, 0.0, 1.0]])
+    )
+    pose = msg.poses[0]
+    assert pose.orientation.w == 0.0
+    assert pose.orientation.z == 1.0
+
+
+def test_pose_array_convert_invalid_pose_raises():
+    with pytest.raises(ValueError):
+        supported_types.PoseArray.convert([(1.0, 2.0)])
+
+
+def test_pose_array_callback_output():
+    heading = 0.75
+    msg = PoseArray()
+    msg.header.frame_id = "odom"
+    pose = ROSPose()
+    pose.position.x, pose.position.y, pose.position.z = 1.0, 2.0, 3.0
+    pose.orientation.z = np.sin(heading / 2)
+    pose.orientation.w = np.cos(heading / 2)
+    msg.poses = [pose, ROSPose()]
+
+    callback = _fed_callback(PoseArrayCallback, "PoseArray")
+    assert callback.get_output() is None
+    callback.callback(msg)
+    output = callback.get_output()
+    assert output.shape == (2, 4)
+    np.testing.assert_allclose(output[0], [1.0, 2.0, 3.0, heading])
+    np.testing.assert_allclose(output[1], [0.0, 0.0, 0.0, 0.0])
+    assert callback.frame_id == "odom"
+
+
+def test_pose_array_type_registration():
+    assert get_msg_type("PoseArray") is supported_types.PoseArray
+    topic = _topic("PoseArray")
+    assert topic.msg_type.get_ros_type() is PoseArray
+    assert topic.msg_type.callback is PoseArrayCallback
+
+
+def test_pose_array_ui_content():
+    callback = _fed_callback(PoseArrayCallback, "PoseArray")
+    assert callback._get_ui_content() == {"frame_id": None, "data": None}
+    msg = PoseArray()
+    msg.header.frame_id = "odom"
+    msg.poses = [ROSPose()]
+    callback.callback(msg)
+    content = callback._get_ui_content()
+    assert content["frame_id"] == "odom"
+    assert content["data"] == [[0.0, 0.0, 0.0, 0.0]]
+
+
+# ---------------------------------------------------------------------------
+# Odometry / PoseStamped
+# ---------------------------------------------------------------------------
+
+
+def test_odom_process():
+    yaw = np.pi / 2
+    msg = Odometry()
+    msg.pose.pose.position.x = 1.0
+    msg.pose.pose.position.y = 2.0
+    msg.pose.pose.position.z = 0.5
+    msg.pose.pose.orientation.z = np.sin(yaw / 2)
+    msg.pose.pose.orientation.w = np.cos(yaw / 2)
+    msg.twist.twist.linear.x = 3.0
+    msg.twist.twist.linear.y = 4.0
+
+    output = _fed_callback(OdomCallback, "Odometry", msg).get_output()
+    # speed is the 2D twist magnitude sqrt(x^2 + y^2)
+    np.testing.assert_allclose(output, [1.0, 2.0, 0.5, yaw, 5.0])
+
+
+def test_odom_fixed_position_passthrough():
+    callback = _fed_callback(OdomCallback, "Odometry")
+    fixed = np.array([9.0, 8.0, 7.0, 0.0, 0.0])
+    callback.msg = fixed
+    assert callback.get_output() is fixed
+
+
+def test_pose_stamped_process():
+    yaw = -np.pi / 2
+    msg = PoseStamped()
+    msg.pose.position.x = 1.0
+    msg.pose.position.y = -1.0
+    msg.pose.position.z = 2.0
+    msg.pose.orientation.z = np.sin(yaw / 2)
+    msg.pose.orientation.w = np.cos(yaw / 2)
+
+    output = _fed_callback(PoseStampedCallback, "PoseStamped", msg).get_output()
+    np.testing.assert_allclose(output, [1.0, -1.0, 2.0, yaw])
+
+
+# ---------------------------------------------------------------------------
+# OccupancyGrid
+# ---------------------------------------------------------------------------
+
+
+def _make_grid(
+    data: List[int],
+    width: int,
+    height: int,
+    resolution: float = 1.0,
+    origin_x: float = 0.0,
+    origin_y: float = 0.0,
+    origin_yaw: float = 0.0,
+) -> OccupancyGrid:
+    msg = OccupancyGrid()
+    msg.header.frame_id = "map"
+    msg.info.resolution = resolution
+    msg.info.width = width
+    msg.info.height = height
+    msg.info.origin.position.x = origin_x
+    msg.info.origin.position.y = origin_y
+    msg.info.origin.orientation.z = np.sin(origin_yaw / 2)
+    msg.info.origin.orientation.w = np.cos(origin_yaw / 2)
+    msg.data = data
+    return msg
+
+
+def test_grid_metadata():
+    msg = _make_grid(
+        [0] * 6, width=3, height=2, resolution=0.5, origin_x=1.0, origin_y=2.0,
+        origin_yaw=np.pi / 2,
+    )
+    metadata = _fed_callback(OccupancyGridCallback, "OccupancyGrid", msg).get_output(
+        get_metadata=True
+    )
+    assert metadata["resolution"] == pytest.approx(0.5)
+    assert metadata["width"] == 3
+    assert metadata["height"] == 2
+    assert metadata["origin_x"] == pytest.approx(1.0)
+    assert metadata["origin_y"] == pytest.approx(2.0)
+    assert metadata["origin_yaw"] == pytest.approx(np.pi / 2)
+
+
+def test_grid_convert_callback_round_trip():
+    # OccupancyGrid.convert flattens column-major; the callback reads it back
+    # with a reshape + transpose -- together they must round-trip
+    grid = np.array([[0, 100], [50, 0], [0, -1]], dtype=np.int8)
+    msg = supported_types.OccupancyGrid.convert(grid, resolution=1.0)
+    assert isinstance(msg.info.origin, ROSPose)
+    assert msg.info.width == 3
+    assert msg.info.height == 2
+
+    callback = _fed_callback(OccupancyGridCallback, "OccupancyGrid", msg)
+    np.testing.assert_array_equal(
+        callback.get_output(get_obstacles=False), grid
+    )
+
+
+def test_grid_convert_rejects_non_2d():
+    with pytest.raises(TypeError):
+        supported_types.OccupancyGrid.convert(
+            np.array([1, 2, 3], dtype=np.int8), resolution=1.0
+        )
+
+
+def test_grid_obstacles_in_world_frame():
+    # single occupied cell at grid position (x=2, y=1): data index y*width + x
+    data = [0] * 6
+    data[1 * 3 + 2] = 100
+    msg = _make_grid(data, width=3, height=2, origin_x=1.0, origin_y=2.0)
+    callback = _fed_callback(OccupancyGridCallback, "OccupancyGrid", msg)
+    # cell center (2.5, 1.5) * resolution + origin
+    np.testing.assert_allclose(
+        callback.get_output(get_three_d=False), [[3.5, 3.5]]
+    )
+    # default output pads a constant z
+    np.testing.assert_allclose(callback.get_output(), [[3.5, 3.5, 0.01]])
+
+    # with a rotated origin the cell offset is rotated before translating
+    msg = _make_grid(
+        data, width=3, height=2, origin_x=1.0, origin_y=2.0, origin_yaw=np.pi / 2
+    )
+    callback = _fed_callback(OccupancyGridCallback, "OccupancyGrid", msg)
+    np.testing.assert_allclose(
+        callback.get_output(get_three_d=False), [[-0.5, 4.5]], atol=1e-6
+    )
+
+
+def test_grid_ui_content():
+    data = [0, 100, 50, 0, -1, 0]
+    msg = _make_grid(data, width=3, height=2, resolution=0.5)
+    content = _fed_callback(
+        OccupancyGridCallback, "OccupancyGrid", msg
+    )._get_ui_content()
+    assert content["frame_id"] == "map"
+    assert content["width"] == 3
+    assert content["height"] == 2
+    decoded = np.frombuffer(base64.b64decode(content["data"]), dtype=np.int8)
+    np.testing.assert_array_equal(decoded, data)
+
+
+# ---------------------------------------------------------------------------
+# MultiArray
+# ---------------------------------------------------------------------------
+
+
+def _make_multi_array(data: List[float], dims: List[int]) -> Float32MultiArray:
+    msg = Float32MultiArray()
+    msg.data = data
+    msg.layout.dim = [
+        MultiArrayDimension(label=f"dim{i}", size=size) for i, size in enumerate(dims)
+    ]
+    return msg
+
+
+def test_multi_array_reshaped_from_layout():
+    msg = _make_multi_array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], dims=[2, 3])
+    output = _fed_callback(StdMsgArrayCallback, "Float32MultiArray", msg).get_output()
+    assert output.shape == (2, 3)
+    np.testing.assert_allclose(output, [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+
+
+def test_multi_array_without_layout_is_flat():
+    msg = _make_multi_array([1.0, 2.0, 3.0], dims=[])
+    output = _fed_callback(StdMsgArrayCallback, "Float32MultiArray", msg).get_output()
+    assert output.shape == (3,)
+
+
+def test_multi_array_layout_mismatch_raises():
+    msg = _make_multi_array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], dims=[2, 2])
+    callback = _fed_callback(StdMsgArrayCallback, "Float32MultiArray", msg)
+    with pytest.raises(ValueError):
+        callback.get_output()
+
+
+# ---------------------------------------------------------------------------
+# Image
+# ---------------------------------------------------------------------------
+
+
+def test_image_rgb8_decoding():
+    msg = Image()
+    msg.height = 2
+    msg.width = 2
+    msg.encoding = "rgb8"
+    msg.step = 6
+    msg.data = bytes(range(12))
+    output = _fed_callback(ImageCallback, "Image", msg).get_output()
+    assert output.dtype == np.uint8
+    np.testing.assert_array_equal(
+        output, np.arange(12, dtype=np.uint8).reshape(2, 2, 3)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Path
+# ---------------------------------------------------------------------------
+
+
+def test_path_ui_content_downsampling():
+    # points closer than 5cm to the previous kept point are dropped; the
+    # first and last points always survive
+    msg = Path()
+    msg.header.frame_id = "map"
+    for x in (0.0, 0.01, 0.2, 0.21, 1.0):
+        pose = PoseStamped()
+        pose.pose.position.x = x
+        msg.poses.append(pose)
+
+    content = _fed_callback(PathCallback, "Path", msg)._get_ui_content()
+    assert content["frame_id"] == "map"
+    assert content["data"] == [0.0, 0.0, 0.2, 0.0, 1.0, 0.0]


### PR DESCRIPTION
Two related improvements: sensor-data handling moves upstream into sugarcoat as first-class supported types, and the recipe UI gains an explicit API-only mode that runs on minimal dependencies (Python 3.8 compatible).

## Sensor datatypes upstreamed

New `ros_sugar/io/datatypes.py` with framework-level containers, exported from `ros_sugar.io`:

- **`PointCloudData`** — carries the raw (undecoded) `PointCloud2` buffer plus layout metadata, so consumers of the raw buffer pay no decoding cost. Cartesian points are available via the lazily-decoded, cached `xyz` property (handles float32/float64 fields, big-endian buffers, organized clouds with row padding; non-finite padding points are dropped).
- **`LaserScanData`** — structured scan with polar-coordinate utilities: angular-zone queries (`get_ranges`/`get_angles`) and polar frame-to-frame transformation helpers.

Supported types and callbacks:

- `LaserScan` now has a real callback (`LaserScanCallback`): produces `LaserScanData`, supports range clipping and an optional goal-frame transform (settable `TransformStamped`).
- New `PointCloud2` type (`PointCloudCallback` → `PointCloudData`).
- New `PoseArray` type: converts sets of `[x, y, z]`, `[x, y, z, heading]` (heading → quaternion) or full 7-element poses; callback outputs an Nx4 `[x, y, z, heading]` array.
- Both dense sensor streams declare `_ui_rate_sampled = True` (rate-sampled on `/api/outputs`, not event-pushed). Their UI content intentionally carries **metadata only** (scan: `angle_min/angle_max/num_points`; cloud: `width/height/point_step`) until a browser consumer exists.

Fixes found along the way:

- `OdomCallback` speed used `sqrt(y² + y²)` instead of `sqrt(x² + y²)`.
- `OdomCallback` treated a fixed all-zeros position array as "no message" (`if not self.msg` → `if self.msg is None`).
- `OccupancyGrid.convert` crashed when no origin was given (used sugarcoat's `Pose` class instead of the ROS message for the default).

## API-only UI mode (`serve_browser=False`)

`enable_ui` now serves the JSON/WebSocket API without the browser front-end:

```python
launcher.enable_ui(inputs=[...], outputs=[...], serve_browser=False)
```

This requires only `starlette` + `uvicorn` — verified compatible with the last Python 3.8-capable releases (starlette 0.39.2, uvicorn 0.33.0; the full API test suite passes against them). The one 3.8 violation in core (`str.removeprefix`) is fixed.

**Dependency model: mode-aware fail-fast, no silent degradation.** `enable_ui` verifies the requested mode's dependencies at recipe-definition time and raises one complete error listing every missing package, the install command, and the `serve_browser=False` alternative. The old executable fallback (browser deps missing → warn in the node log → silently serve API-only) is removed: a requested browser is served or fails loudly. UI extensions from derived packages are never invoked in API-only mode; in browser mode a broken extension raises at `enable_ui` instead of silently dropping its widgets.

## `enable_ui` config surface completed

`enable_ui` is the single configuration surface for the UI node, but two live options were unreachable and one was dead:

- Added `api_stream_default_rate` (default 10 Hz) and `api_max_stream_rate` (default 30 Hz) — the API stream sampling rates were previously advertised in discovery but impossible to configure. Invalid values fail at the `enable_ui()` call via the config validators.
- Removed `feedback_update_period` (fed the action-feedback timer removed with the event-push migration; zero consumers).
