### PR TITLE
Upstream the robot description classes and adds new supported types

### DIFF
--- a/ros_sugar/config/__init__.py
+++ b/ros_sugar/config/__init__.py
@@ -4,6 +4,7 @@ from .base_config import BaseConfig, BaseComponentConfig, QoSConfig, ComponentRu
 from . import base_validators
 from .base_attrs import BaseAttrs
 from .robot import (
+    StrEnum,
     RobotFrames,
     RobotConfig,
     RobotType,
@@ -20,6 +21,7 @@ __all__ = [
     "BaseComponentConfig",
     "BaseConfig",
     "ComponentRunType",
+    "StrEnum",
     "RobotFrames",
     "RobotConfig",
     "RobotType",

--- a/ros_sugar/config/__init__.py
+++ b/ros_sugar/config/__init__.py
@@ -3,7 +3,15 @@
 from .base_config import BaseConfig, BaseComponentConfig, QoSConfig, ComponentRunType
 from . import base_validators
 from .base_attrs import BaseAttrs
-from .robot import RobotFrames
+from .robot import (
+    RobotFrames,
+    RobotConfig,
+    RobotType,
+    RobotGeometryType,
+    LinearCtrlLimits,
+    AngularCtrlLimits,
+    GEOMETRY_PARAMS_LENGTH,
+)
 
 __all__ = [
     "BaseAttrs",
@@ -13,4 +21,10 @@ __all__ = [
     "BaseConfig",
     "ComponentRunType",
     "RobotFrames",
+    "RobotConfig",
+    "RobotType",
+    "RobotGeometryType",
+    "LinearCtrlLimits",
+    "AngularCtrlLimits",
+    "GEOMETRY_PARAMS_LENGTH",
 ]

--- a/ros_sugar/config/__init__.py
+++ b/ros_sugar/config/__init__.py
@@ -3,6 +3,7 @@
 from .base_config import BaseConfig, BaseComponentConfig, QoSConfig, ComponentRunType
 from . import base_validators
 from .base_attrs import BaseAttrs
+from .robot import RobotFrames
 
 __all__ = [
     "BaseAttrs",
@@ -11,4 +12,5 @@ __all__ = [
     "BaseComponentConfig",
     "BaseConfig",
     "ComponentRunType",
+    "RobotFrames",
 ]

--- a/ros_sugar/config/base_attrs.py
+++ b/ros_sugar/config/base_attrs.py
@@ -85,6 +85,53 @@ class BaseAttrs:
         return getattr(some_type, "__origin__", None)
 
     @classmethod
+    def __nested_attrs_type(cls, attribute_type) -> Optional[type]:
+        """Get the attrs class an attribute can hold, if any.
+
+        Used for optional nested configs: when the attribute is currently None
+        there is no instance to deserialize into, so the declared type is the
+        only thing that says what to rebuild.
+
+        :param attribute_type: Declared type of the attribute
+        :return: The attrs class, or None if the attribute holds no attrs class
+        :rtype: Optional[type]
+        """
+        candidates = (
+            cls.__get_subscribed_generic_simple_types(attribute_type)
+            if cls.__is_subscripted_generic(attribute_type)
+            else [attribute_type]
+        )
+        for candidate in candidates:
+            if hasattr(candidate, "__attrs_attrs__"):
+                return candidate
+        return None
+
+    @classmethod
+    def __build_nested(cls, target_cls: type, value: Dict):
+        """Construct an attrs class from a serialized dict.
+
+        Recurses so that nested configs arrive as their own class rather than
+        as raw dictionaries, which would otherwise be stored as-is and blow up
+        at first use.
+
+        :param target_cls: The attrs class to construct
+        :param value: Serialized attribute values
+        :return: An instance of ``target_cls``
+        """
+        target_fields = fields_dict(target_cls)
+        kwargs = {}
+        for key, item in value.items():
+            attribute = target_fields.get(key)
+            if attribute is None or not attribute.init:
+                continue
+            nested_cls = cls.__nested_attrs_type(attribute.type)
+            if nested_cls is not None and isinstance(item, Dict):
+                item = cls.__build_nested(nested_cls, item)
+            # attrs strips the leading underscore of private fields for __init__
+            kwargs[attribute.alias] = item
+        return target_cls(**kwargs)
+
+    @classmethod
     def __get_subscribed_generic_simple_types(cls, sg_type) -> List:
         _types = get_args(sg_type)
         _parsed_types = []
@@ -198,6 +245,15 @@ class BaseAttrs:
                         f"Trying to set with incompatible type. Attribute {key} expecting dictionary got '{type(value)}'"
                     )
                 attribute_to_set.from_dict(value)
+            elif (
+                isinstance(value, Dict)
+                and attribute_to_set is None
+                and attribute_type
+                and (nested_cls := self.__nested_attrs_type(attribute_type))
+            ):
+                # An optional nested config that is currently unset: there is no
+                # instance to deserialize into, so build one from the declared type
+                setattr(self, key, self.__build_nested(nested_cls, value))
             elif isinstance(attribute_to_set, List) and attribute_to_set:
                 setattr(
                     self,

--- a/ros_sugar/config/base_config.py
+++ b/ros_sugar/config/base_config.py
@@ -300,7 +300,9 @@ class BaseComponentConfig(BaseConfig):
     :type wait_for_restart_time: float
 
     :param robot: Physical description of the robot (motion model, geometry, control limits).
-    :type robot: RobotConfig
+        Defaults to None: components that do not reason about the robot's body never need it,
+        and those that do should fail loudly rather than assume a robot that does not exist.
+    :type robot: Optional[RobotConfig]
 
     :param frames: Robot coordinate frames incoming data is transformed into.
     :type frames: RobotFrames
@@ -308,7 +310,7 @@ class BaseComponentConfig(BaseConfig):
 
     _use_without_launcher: bool = field(default=False, init=False)
 
-    robot: RobotConfig = field(default=Factory(RobotConfig))
+    robot: Optional[RobotConfig] = field(default=None)
 
     frames: RobotFrames = field(default=Factory(RobotFrames))
 

--- a/ros_sugar/config/base_config.py
+++ b/ros_sugar/config/base_config.py
@@ -8,7 +8,7 @@ from rclpy.logging import LoggingSeverity
 
 from . import base_validators
 from .base_attrs import BaseAttrs
-from .robot import RobotFrames
+from .robot import RobotFrames, RobotConfig
 
 __all__ = ["QoSConfig", "BaseComponentConfig", "BaseConfig", "ComponentRunType"]
 
@@ -299,11 +299,16 @@ class BaseComponentConfig(BaseConfig):
     :param wait_for_restart_time: Time (in seconds) the component waits for a node to come back online after restart. Used to avoid infinite restart loops. Recommended to use a high value.
     :type wait_for_restart_time: float
 
-    :param frames: Robot coordinate frames used to resolve the symbolic targets of `Topic.transform_to`.
+    :param robot: Physical description of the robot (motion model, geometry, control limits).
+    :type robot: RobotConfig
+
+    :param frames: Robot coordinate frames incoming data is transformed into.
     :type frames: RobotFrames
     """
 
     _use_without_launcher: bool = field(default=False, init=False)
+
+    robot: RobotConfig = field(default=Factory(RobotConfig))
 
     frames: RobotFrames = field(default=Factory(RobotFrames))
 

--- a/ros_sugar/config/base_config.py
+++ b/ros_sugar/config/base_config.py
@@ -314,11 +314,6 @@ class BaseComponentConfig(BaseConfig):
 
     frames: RobotFrames = field(default=Factory(RobotFrames))
 
-    # NOTE: Layer ID to be added in coming updates
-    # layer_id: int = field(
-    #     default=0, validator=base_validators.in_range(min_value=0, max_value=1e3)
-    # )
-
     fallback_rate: float = field(
         default=100.0, validator=base_validators.in_range(min_value=1e-9, max_value=1e9)
     )

--- a/ros_sugar/config/base_config.py
+++ b/ros_sugar/config/base_config.py
@@ -2,12 +2,13 @@
 
 from enum import Enum
 from typing import List, Union, Optional
-from attrs import define, field
+from attrs import define, field, Factory
 from rclpy import qos
 from rclpy.logging import LoggingSeverity
 
 from . import base_validators
 from .base_attrs import BaseAttrs
+from .robot import RobotFrames
 
 __all__ = ["QoSConfig", "BaseComponentConfig", "BaseConfig", "ComponentRunType"]
 
@@ -297,9 +298,14 @@ class BaseComponentConfig(BaseConfig):
 
     :param wait_for_restart_time: Time (in seconds) the component waits for a node to come back online after restart. Used to avoid infinite restart loops. Recommended to use a high value.
     :type wait_for_restart_time: float
+
+    :param frames: Robot coordinate frames used to resolve the symbolic targets of `Topic.transform_to`.
+    :type frames: RobotFrames
     """
 
     _use_without_launcher: bool = field(default=False, init=False)
+
+    frames: RobotFrames = field(default=Factory(RobotFrames))
 
     # NOTE: Layer ID to be added in coming updates
     # layer_id: int = field(

--- a/ros_sugar/config/robot.py
+++ b/ros_sugar/config/robot.py
@@ -1,8 +1,89 @@
 """Robot description primitives shared by all Sugarcoat components"""
 
-from attrs import define, field
+import math
+from enum import StrEnum
+from typing import Dict, Union
+
+import numpy as np
+from attrs import define, field, validators
 
 from .base_attrs import BaseAttrs
+
+
+class RobotType(StrEnum):
+    """Robot motion model."""
+
+    ACKERMANN = "ACKERMANN"
+    DIFFERENTIAL_DRIVE = "DIFFERENTIAL_DRIVE"
+    OMNI = "OMNI"
+
+
+class RobotGeometryType(StrEnum):
+    """Shape of the volume the robot occupies."""
+
+    BOX = "BOX"
+    CYLINDER = "CYLINDER"
+    SPHERE = "SPHERE"
+    ELLIPSOID = "ELLIPSOID"
+    CAPSULE = "CAPSULE"
+    CONE = "CONE"
+
+
+#: Number of strictly positive parameters each geometry requires:
+#: BOX/ELLIPSOID are (x, y, z), CYLINDER/CAPSULE/CONE are (radius, length),
+#: SPHERE is (radius).
+GEOMETRY_PARAMS_LENGTH: Dict[RobotGeometryType, int] = {
+    RobotGeometryType.BOX: 3,
+    RobotGeometryType.CYLINDER: 2,
+    RobotGeometryType.SPHERE: 1,
+    RobotGeometryType.ELLIPSOID: 3,
+    RobotGeometryType.CAPSULE: 2,
+    RobotGeometryType.CONE: 2,
+}
+
+
+def _to_enum(enum_cls, value):
+    """Normalize a value into ``enum_cls``.
+
+    Accepts a member of ``enum_cls``, a bare string, or a member of any other
+    enum carrying the same name -- notably the equivalent ``kompass_core``
+    types, so recipes written against those keep working unchanged. The
+    ``"Type.CYLINDER"`` form previously emitted by serialization is tolerated
+    too, so configs saved by older releases still load.
+    """
+    if isinstance(value, enum_cls):
+        return value
+    raw = getattr(value, "value", value)
+    if isinstance(raw, str):
+        try:
+            return enum_cls(raw.rsplit(".", 1)[-1])
+        except ValueError:
+            pass
+    raise ValueError(
+        f"'{value}' is not a valid {enum_cls.__name__}. "
+        f"Expected one of {[m.value for m in enum_cls]}"
+    )
+
+
+@define(kw_only=True)
+class LinearCtrlLimits(BaseAttrs):
+    """Linear velocity control limits along one axis"""
+
+    max_vel: float = field(validator=validators.ge(0.0))  # m/s
+    max_acc: float = field(validator=validators.ge(0.0))  # m/s^2
+    max_decel: float = field(validator=validators.ge(0.0))  # m/s^2
+    min_absolute_val: float = field(default=0.01, validator=validators.ge(0.0))
+
+
+@define(kw_only=True)
+class AngularCtrlLimits(BaseAttrs):
+    """Angular velocity control limits"""
+
+    max_vel: float = field(validator=validators.ge(0.0))  # rad/s
+    max_steer: float = field(validator=validators.ge(0.0))  # rad
+    max_acc: float = field(validator=validators.ge(0.0))  # rad/s^2
+    max_decel: float = field(validator=validators.ge(0.0))  # rad/s^2
+    min_absolute_val: float = field(default=0.01, validator=validators.ge(0.0))
 
 
 @define(kw_only=True)
@@ -33,3 +114,85 @@ class RobotFrames(BaseAttrs):
 
     robot_base: str = field(default="base_link")
     world: str = field(default="map")
+
+
+@define(kw_only=True)
+class RobotConfig(BaseAttrs):
+    """Physical description of the robot: how it moves, how big it is, how fast.
+
+    This is a *navigation* description -- a motion model, a bounding volume and
+    a velocity envelope. It deliberately carries no links, joints, masses or
+    URDF: consumers that need those read them from the ROS graph.
+
+    ```{list-table}
+    :widths: 10 20 70
+    :header-rows: 1
+
+    * - Name
+      - Type, Default
+      - Description
+
+    * - **model_type**
+      - `RobotType | str`, `ACKERMANN`
+      - Robot motion model type
+
+    * - **geometry_type**
+      - `RobotGeometryType | str`, `CYLINDER`
+      - Robot 3D geometry shape type
+
+    * - **geometry_params**
+      - `np.ndarray`, `[0.2, 1.0]`
+      - Shape parameters, whose length must match the geometry type
+
+    * - **ctrl_vx_limits**
+      - `LinearCtrlLimits`
+      - Forward linear velocity (x-direction) control limits
+
+    * - **ctrl_omega_limits**
+      - `AngularCtrlLimits`
+      - Angular velocity control limits
+
+    * - **ctrl_vy_limits**
+      - `LinearCtrlLimits`
+      - Lateral linear velocity (y-direction) control limits
+    ```
+    """
+
+    # Robot Motion Model Type
+    model_type: Union[str, RobotType] = field(
+        default=RobotType.ACKERMANN,
+        converter=lambda value: _to_enum(RobotType, value),
+    )
+
+    # Geometry
+    geometry_type: Union[str, RobotGeometryType] = field(
+        default=RobotGeometryType.CYLINDER,
+        converter=lambda value: _to_enum(RobotGeometryType, value),
+    )
+    geometry_params: np.ndarray = field(
+        default=np.array([0.2, 1.0]), converter=np.asarray
+    )
+
+    # Control limits
+    ctrl_vx_limits: LinearCtrlLimits = field(
+        default=LinearCtrlLimits(max_vel=1.0, max_acc=3.0, max_decel=5.0)
+    )
+    ctrl_omega_limits: AngularCtrlLimits = field(
+        default=AngularCtrlLimits(
+            max_vel=5.0, max_steer=math.pi, max_acc=10.0, max_decel=10.0
+        )
+    )
+    ctrl_vy_limits: LinearCtrlLimits = field(
+        default=LinearCtrlLimits(max_vel=0.0, max_acc=0.0, max_decel=0.0)
+    )  # Default to ackermann robot
+
+    @geometry_params.validator
+    def validate_params(self, _, value):
+        """Validates geometry parameters against geometry type"""
+        required_length = GEOMETRY_PARAMS_LENGTH[self.geometry_type]
+        if len(value) != required_length or not all(param > 0 for param in value):
+            raise ValueError(
+                f"Robot geometry parameters '{value}' are incompatible with given "
+                f"robot geometry {self.geometry_type}. Requires "
+                f"'{required_length}' strictly positive parameters"
+            )

--- a/ros_sugar/config/robot.py
+++ b/ros_sugar/config/robot.py
@@ -1,7 +1,7 @@
 """Robot description primitives shared by all Sugarcoat components"""
 
 from enum import Enum
-from typing import Dict, List, Optional, TypeVar, Union
+from typing import Dict, List, Optional, TypeVar, Union, Type
 
 import numpy as np
 from attrs import Factory, define, field, validators
@@ -37,7 +37,7 @@ class StrEnum(str, Enum):
     __format__ = str.__format__
 
     @classmethod
-    def get_enum(cls: type, __value: str) -> Optional[T]:
+    def get_enum(cls: Type[T], __value: str) -> Optional[T]:
         """
         Get Enum member equal to the given value
 

--- a/ros_sugar/config/robot.py
+++ b/ros_sugar/config/robot.py
@@ -1,11 +1,10 @@
 """Robot description primitives shared by all Sugarcoat components"""
 
-import math
 from enum import Enum
 from typing import Dict, List, Optional, TypeVar, Union
 
 import numpy as np
-from attrs import define, field, validators
+from attrs import Factory, define, field, validators
 
 from .base_attrs import BaseAttrs
 
@@ -208,33 +207,29 @@ class RobotConfig(BaseAttrs):
     ```
     """
 
+    # NOTE: every field is mandatory on purpose. Silently defaulting a robot's
+    # size or velocity envelope means collision checking and control run
+    # against a robot that does not exist, so it must be declared in the recipe.
+
     # Robot Motion Model Type
     model_type: Union[str, RobotType] = field(
-        default=RobotType.ACKERMANN,
-        converter=lambda value: _to_enum(RobotType, value),
+        converter=lambda value: _to_enum(RobotType, value)
     )
 
     # Geometry
     geometry_type: Union[str, RobotGeometryType] = field(
-        default=RobotGeometryType.CYLINDER,
-        converter=lambda value: _to_enum(RobotGeometryType, value),
+        converter=lambda value: _to_enum(RobotGeometryType, value)
     )
-    geometry_params: np.ndarray = field(
-        default=np.array([0.2, 1.0]), converter=np.asarray
-    )
+    # np.array (unlike np.asarray) copies, so a caller keeping a reference to
+    # the array it passed in cannot mutate this config through it
+    geometry_params: np.ndarray = field(converter=np.array)
 
     # Control limits
-    ctrl_vx_limits: LinearCtrlLimits = field(
-        default=LinearCtrlLimits(max_vel=1.0, max_acc=3.0, max_decel=5.0)
-    )
-    ctrl_omega_limits: AngularCtrlLimits = field(
-        default=AngularCtrlLimits(
-            max_vel=5.0, max_steer=math.pi, max_acc=10.0, max_decel=10.0
-        )
-    )
+    ctrl_vx_limits: LinearCtrlLimits = field()
+    ctrl_omega_limits: AngularCtrlLimits = field()
     ctrl_vy_limits: LinearCtrlLimits = field(
-        default=LinearCtrlLimits(max_vel=0.0, max_acc=0.0, max_decel=0.0)
-    )  # Default to ackermann robot
+        default=Factory(lambda: LinearCtrlLimits(max_vel=0.0, max_acc=0.0, max_decel=0.0))
+    )  # Lateral motion is zero unless the robot is omnidirectional
 
     @geometry_params.validator
     def validate_params(self, _, value):

--- a/ros_sugar/config/robot.py
+++ b/ros_sugar/config/robot.py
@@ -9,13 +9,8 @@ from .base_attrs import BaseAttrs
 class RobotFrames(BaseAttrs):
     """Coordinate frames of the robot.
 
-    Only the three frames a deployment genuinely has to *choose* are declared
-    here. Sensor frames are deliberately absent: every spatial ROS message
-    already carries its own ``header.frame_id``, so a component asks for its
-    input in the frame it needs (via ``Component.transform_input_to``) and
-    Sugarcoat looks up ``header.frame_id`` -> that frame on the fly. That keeps
-    the config independent of how many sensors are attached, and of what they
-    are called.
+    Only the two frames a deployment genuinely has to *choose* are declared
+    here. Every other frame is read from the online data.
 
     ```{list-table}
     :widths: 10 20 70
@@ -27,19 +22,14 @@ class RobotFrames(BaseAttrs):
 
     * - **robot_base**
       - `str`, `"base_link"`
-      - Frame rigidly attached to the robot body. Sensor data is expressed in
-        this frame.
-
-    * - **odom**
-      - `str`, `"odom"`
-      - Continuous (drift-prone, jump-free) localization frame.
+      - Frame rigidly attached to the robot body.
 
     * - **world**
       - `str`, `"map"`
-      - Global reference frame. Goals, paths and maps are expressed in it.
+      - Global reference frame the robot operates in. Goals, paths and maps
+        are expressed in it, and robot location is transformed into it.
     ```
     """
 
     robot_base: str = field(default="base_link")
-    odom: str = field(default="odom")
     world: str = field(default="map")

--- a/ros_sugar/config/robot.py
+++ b/ros_sugar/config/robot.py
@@ -1,0 +1,45 @@
+"""Robot description primitives shared by all Sugarcoat components"""
+
+from attrs import define, field
+
+from .base_attrs import BaseAttrs
+
+
+@define(kw_only=True)
+class RobotFrames(BaseAttrs):
+    """Coordinate frames of the robot.
+
+    Only the three frames a deployment genuinely has to *choose* are declared
+    here. Sensor frames are deliberately absent: every spatial ROS message
+    already carries its own ``header.frame_id``, so a component asks for its
+    input in the frame it needs (via ``Component.transform_input_to``) and
+    Sugarcoat looks up ``header.frame_id`` -> that frame on the fly. That keeps
+    the config independent of how many sensors are attached, and of what they
+    are called.
+
+    ```{list-table}
+    :widths: 10 20 70
+    :header-rows: 1
+
+    * - Name
+      - Type, Default
+      - Description
+
+    * - **robot_base**
+      - `str`, `"base_link"`
+      - Frame rigidly attached to the robot body. Sensor data is expressed in
+        this frame.
+
+    * - **odom**
+      - `str`, `"odom"`
+      - Continuous (drift-prone, jump-free) localization frame.
+
+    * - **world**
+      - `str`, `"map"`
+      - Global reference frame. Goals, paths and maps are expressed in it.
+    ```
+    """
+
+    robot_base: str = field(default="base_link")
+    odom: str = field(default="odom")
+    world: str = field(default="map")

--- a/ros_sugar/config/robot.py
+++ b/ros_sugar/config/robot.py
@@ -1,13 +1,63 @@
 """Robot description primitives shared by all Sugarcoat components"""
 
 import math
-from enum import StrEnum
-from typing import Dict, Union
+from enum import Enum
+from typing import Dict, List, Optional, TypeVar, Union
 
 import numpy as np
 from attrs import define, field, validators
 
 from .base_attrs import BaseAttrs
+
+T = TypeVar("T", bound="StrEnum")
+
+
+class StrEnum(str, Enum):
+    """A string-valued enum whose members behave like their own value.
+
+    ``enum.StrEnum`` only exists on Python 3.11+, so it is implemented here to
+    keep the package usable on older interpreters.
+
+    The ``str`` mixin is the load-bearing part: it makes a member compare equal
+    to its name across package boundaries, so a consumer holding an equivalent
+    enum of its own (or a plain string read from a config file) still matches.
+    Overriding ``__str__`` keeps serialization emitting ``"CYLINDER"`` rather
+    than the ``"RobotGeometryType.CYLINDER"`` repr that a bare mixin produces.
+    """
+
+    def __str__(self) -> str:
+        """
+        Gets value of enum
+
+        :return: Enum value
+        :rtype: str
+        """
+        return self.value
+
+    # Without this, f-strings fall back to Enum.__format__ on some versions
+    __format__ = str.__format__
+
+    @classmethod
+    def get_enum(cls: type, __value: str) -> Optional[T]:
+        """
+        Get Enum member equal to the given value
+
+        :param __value: Reference value
+        :type __value: str
+        :return: Enum member
+        :rtype: StrEnum | None
+        """
+        for enum_member in cls:
+            if enum_member.value == __value:
+                return enum_member
+        return None
+
+    @classmethod
+    def values(cls) -> List[str]:
+        """
+        Get all enum values
+        """
+        return [member.value for member in cls]
 
 
 class RobotType(StrEnum):

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -805,6 +805,9 @@ class BaseComponent(lifecycle.Node):
         self.get_logger().info("STARTING ALL SUBSCRIBERS")
         # Create subscribers
         for topic_name, callback in self.callbacks.items():
+            # Frame handling applies to plugin-fed inputs too, so it is wired up
+            # before the external-topic check below
+            self._attach_transform_provider(topic_name, callback)
             # Inputs bound to a non-ROS robot plugin transport are fed through
             # the feedback bus, not a ROS subscription
             if topic_name in self._external_topics:
@@ -1048,6 +1051,123 @@ class BaseComponent(lifecycle.Node):
         )  # timer to lookup the transform with given rate
         tf_handler.timer = transform_timer
         return tf_handler
+
+    # TRANSFORMS
+    @property
+    def tf_buffer(self) -> Buffer:
+        """The node's shared TF buffer, created on first use.
+
+        All frame pairs the component looks up share this buffer, so the node
+        subscribes to `/tf` and `/tf_static` exactly once however many sensors
+        it tracks.
+
+        :return: Shared TF buffer
+        :rtype: Buffer
+        """
+        if self._tf_buffer is None:
+            self._tf_buffer = Buffer()
+            self._tf_transform_listener = TransformListener(
+                buffer=self._tf_buffer, node=self
+            )
+        return self._tf_buffer
+
+    def get_transform_listener(
+        self, source_frame: str, goal_frame: str, static_tf: bool = False
+    ) -> TFListener:
+        """Get (or create) a listener polling the transform between two frames.
+
+        Listeners are cached per frame pair, so asking repeatedly - for
+        instance once per incoming message - is cheap.
+
+        :param source_frame: Frame the data is currently expressed in
+        :type source_frame: str
+        :param goal_frame: Frame the data should be expressed in
+        :type goal_frame: str
+        :param static_tf: Whether the transform is fixed, in which case polling
+            stops once it has been acquired
+        :type static_tf: bool
+
+        :return: Transform lookup handler for the pair
+        :rtype: TFListener
+        """
+        key = (source_frame, goal_frame)
+        if listener := self._tf_listeners.get(key):
+            return listener
+
+        tf_config = TFListenerConfig(
+            source_frame=source_frame, goal_frame=goal_frame, static_tf=static_tf
+        )
+        listener = TFListener(
+            tf_config=tf_config, node_name=self.node_name, buffer=self.tf_buffer
+        )
+        listener.timer = self.create_timer(
+            1 / tf_config.lookup_rate,
+            listener.timer_callback,
+            callback_group=MutuallyExclusiveCallbackGroup(),
+        )
+        self._tf_listeners[key] = listener
+        return listener
+
+    def get_transform(
+        self, source_frame: str, goal_frame: str, static_tf: bool = False
+    ) -> Optional[TransformStamped]:
+        """Get the transform between two frames, if it has been resolved yet.
+
+        :param source_frame: Frame the data is currently expressed in
+        :type source_frame: str
+        :param goal_frame: Frame the data should be expressed in
+        :type goal_frame: str
+        :param static_tf: Whether the transform is fixed
+        :type static_tf: bool
+
+        :return: The transform, or None while it is still unavailable
+        :rtype: Optional[TransformStamped]
+        """
+        if not source_frame or not goal_frame or source_frame == goal_frame:
+            return None
+        return self.get_transform_listener(source_frame, goal_frame, static_tf).transform
+
+    def transform_input_to(
+        self, topic_name: str, goal_frame: str, static_tf: bool = False
+    ) -> None:
+        """Ask for an input's data expressed in a given frame.
+
+        The source frame is taken from each message's `header.frame_id`, so no
+        sensor frame has to be configured anywhere: the component states which
+        frame its algorithm needs, and the data is transformed on arrival.
+
+        Call this from `init_variables`, before subscribers are created.
+
+        :param topic_name: Name of the component input topic
+        :type topic_name: str
+        :param goal_frame: Frame the data should be expressed in, usually one
+            of the component's `config.frames`
+        :type goal_frame: str
+        :param static_tf: Whether the sensor is rigidly mounted, in which case
+            the transform is looked up once instead of continuously. Leave
+            False for anything on a moving mount, such as a pan-tilt camera.
+        :type static_tf: bool
+        """
+        self._input_frame_targets[topic_name] = (goal_frame, static_tf)
+
+    def _attach_transform_provider(self, topic_name: str, callback) -> None:
+        """Wire a callback up to resolve its own transform on every message.
+
+        The transform cannot be resolved ahead of time because the source frame
+        is only known once a message arrives, so the callback is handed a
+        resolver instead of a fixed transform.
+        """
+        target = self._input_frame_targets.get(topic_name)
+        if target is None:
+            return
+        goal_frame, static_tf = target
+
+        def _provider(cb) -> Optional[TransformStamped]:
+            if not cb.frame_id:
+                return None
+            return self.get_transform(cb.frame_id, goal_frame, static_tf=static_tf)
+
+        callback.set_transform_provider(_provider)
 
     def create_client(self, *args, **kwargs) -> Client:
         """

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -144,8 +144,7 @@ class BaseComponent(lifecycle.Node):
         self._fallbacks_topics_timeout: Dict[str, float] = {}
 
         # Created on activation, but declared here so that tearing the component
-        # down is safe whatever state it reached -- a failed or skipped
-        # activation must not turn into an AttributeError during cleanup
+        # down is safe whatever state it reached
         self._default_services: List = []
         self.health_status_publisher: Optional[ROSPublisher] = None
 
@@ -817,8 +816,7 @@ class BaseComponent(lifecycle.Node):
         self.get_logger().info("STARTING ALL SUBSCRIBERS")
         # Create subscribers
         for topic_name, callback in self.callbacks.items():
-            # Frame handling applies to plugin-fed inputs too, so it is wired up
-            # before the external-topic check below
+            # Frame handling applies to plugin-fed non-ROS inputs too
             self._attach_transform_provider(topic_name, callback)
             # Inputs bound to a non-ROS robot plugin transport are fed through
             # the feedback bus, not a ROS subscription

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -762,6 +762,9 @@ class BaseComponent(lifecycle.Node):
         # Setup node timers
         self.create_all_timers()
 
+        # Restart any TF lookups paused by a previous deactivation
+        self._resume_tf_listeners()
+
     def deactivate(self):
         """
         Destroy all declared subscriptions, publications, timers, ... etc. to deactivate the node
@@ -779,6 +782,9 @@ class BaseComponent(lifecycle.Node):
         self.destroy_all_subscribers()
 
         self.destroy_all_publishers()
+
+        # Stop TF lookups too: destroy_all_timers only owns the execution timer
+        self._pause_tf_listeners()
 
     def configure(self, config_file: Optional[str] = None):
         """
@@ -1107,6 +1113,30 @@ class BaseComponent(lifecycle.Node):
         )
         self._tf_listeners[key] = listener
         return listener
+
+    def _pause_tf_listeners(self) -> None:
+        """Stop the TF lookup timers while the component is inactive.
+
+        The buffer and the listeners themselves are kept, so a transform that
+        was already resolved survives a deactivate/activate cycle instead of
+        having to be looked up again.
+        """
+        for listener in self._tf_listeners.values():
+            if listener.timer is not None:
+                listener.timer.cancel()
+
+    def _resume_tf_listeners(self) -> None:
+        """Restart the TF lookup timers paused by deactivation.
+
+        A static transform that has already been acquired stays cancelled: it
+        stopped its own timer on purpose and there is nothing left to look up.
+        """
+        for listener in self._tf_listeners.values():
+            if listener.timer is None:
+                continue
+            if listener.config.static_tf and listener.got_transform:
+                continue
+            listener.timer.reset()
 
     def get_transform(
         self, source_frame: str, goal_frame: str, static_tf: bool = False

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -23,8 +23,10 @@ from rclpy.lifecycle.node import TransitionCallbackReturn, LifecycleState
 from rclpy.publisher import Publisher as ROSPublisher
 from rclpy.subscription import Subscription
 from rclpy.client import Client
+from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener
 from builtin_interfaces.msg import Time
+from geometry_msgs.msg import TransformStamped
 from lifecycle_msgs.msg import State as LifecycleStateMsg
 
 from automatika_ros_sugar.srv import (
@@ -182,6 +184,15 @@ class BaseComponent(lifecycle.Node):
         self._external_topics: set = set()
         # Feedback-bus subscription handles to release on deactivation
         self._robot_plugin_bus_handles: List = []
+
+        # TF lookup: one buffer (and so one /tf + /tf_static subscription) per
+        # node, shared by every frame pair the component looks up
+        self._tf_buffer: Optional[Buffer] = None
+        self._tf_transform_listener: Optional[TransformListener] = None
+        self._tf_listeners: Dict[Tuple[str, str], TFListener] = {}
+        # Input topic name -> (goal frame, is the mount rigid). Declared by the
+        # component (usually in init_variables)
+        self._input_frame_targets: Dict[str, Tuple[str, bool]] = {}
 
         # To use without launcher -> Init the ROS2 node directly
         if self.config._use_without_launcher:

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -143,6 +143,12 @@ class BaseComponent(lifecycle.Node):
         self._fallbacks_topics_blackboard: Dict[str, EventBlackboardEntry] = {}
         self._fallbacks_topics_timeout: Dict[str, float] = {}
 
+        # Created on activation, but declared here so that tearing the component
+        # down is safe whatever state it reached -- a failed or skipped
+        # activation must not turn into an AttributeError during cleanup
+        self._default_services: List = []
+        self.health_status_publisher: Optional[ROSPublisher] = None
+
         if self.config._use_without_launcher:
             # Create default services for changing config/inputs/outputs during runtime
             self._create_default_services()
@@ -957,8 +963,9 @@ class BaseComponent(lifecycle.Node):
         """
         self.get_logger().info("DESTROYING ALL PUBLISHERS")
         # Destroy health status publisher
-        self.destroy_publisher(self.health_status_publisher)
-        self.health_status_publisher = None
+        if self.health_status_publisher:
+            self.destroy_publisher(self.health_status_publisher)
+            self.health_status_publisher = None
 
         for publisher in self.publishers_dict.values():
             if publisher._publisher:
@@ -970,7 +977,7 @@ class BaseComponent(lifecycle.Node):
         Destroys all node services
         """
         # Destroy node main Server if runtype is server
-        if self.run_type == ComponentRunType.SERVER:
+        if self.run_type == ComponentRunType.SERVER and hasattr(self, "server"):
             self.destroy_service(self.server)
         if (
             hasattr(self, "_maintain_default_services")

--- a/ros_sugar/io/callbacks.py
+++ b/ros_sugar/io/callbacks.py
@@ -12,7 +12,7 @@ import numpy as np
 from geometry_msgs.msg import Pose
 from jinja2.environment import Template
 from nav_msgs.msg import OccupancyGrid, Odometry
-from sensor_msgs.msg import JointState, LaserScan
+from sensor_msgs.msg import Imu, JointState, LaserScan, NavSatFix
 from std_msgs.msg import Header
 from rclpy.logging import get_logger
 from rclpy.subscription import Subscription
@@ -629,6 +629,77 @@ class JointStateCallback(GenericCallback):
             return None
 
         return np.array(self.msg.position, dtype=np.float64)
+
+    def _get_ui_content(self, **_) -> Dict:
+        """
+        Utility method to get UI compatible content.
+        To be used with external callbacks in UI Node
+        :returns:   Topic content
+        :rtype:     Any
+        """
+        output = self.get_output()
+        return {"data": output.tolist() if output is not None else None}
+
+
+class ImuCallback(GenericCallback):
+    """
+    sensor_msgs/Imu callback.
+
+    Returns the IMU state as a flat numpy array
+    ``[qx, qy, qz, qw, wx, wy, wz, ax, ay, az]`` -- orientation quaternion,
+    angular velocity (rad/s) and linear acceleration (m/s^2).
+    """
+
+    def _get_output(self, **_) -> Optional[np.ndarray]:
+        """
+        Gets the IMU state as a numpy array.
+
+        :returns:   [qx, qy, qz, qw, wx, wy, wz, ax, ay, az]
+        :rtype:     Optional[np.ndarray]
+        """
+        if not self.msg:
+            return None
+
+        o = self.msg.orientation
+        w = self.msg.angular_velocity
+        a = self.msg.linear_acceleration
+        return np.array(
+            [o.x, o.y, o.z, o.w, w.x, w.y, w.z, a.x, a.y, a.z], dtype=np.float64
+        )
+
+    def _get_ui_content(self, **_) -> Dict:
+        """
+        Utility method to get UI compatible content.
+        To be used with external callbacks in UI Node
+        :returns:   Topic content
+        :rtype:     Any
+        """
+        output = self.get_output()
+        return {"data": output.tolist() if output is not None else None}
+
+
+class NavSatFixCallback(GenericCallback):
+    """
+    sensor_msgs/NavSatFix callback.
+
+    Returns the satellite fix as a numpy array ``[latitude, longitude,
+    altitude]`` (degrees, degrees, metres).
+    """
+
+    def _get_output(self, **_) -> Optional[np.ndarray]:
+        """
+        Gets the satellite fix as a numpy array.
+
+        :returns:   [latitude, longitude, altitude]
+        :rtype:     Optional[np.ndarray]
+        """
+        if not self.msg:
+            return None
+
+        return np.array(
+            [self.msg.latitude, self.msg.longitude, self.msg.altitude],
+            dtype=np.float64,
+        )
 
     def _get_ui_content(self, **_) -> Dict:
         """

--- a/ros_sugar/io/callbacks.py
+++ b/ros_sugar/io/callbacks.py
@@ -49,6 +49,14 @@ class GenericCallback:
         # Coordinates frame of the message data (if available)
         self._frame_id: Optional[str] = None
 
+        # Transform applied to the data before it is handed to the component.
+        # Populated from `_transform_provider` on every message when the
+        # component asked for this input in a specific frame.
+        self._transformation: Optional[TransformStamped] = None
+        self._transform_provider: Optional[
+            Callable[["GenericCallback"], Optional[TransformStamped]]
+        ] = None
+
         self._extra_callback: Optional[Callable] = None
         self._get_processed: bool = True  # utilized only if extra callback is set
         self._subscriber: Optional[Subscription] = None
@@ -62,6 +70,39 @@ class GenericCallback:
         :rtype: Optional[str]
         """
         return self._frame_id
+
+    @property
+    def transformation(self) -> Optional[TransformStamped]:
+        """Getter of the transformation applied to the data
+
+        :return: Transformation from the message frame to the requested frame
+        :rtype: Optional[TransformStamped]
+        """
+        return self._transformation
+
+    @transformation.setter
+    def transformation(self, transform: Optional[TransformStamped]) -> None:
+        """
+        Sets a new transformation value
+
+        :param transform: Transformation to apply to the data
+        :type transform: Optional[TransformStamped]
+        """
+        self._transformation = transform
+
+    def set_transform_provider(
+        self, provider: Optional[Callable[["GenericCallback"], Optional[TransformStamped]]]
+    ) -> None:
+        """Attach a resolver called on every message to refresh `transformation`.
+
+        The provider is given this callback (so it can read `frame_id`, which is
+        only known once data arrives) and returns the transform to apply, or
+        None if it is not available yet.
+
+        :param provider: Transform resolver
+        :type provider: Optional[Callable[[GenericCallback], Optional[TransformStamped]]]
+        """
+        self._transform_provider = provider
 
     def set_node_name(self, node_name: str) -> None:
         """Set node name.
@@ -102,6 +143,11 @@ class GenericCallback:
         # Get the frame if available
         if hasattr(msg, "header") and isinstance(msg.header, Header):
             self._frame_id = msg.header.frame_id
+
+        # Refresh the transform before any output is produced below, since the
+        # source frame is only known now that a message has arrived
+        if self._transform_provider is not None:
+            self._transformation = self._transform_provider(self)
 
         if self._extra_callback:
             if self._get_processed:
@@ -457,27 +503,6 @@ class OdomCallback(GenericCallback):
         node_name: str = "",
     ) -> None:
         super().__init__(input_topic, node_name)
-        self.__tf: Optional[TransformStamped] = None
-
-    @property
-    def transformation(self) -> Optional[TransformStamped]:
-        """
-        Sets a new transformation value
-
-        :return:  Detected transform from source to desired goal frame
-        :rtype: TransformStamped
-        """
-        return self.__tf
-
-    @transformation.setter
-    def transformation(self, transform: TransformStamped) -> None:
-        """
-        Sets a new transformation value
-
-        :param transform: Detected transform from source to desired goal frame
-        :type transform: TransformStamped
-        """
-        self.__tf = transform
 
     def _get_output(self, **_) -> Optional[np.ndarray]:
         """
@@ -631,27 +656,6 @@ class PoseCallback(GenericCallback):
         node_name: str = '',
     ) -> None:
         super().__init__(input_topic, node_name)
-        self.__tf: Optional[TransformStamped] = None
-
-    @property
-    def transformation(self) -> Optional[TransformStamped]:
-        """
-        Sets a new transformation value
-
-        :return:  Detected transform from source to desired goal frame
-        :rtype: TransformStamped
-        """
-        return self.__tf
-
-    @transformation.setter
-    def transformation(self, transform: TransformStamped) -> None:
-        """
-        Sets a new transformation value
-
-        :param transform: Detected transform from source to desired goal frame
-        :type transform: TransformStamped
-        """
-        self.__tf = transform
 
     def _process(self, msg: Pose) -> np.ndarray:
         """Takes Pose ROS object and converts it to a numpy array with [x, y, z, heading]
@@ -994,26 +998,7 @@ class LaserScanCallback(GenericCallback):
         transformation: Optional[TransformStamped] = None,
     ) -> None:
         super().__init__(input_topic, node_name)
-        self.__tf = transformation
-
-    @property
-    def transformation(self) -> Optional[TransformStamped]:
-        """Getter of the laserscan transformation
-
-        :return: Detected transform from source to desired goal frame
-        :rtype: Optional[TransformStamped]
-        """
-        return self.__tf
-
-    @transformation.setter
-    def transformation(self, transform: TransformStamped) -> None:
-        """
-        Sets a new transformation value
-
-        :param transform: Detected transform from source to desired goal frame
-        :type transform: TransformStamped
-        """
-        self.__tf = transform
+        self._transformation = transformation
 
     def _get_output(
         self,

--- a/ros_sugar/io/callbacks.py
+++ b/ros_sugar/io/callbacks.py
@@ -12,7 +12,7 @@ import numpy as np
 from geometry_msgs.msg import Pose
 from jinja2.environment import Template
 from nav_msgs.msg import OccupancyGrid, Odometry
-from sensor_msgs.msg import LaserScan
+from sensor_msgs.msg import JointState, LaserScan
 from std_msgs.msg import Header
 from rclpy.logging import get_logger
 from rclpy.subscription import Subscription
@@ -598,6 +598,37 @@ class PointCallback(GenericCallback):
             return None
 
         return np.array([self.msg.x, self.msg.y, self.msg.z])
+
+    def _get_ui_content(self, **_) -> Dict:
+        """
+        Utility method to get UI compatible content.
+        To be used with external callbacks in UI Node
+        :returns:   Topic content
+        :rtype:     Any
+        """
+        output = self.get_output()
+        return {"data": output.tolist() if output is not None else None}
+
+
+class JointStateCallback(GenericCallback):
+    """
+    sensor_msgs/JointState callback.
+
+    Returns the joint positions as a numpy array, ordered as the incoming
+    message's ``name`` field.
+    """
+
+    def _get_output(self, **_) -> Optional[np.ndarray]:
+        """
+        Gets the joint positions as a numpy array.
+
+        :returns:   joint positions (rad or m), ordered as ``msg.name``
+        :rtype:     Optional[np.ndarray]
+        """
+        if not self.msg:
+            return None
+
+        return np.array(self.msg.position, dtype=np.float64)
 
     def _get_ui_content(self, **_) -> Dict:
         """

--- a/ros_sugar/io/supported_types.py
+++ b/ros_sugar/io/supported_types.py
@@ -22,8 +22,10 @@ from automatika_ros_sugar.msg import ComponentStatus as ROSComponentStatus
 
 # SENSOR_MSGS SUPPORTED ROS TYPES
 from sensor_msgs.msg import Image as ROSImage, CompressedImage as ROSCompressedImage
+from sensor_msgs.msg import Imu as ROSImu
 from sensor_msgs.msg import JointState as ROSJointState
 from sensor_msgs.msg import LaserScan as ROSLaserScan
+from sensor_msgs.msg import NavSatFix as ROSNavSatFix
 from sensor_msgs.msg import PointCloud2 as ROSPointCloud2
 
 # STD_MSGS SUPPORTED ROS TYPES
@@ -551,6 +553,20 @@ class JointState(SupportedType):
         msg = ROSJointState()
         msg.position = [float(v) for v in np.asarray(output, dtype=np.float64).ravel()]
         return msg
+
+
+class Imu(SupportedType):
+    """Imu"""
+
+    _ros_type = ROSImu
+    callback = callbacks.ImuCallback
+
+
+class NavSatFix(SupportedType):
+    """NavSatFix"""
+
+    _ros_type = ROSNavSatFix
+    callback = callbacks.NavSatFixCallback
 
 
 class Path(SupportedType):

--- a/ros_sugar/io/supported_types.py
+++ b/ros_sugar/io/supported_types.py
@@ -540,7 +540,7 @@ class JointState(SupportedType):
     callback = callbacks.JointStateCallback
 
     # NOTE: Deliberately push-default (no _ui_rate_sampled): API consumers
-    # may need full-rate inertial data; dashboards can throttle with ?rate=<hz>
+    # may need full-rate state data; dashboards can throttle with ?rate=<hz>
 
     @classmethod
     def convert(cls, output: Union[np.ndarray, List], **_) -> ROSJointState:

--- a/ros_sugar/io/supported_types.py
+++ b/ros_sugar/io/supported_types.py
@@ -539,6 +539,9 @@ class JointState(SupportedType):
     _ros_type = ROSJointState
     callback = callbacks.JointStateCallback
 
+    # NOTE: Deliberately push-default (no _ui_rate_sampled): API consumers
+    # may need full-rate inertial data; dashboards can throttle with ?rate=<hz>
+
     @classmethod
     def convert(cls, output: Union[np.ndarray, List], **_) -> ROSJointState:
         """ROS message converter for datatype JointState.
@@ -560,6 +563,9 @@ class Imu(SupportedType):
 
     _ros_type = ROSImu
     callback = callbacks.ImuCallback
+
+    # NOTE: Deliberately push-default (no _ui_rate_sampled): API consumers
+    # may need full-rate inertial data; dashboards can throttle with ?rate=<hz>
 
 
 class NavSatFix(SupportedType):

--- a/ros_sugar/io/supported_types.py
+++ b/ros_sugar/io/supported_types.py
@@ -22,6 +22,7 @@ from automatika_ros_sugar.msg import ComponentStatus as ROSComponentStatus
 
 # SENSOR_MSGS SUPPORTED ROS TYPES
 from sensor_msgs.msg import Image as ROSImage, CompressedImage as ROSCompressedImage
+from sensor_msgs.msg import JointState as ROSJointState
 from sensor_msgs.msg import LaserScan as ROSLaserScan
 from sensor_msgs.msg import PointCloud2 as ROSPointCloud2
 
@@ -528,6 +529,28 @@ class PointCloud2(SupportedType):
     _ros_type = ROSPointCloud2
     callback = callbacks.PointCloudCallback
     _ui_rate_sampled = True  # dense sensor stream
+
+
+class JointState(SupportedType):
+    """JointState"""
+
+    _ros_type = ROSJointState
+    callback = callbacks.JointStateCallback
+
+    @classmethod
+    def convert(cls, output: Union[np.ndarray, List], **_) -> ROSJointState:
+        """ROS message converter for datatype JointState.
+
+        Takes an array of joint positions and produces a
+        ``sensor_msgs/JointState`` with its ``position`` field populated.
+
+        :param output: joint positions
+        :type output: Union[np.ndarray, List]
+        :rtype: ROSJointState
+        """
+        msg = ROSJointState()
+        msg.position = [float(v) for v in np.asarray(output, dtype=np.float64).ravel()]
+        return msg
 
 
 class Path(SupportedType):

--- a/ros_sugar/robot/types.py
+++ b/ros_sugar/robot/types.py
@@ -17,6 +17,7 @@ def create_supported_type(
     ros_msg_type: type,
     converter: Optional[Callable] = None,
     callback: Optional[Callable] = None,
+    module: Optional[str] = None,
 ) -> Type[SupportedType]:
     """Add a new ``SupportedType`` derived class wrapping ``ros_msg_type``.
 
@@ -26,6 +27,9 @@ def create_supported_type(
     :param callback: ``callback(msg: ros_msg_type) -> <python type>`` — ROS
         message to python value; its first-arg annotation must equal
         ``ros_msg_type`` and its return annotation must be a non-ROS python type.
+    :param module: Module path the type is registered under. Defaults to the
+        caller's module. Together with ``name`` this forms the registry key, so
+        it must be the module the bound variable actually lives in.
     :return: The newly registered ``SupportedType`` subclass.
     """
     if not hasattr(ros_msg_type, "SLOT_TYPES"):
@@ -33,9 +37,17 @@ def create_supported_type(
 
     # Dynamically create the new class
     class_name = f"{ros_msg_type.__name__}"
+
+    # NOTE: Stamp the new class with the *caller's* module rather than this one (where
+    # ``type()`` actually runs). The type registers under
+    # ``f"{__module__}.{__qualname__}"``.
+    if module is None:
+        module = sys._getframe(1).f_globals.get("__name__", __name__)
+
     class_bases = (SupportedType,)
     class_attrs = {
         "_ros_type": ros_msg_type,
+        "__module__": module,
     }
 
     if converter:

--- a/ros_sugar/robot/types.py
+++ b/ros_sugar/robot/types.py
@@ -7,6 +7,7 @@
 """
 
 import inspect
+import sys
 from typing import Callable, Optional, Type
 
 from ..io.callbacks import GenericCallback

--- a/ros_sugar/tf.py
+++ b/ros_sugar/tf.py
@@ -6,7 +6,7 @@ from attrs import define, field
 from rclpy.logging import get_logger
 from rclpy.time import Time
 from rclpy.timer import Timer
-from tf2_ros import ConnectivityException, LookupException
+from tf2_ros import ConnectivityException, ExtrapolationException, LookupException
 from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener
 
@@ -37,6 +37,7 @@ class TFListener:
         self,
         tf_config: Optional[TFListenerConfig] = None,
         node_name: str = "",
+        buffer: Optional[Buffer] = None,
     ) -> None:
         """
         Sets up a transform listener in ros
@@ -45,11 +46,19 @@ class TFListener:
         :type node: Node
         :param tf_config: Lookup config, defaults to TFListenerConfig()
         :type tf_config: TFListenerConfig, optional
+        :param buffer: Existing TF buffer to look the transform up in. Passing
+            the node's shared buffer avoids paying for another `/tf` and
+            `/tf_static` subscription per frame pair, which matters once a
+            component tracks several sensors. Defaults to a private buffer.
+        :type buffer: Buffer, optional
         """
         if not tf_config:
             tf_config = TFListenerConfig()
 
-        self._tf_buffer = Buffer()
+        self._tf_buffer = buffer if buffer is not None else Buffer()
+        # A shared buffer is fed by a listener owned by whoever created it, so
+        # this listener must not be treated as unset (see ``timer_callback``).
+        self._shared_buffer = buffer is not None
         self.node_name = node_name
         self.config = tf_config
 
@@ -132,10 +141,10 @@ class TFListener:
 
     def timer_callback(self):
         """
-        Timer callback to performe the requested transformation lookup
+        Timer callback to perform the requested transformation lookup
         """
         # Lookup transform if the listener is set
-        if self._tf_listener:
+        if self._tf_listener or self._shared_buffer:
             try:
                 # update the transform if found
                 self.transform = self._tf_buffer.lookup_transform(
@@ -143,7 +152,12 @@ class TFListener:
                 )
                 self.got_transform = True
 
-            except (LookupException, ConnectivityException):
+                # A static transform never changes, so stop paying for the
+                # lookup once it has been acquired.
+                if self.config.static_tf and self._timer is not None:
+                    self._timer.cancel()
+
+            except (LookupException, ConnectivityException, ExtrapolationException):
                 get_logger(self.node_name).debug(
                     f"Failed to get transform from {self.config.source_frame} to {self.config.goal_frame}"
                 )

--- a/test/robot_config_test.py
+++ b/test/robot_config_test.py
@@ -7,11 +7,13 @@ cross package boundaries without every consumer importing the same enum class.
 """
 
 import json
+import math
 
 import numpy as np
 import pytest
 
 from ros_sugar.config import (
+    AngularCtrlLimits,
     BaseComponentConfig,
     LinearCtrlLimits,
     RobotConfig,
@@ -19,6 +21,57 @@ from ros_sugar.config import (
     RobotGeometryType,
     RobotType,
 )
+
+
+def robot_config(**overrides) -> RobotConfig:
+    """Build a RobotConfig, letting each test state only what it exercises.
+
+    Every field is mandatory by design -- a robot's size and velocity envelope
+    must not be silently defaulted -- so tests need a baseline to vary from.
+    """
+    return RobotConfig(**{
+        "model_type": RobotType.ACKERMANN,
+        "geometry_type": RobotGeometryType.CYLINDER,
+        "geometry_params": [0.2, 1.0],
+        "ctrl_vx_limits": LinearCtrlLimits(max_vel=1.0, max_acc=3.0, max_decel=5.0),
+        "ctrl_omega_limits": AngularCtrlLimits(
+            max_vel=5.0, max_steer=math.pi, max_acc=10.0, max_decel=10.0
+        ),
+        **overrides,
+    })
+
+
+# ---- Mandatory fields -----------------------------------------------------
+
+
+def test_every_safety_relevant_field_is_mandatory():
+    """A silently defaulted geometry or velocity envelope means collision
+    checking and control run against a robot that does not exist."""
+    with pytest.raises(TypeError, match="required keyword-only argument"):
+        RobotConfig()
+
+
+def test_no_state_is_shared_between_instances():
+    """Mutable defaults evaluated once at class definition would be shared by
+    every instance -- and with `robot` on every component config, that means
+    cross-component contamination."""
+    a, b = robot_config(), robot_config()
+    assert a.geometry_params is not b.geometry_params
+    assert a.ctrl_vy_limits is not b.ctrl_vy_limits
+
+    a.geometry_params[0] = 99.0
+    a.ctrl_vy_limits.max_vel = 42.0
+
+    np.testing.assert_allclose(b.geometry_params, [0.2, 1.0])
+    assert b.ctrl_vy_limits.max_vel == 0.0
+    np.testing.assert_allclose(robot_config().geometry_params, [0.2, 1.0])
+
+
+def test_caller_cannot_mutate_config_through_the_array_it_passed():
+    params = np.array([0.2, 1.0])
+    config = robot_config(geometry_params=params)
+    params[0] = 77.0
+    assert config.geometry_params[0] == 0.2
 
 
 # ---- Frames ---------------------------------------------------------------
@@ -40,7 +93,7 @@ def test_model_type_compares_equal_to_its_name():
     """Regression: this comparison was always False when the config stored a
     plain string and consumers compared against a non-str Enum, so an Ackermann
     robot was allowed to attempt rotate-in-place."""
-    config = RobotConfig(model_type=RobotType.ACKERMANN)
+    config = robot_config(model_type=RobotType.ACKERMANN)
     assert config.model_type == RobotType.ACKERMANN
     assert config.model_type == "ACKERMANN"
 
@@ -48,7 +101,7 @@ def test_model_type_compares_equal_to_its_name():
 def test_enums_serialize_as_plain_names():
     """Not as a Python repr like 'Type.CYLINDER', which is neither stable nor
     writable by hand in a config file."""
-    payload = json.loads(RobotConfig().to_json())
+    payload = json.loads(robot_config().to_json())
     assert payload["model_type"] == "ACKERMANN"
     assert payload["geometry_type"] == "CYLINDER"
 
@@ -62,12 +115,12 @@ def test_geometry_type_accepts_equivalent_spellings(value):
     The legacy form matters because configs written by earlier releases stored
     the Python repr.
     """
-    assert RobotConfig(geometry_type=value).geometry_type is RobotGeometryType.CYLINDER
+    assert robot_config(geometry_type=value).geometry_type is RobotGeometryType.CYLINDER
 
 
 def test_unknown_enum_value_is_rejected():
     with pytest.raises(ValueError, match="not a valid RobotGeometryType"):
-        RobotConfig(geometry_type="TRIANGLE")
+        robot_config(geometry_type="TRIANGLE")
 
 
 # ---- Geometry validation --------------------------------------------------
@@ -84,11 +137,11 @@ def test_unknown_enum_value_is_rejected():
 )
 def test_geometry_params_must_match_geometry(geometry, params):
     with pytest.raises(ValueError, match="incompatible with given robot geometry"):
-        RobotConfig(geometry_type=geometry, geometry_params=params)
+        robot_config(geometry_type=geometry, geometry_params=params)
 
 
 def test_valid_geometry_params_are_kept_as_array():
-    config = RobotConfig(
+    config = robot_config(
         geometry_type=RobotGeometryType.BOX, geometry_params=[0.61, 0.37, 0.4]
     )
     assert isinstance(config.geometry_params, np.ndarray)
@@ -101,14 +154,14 @@ def test_valid_geometry_params_are_kept_as_array():
 def test_round_trip_restores_types_not_just_values():
     """Components rebuild their config from JSON in a separate process, so the
     rebuilt object must be usable exactly like the original."""
-    original = RobotConfig(
+    original = robot_config(
         model_type=RobotType.DIFFERENTIAL_DRIVE,
         geometry_type=RobotGeometryType.BOX,
         geometry_params=np.array([0.61, 0.37, 0.4]),
         ctrl_vx_limits=LinearCtrlLimits(max_vel=1.0, max_acc=2.5, max_decel=7.5),
     )
 
-    rebuilt = RobotConfig()
+    rebuilt = robot_config()
     rebuilt.from_json(original.to_json())
 
     assert isinstance(rebuilt.model_type, RobotType)
@@ -120,11 +173,22 @@ def test_round_trip_restores_types_not_just_values():
     assert rebuilt.ctrl_vx_limits.max_decel == 7.5
 
 
+def test_component_config_defaults_to_no_robot():
+    """A component that never reasons about the robot's body should not be
+    forced to describe one, and must not be handed an invented default."""
+    config = BaseComponentConfig()
+    assert config.robot is None
+
+    rebuilt = BaseComponentConfig()
+    rebuilt.from_json(config.to_json())
+    assert rebuilt.robot is None
+
+
 def test_component_config_carries_robot_and_frames():
     """Both ride the same JSON payload into the component subprocess."""
     config = BaseComponentConfig()
-    config.robot = RobotConfig(geometry_type=RobotGeometryType.SPHERE,
-                               geometry_params=[0.5])
+    config.robot = robot_config(geometry_type=RobotGeometryType.SPHERE,
+                                geometry_params=[0.5])
     config.frames = RobotFrames(robot_base="body", world="odom")
 
     rebuilt = BaseComponentConfig()

--- a/test/robot_config_test.py
+++ b/test/robot_config_test.py
@@ -1,0 +1,135 @@
+"""Tests for ros_sugar.config.robot -- the robot description primitives.
+
+These cover the two things that are easy to break silently: the serialization
+round-trip (components are launched in their own process and rebuild their
+config from JSON), and the string-enum behaviour that lets the description
+cross package boundaries without every consumer importing the same enum class.
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+from ros_sugar.config import (
+    BaseComponentConfig,
+    LinearCtrlLimits,
+    RobotConfig,
+    RobotFrames,
+    RobotGeometryType,
+    RobotType,
+)
+
+
+# ---- Frames ---------------------------------------------------------------
+
+
+def test_frames_declare_only_what_must_be_chosen():
+    """Sensor and localization frames come from the data, not from config."""
+    frames = RobotFrames()
+    assert frames.robot_base == "base_link"
+    assert frames.world == "map"
+    for derived in ("odom", "scan", "rgb", "depth", "point_cloud"):
+        assert not hasattr(frames, derived), f"{derived} should be read from the data"
+
+
+# ---- Enum behaviour -------------------------------------------------------
+
+
+def test_model_type_compares_equal_to_its_name():
+    """Regression: this comparison was always False when the config stored a
+    plain string and consumers compared against a non-str Enum, so an Ackermann
+    robot was allowed to attempt rotate-in-place."""
+    config = RobotConfig(model_type=RobotType.ACKERMANN)
+    assert config.model_type == RobotType.ACKERMANN
+    assert config.model_type == "ACKERMANN"
+
+
+def test_enums_serialize_as_plain_names():
+    """Not as a Python repr like 'Type.CYLINDER', which is neither stable nor
+    writable by hand in a config file."""
+    payload = json.loads(RobotConfig().to_json())
+    assert payload["model_type"] == "ACKERMANN"
+    assert payload["geometry_type"] == "CYLINDER"
+
+
+@pytest.mark.parametrize(
+    "value", ["CYLINDER", RobotGeometryType.CYLINDER, "Type.CYLINDER"]
+)
+def test_geometry_type_accepts_equivalent_spellings(value):
+    """Bare name, enum member, and the legacy serialized form all normalize.
+
+    The legacy form matters because configs written by earlier releases stored
+    the Python repr.
+    """
+    assert RobotConfig(geometry_type=value).geometry_type is RobotGeometryType.CYLINDER
+
+
+def test_unknown_enum_value_is_rejected():
+    with pytest.raises(ValueError, match="not a valid RobotGeometryType"):
+        RobotConfig(geometry_type="TRIANGLE")
+
+
+# ---- Geometry validation --------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "geometry, params",
+    [
+        (RobotGeometryType.BOX, [1.0, 2.0]),  # needs 3
+        (RobotGeometryType.SPHERE, [1.0, 2.0]),  # needs 1
+        (RobotGeometryType.CYLINDER, [0.2, -1.0]),  # must be positive
+        (RobotGeometryType.CYLINDER, [0.2, 0.0]),  # strictly positive
+    ],
+)
+def test_geometry_params_must_match_geometry(geometry, params):
+    with pytest.raises(ValueError, match="incompatible with given robot geometry"):
+        RobotConfig(geometry_type=geometry, geometry_params=params)
+
+
+def test_valid_geometry_params_are_kept_as_array():
+    config = RobotConfig(
+        geometry_type=RobotGeometryType.BOX, geometry_params=[0.61, 0.37, 0.4]
+    )
+    assert isinstance(config.geometry_params, np.ndarray)
+    np.testing.assert_allclose(config.geometry_params, [0.61, 0.37, 0.4])
+
+
+# ---- Serialization round-trip (the multiprocess launch path) --------------
+
+
+def test_round_trip_restores_types_not_just_values():
+    """Components rebuild their config from JSON in a separate process, so the
+    rebuilt object must be usable exactly like the original."""
+    original = RobotConfig(
+        model_type=RobotType.DIFFERENTIAL_DRIVE,
+        geometry_type=RobotGeometryType.BOX,
+        geometry_params=np.array([0.61, 0.37, 0.4]),
+        ctrl_vx_limits=LinearCtrlLimits(max_vel=1.0, max_acc=2.5, max_decel=7.5),
+    )
+
+    rebuilt = RobotConfig()
+    rebuilt.from_json(original.to_json())
+
+    assert isinstance(rebuilt.model_type, RobotType)
+    assert isinstance(rebuilt.geometry_type, RobotGeometryType)
+    assert isinstance(rebuilt.geometry_params, np.ndarray)
+    assert rebuilt.model_type == original.model_type
+    assert rebuilt.geometry_type == original.geometry_type
+    np.testing.assert_allclose(rebuilt.geometry_params, original.geometry_params)
+    assert rebuilt.ctrl_vx_limits.max_decel == 7.5
+
+
+def test_component_config_carries_robot_and_frames():
+    """Both ride the same JSON payload into the component subprocess."""
+    config = BaseComponentConfig()
+    config.robot = RobotConfig(geometry_type=RobotGeometryType.SPHERE,
+                               geometry_params=[0.5])
+    config.frames = RobotFrames(robot_base="body", world="odom")
+
+    rebuilt = BaseComponentConfig()
+    rebuilt.from_json(config.to_json())
+
+    assert rebuilt.robot.geometry_type is RobotGeometryType.SPHERE
+    assert rebuilt.frames.robot_base == "body"
+    assert rebuilt.frames.world == "odom"

--- a/test/tf_lifecycle_test.py
+++ b/test/tf_lifecycle_test.py
@@ -1,0 +1,112 @@
+"""Tests for the component's TF lookup lifecycle.
+
+Transform lookups run on their own timers, one per frame pair, created lazily
+as frames are discovered from incoming data. Those timers are not owned by
+``destroy_all_timers`` (which only owns the execution timer), so the component
+has to pause and resume them itself around deactivation.
+"""
+
+import pytest
+import rclpy
+from geometry_msgs.msg import TransformStamped
+
+from ros_sugar.config import BaseComponentConfig, RobotFrames
+from ros_sugar.core.component import BaseComponent
+from ros_sugar.io.topic import Topic
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ros_context():
+    # Other suites in this package init rclpy and never shut down; tolerate it
+    if not rclpy.ok():
+        rclpy.init()
+    yield
+
+
+def make_tf(parent: str, child: str, x: float = 0.0) -> TransformStamped:
+    transform = TransformStamped()
+    transform.header.frame_id = parent
+    transform.child_frame_id = child
+    transform.transform.translation.x = x
+    transform.transform.rotation.w = 1.0
+    return transform
+
+
+@pytest.fixture
+def component(request):
+    config = BaseComponentConfig()
+    config.frames = RobotFrames(robot_base="base_link", world="map")
+    comp = BaseComponent(
+        component_name=request.node.name.replace("[", "_").replace("]", "_"),
+        inputs=[Topic(name="/scan", msg_type="LaserScan")],
+        config=config,
+    )
+    comp.rclpy_init_node()
+    comp.activate()
+    return comp
+
+
+def test_lookup_timers_stop_on_deactivate(component):
+    """Otherwise a deactivated component keeps polling TF forever."""
+    dynamic = component.get_transform_listener("odom", "map", static_tf=False)
+    static = component.get_transform_listener("lidar_link", "base_link", static_tf=True)
+    assert not dynamic.timer.is_canceled()
+    assert not static.timer.is_canceled()
+
+    component.deactivate()
+
+    assert dynamic.timer.is_canceled()
+    assert static.timer.is_canceled()
+
+
+def test_lookups_resume_on_reactivate(component):
+    dynamic = component.get_transform_listener("odom", "map", static_tf=False)
+    component.deactivate()
+    assert dynamic.timer.is_canceled()
+
+    component.activate()
+
+    assert not dynamic.timer.is_canceled()
+
+
+def test_reactivate_does_not_restart_an_acquired_static_lookup(component):
+    """A static transform cancels its own timer once resolved; resuming must
+    not undo that, or the saving is lost after the first restart."""
+    static = component.get_transform_listener("lidar_link", "base_link", static_tf=True)
+    component.tf_buffer.set_transform_static(
+        make_tf("base_link", "lidar_link", x=0.3), "unit_test"
+    )
+    static.timer_callback()
+    assert static.got_transform
+    assert static.timer.is_canceled(), "static lookup should stop polling once acquired"
+
+    component.deactivate()
+    component.activate()
+
+    assert static.timer.is_canceled()
+
+
+def test_resolved_transforms_survive_a_restart(component):
+    """Pausing must not discard the buffer or the listener cache, or every
+    component restart would re-pay the lookup latency."""
+    component.tf_buffer.set_transform(make_tf("map", "odom", x=5.0), "unit_test")
+    dynamic = component.get_transform_listener("odom", "map", static_tf=False)
+    dynamic.timer_callback()
+    assert dynamic.got_transform
+
+    buffer_before = component.tf_buffer
+    component.deactivate()
+    component.activate()
+
+    assert component.tf_buffer is buffer_before
+    assert component.get_transform_listener("odom", "map") is dynamic
+    assert dynamic.got_transform
+    assert dynamic.transform.transform.translation.x == 5.0
+
+
+def test_no_tf_machinery_is_created_when_unused(component):
+    """A component that never asks for a transform should not pay for a buffer
+    or the /tf and /tf_static subscriptions that come with it."""
+    assert component._tf_buffer is None
+    component.deactivate()  # must not blow up with nothing to pause
+    assert component._tf_buffer is None

--- a/test/tf_lifecycle_test.py
+++ b/test/tf_lifecycle_test.py
@@ -32,16 +32,43 @@ def make_tf(parent: str, child: str, x: float = 0.0) -> TransformStamped:
     return transform
 
 
-@pytest.fixture
-def component(request):
+def _make_component(name: str) -> BaseComponent:
     config = BaseComponentConfig()
     config.frames = RobotFrames(robot_base="base_link", world="map")
     comp = BaseComponent(
-        component_name=request.node.name.replace("[", "_").replace("]", "_"),
+        component_name=name,
         inputs=[Topic(name="/scan", msg_type="LaserScan")],
         config=config,
     )
     comp.rclpy_init_node()
+    return comp
+
+
+@pytest.fixture
+def make_component(request):
+    """Build components and tear them down with the test.
+
+    Nodes must not outlive their test: these suites share one rclpy context
+    with the launch_testing integration tests that run later in the session,
+    and leaked live nodes destabilise it.
+    """
+    created = []
+
+    def _factory(suffix: str = "") -> BaseComponent:
+        name = request.node.name.replace("[", "_").replace("]", "_") + suffix
+        comp = _make_component(name)
+        created.append(comp)
+        return comp
+
+    yield _factory
+
+    for comp in created:
+        comp.destroy_node()
+
+
+@pytest.fixture
+def component(make_component):
+    comp = make_component()
     comp.activate()
     return comp
 
@@ -116,18 +143,12 @@ def test_no_tf_machinery_is_created_when_unused(component):
     "run_type",
     [ComponentRunType.TIMED, ComponentRunType.SERVER, ComponentRunType.ACTION_SERVER],
 )
-def test_teardown_is_safe_without_a_prior_activation(run_type):
+def test_teardown_is_safe_without_a_prior_activation(make_component, run_type):
     """Cleanup must tolerate whatever state the component reached: an
     activation that failed part-way, or a lifecycle transition that never
     activated at all, should not turn into an AttributeError on the way down.
     """
-    config = BaseComponentConfig()
-    comp = BaseComponent(
-        component_name=f"never_activated_{run_type.value.lower()}",
-        inputs=[Topic(name="/scan", msg_type="LaserScan")],
-        config=config,
-    )
-    comp.rclpy_init_node()
+    comp = make_component()
     comp.run_type = run_type
 
     comp.deactivate()  # never activated

--- a/test/tf_lifecycle_test.py
+++ b/test/tf_lifecycle_test.py
@@ -10,7 +10,7 @@ import pytest
 import rclpy
 from geometry_msgs.msg import TransformStamped
 
-from ros_sugar.config import BaseComponentConfig, RobotFrames
+from ros_sugar.config import BaseComponentConfig, ComponentRunType, RobotFrames
 from ros_sugar.core.component import BaseComponent
 from ros_sugar.io.topic import Topic
 
@@ -110,3 +110,32 @@ def test_no_tf_machinery_is_created_when_unused(component):
     assert component._tf_buffer is None
     component.deactivate()  # must not blow up with nothing to pause
     assert component._tf_buffer is None
+
+
+@pytest.mark.parametrize(
+    "run_type",
+    [ComponentRunType.TIMED, ComponentRunType.SERVER, ComponentRunType.ACTION_SERVER],
+)
+def test_teardown_is_safe_without_a_prior_activation(run_type):
+    """Cleanup must tolerate whatever state the component reached: an
+    activation that failed part-way, or a lifecycle transition that never
+    activated at all, should not turn into an AttributeError on the way down.
+    """
+    config = BaseComponentConfig()
+    comp = BaseComponent(
+        component_name=f"never_activated_{run_type.value.lower()}",
+        inputs=[Topic(name="/scan", msg_type="LaserScan")],
+        config=config,
+    )
+    comp.rclpy_init_node()
+    comp.run_type = run_type
+
+    comp.deactivate()  # never activated
+
+
+def test_teardown_is_idempotent(component):
+    component.deactivate()
+    component.deactivate()
+
+    component.activate()
+    component.deactivate()


### PR DESCRIPTION
This PR:

- Moves `RobotConfig` and `RobotFrames` into Sugarcoat
- Replaces per-sensor frame configuration with frames read from each message's `header.frame_id`. 
- Both `robot` and `frames` now live on `BaseComponentConfig`, so any Sugarcoat component gets them and `launcher.robot` / `launcher.frames` apply uniformly.
- Adds `JointState`, `Imu` and `NavSatFix` supported types and callbacks.

## Robot Frames (Breaking Change)

`RobotFrames` drops from seven fields to just two that a deployment genuinely has to *choose*. `RobotFrames` no longer accepts `odom`, `scan`, `rgb`, `depth` or `point_cloud`. Recipes passing them need updating.

```python
RobotFrames(robot_base="base_link", world="map")
```
