### PR TITLE
Multi-Plugin Recipes: A robot with extra mounted sensors

### DIFF
--- a/docs/development/custom_robot_plugin.md
+++ b/docs/development/custom_robot_plugin.md
@@ -137,13 +137,13 @@ knobs are part of its identity — declared as class attributes rather than
 constructor parameters. Recipe authors normally write `MyRobotPlugin()` and
 nothing more.
 
-Two keyword arguments are **reserved by the framework** and always available,
-whether or not your `__init__` declares them:
+Two keyword arguments are **reserved by the framework**, available whether or
+not your `__init__` declares them:
 
-| Argument | Purpose |
-|:--|:--|
-| `id` | Identity within a recipe. Defaults to a slug of the metadata name. Needed only when two plugins of the same kind are attached. |
-| `frame_id` | Name of the frame this hardware's data is in. Sensors default to `<id>_frame`. |
+| Argument | Available on | Purpose |
+|:--|:--|:--|
+| `id` | every plugin | Identity within a recipe. Defaults to a slug of the metadata name. Needed only when two plugins of the same kind are attached. |
+| `frame_id` | sensor plugins | Name of the frame this sensor's data is in. Defaults to `<id>_frame`. A robot names the frame attached to its body with `base_frame` instead. |
 
 ```python
 class MyRobotPlugin(RobotPlugin):

--- a/docs/development/custom_robot_plugin.md
+++ b/docs/development/custom_robot_plugin.md
@@ -1,14 +1,21 @@
-# Creating a Robot Plugin
+# Creating a Plugin
 
-A **robot plugin** adapts a Sugarcoat-based stack to one specific robot. It maps
-generic component I/O (`Twist`, `Odometry`, `Imu`, …) to whatever the robot
-actually exposes — ROS topics, ROS services, UDP, HTTP, or a vendor SDK — and
-can additionally contribute high-level **actions** (`stand_up`, `backflip`) and
-**events** (`fall_detected`, `low_battery`) that recipes consume directly.
+A **plugin** adapts a Sugarcoat-based stack to one specific piece of hardware. It
+maps generic component I/O (`Twist`, `Odometry`, `Imu`, …) to whatever the
+hardware actually exposes — ROS topics, ROS services, UDP, HTTP, or a vendor SDK
+— and can additionally contribute high-level **actions** (`stand_up`, `backflip`)
+and **events** (`fall_detected`, `low_battery`) that recipes consume directly.
 Component code never changes.
 
-A plugin author subclasses {py:class}`~ros_sugar.robot.RobotPlugin`. One plugin
-instance is passed to the `Launcher`.
+Plugins come in two roles:
+
+| Base class | Represents | Per recipe |
+|:--|:--|:--|
+| {py:class}`~ros_sugar.robot.RobotPlugin` | The robot itself | exactly one |
+| {py:class}`~ros_sugar.robot.SensorPlugin` | A sensor that is not part of the robot's own hardware — an inspection camera bolted on, a fixed camera watching a room | any number |
+
+The role is **intrinsic**: it follows from the base class you subclass, is
+read-only, and a recipe cannot attach a plugin under a different role.
 
 ```{tip}
 A complete, runnable reference plugin lives at
@@ -44,15 +51,17 @@ component thread — the bus is in-process and there is no CLIENT role.
 ```{important}
 Because the plugin must be reconstructable in component subprocesses, its
 `__init__` must be **declarative** — accept only JSON-serializable keyword
-arguments and perform **no I/O**. Open sockets and start threads in
-`on_activate()`, not `__init__()`.
+arguments and perform **no I/O**. Sockets, threads and heartbeats are opened
+for you by the plugin HOST; if you need node-dependent setup of your own,
+override `on_attached(node, bus)`.
 ```
 
 ## Building Blocks
 
 | Class | Role |
 |:------|:-----|
-| {py:class}`~ros_sugar.robot.RobotPlugin` | The plugin itself — subclass this. |
+| {py:class}`~ros_sugar.robot.RobotPlugin` / {py:class}`~ros_sugar.robot.SensorPlugin` | The plugin itself — subclass one of these. |
+| {py:class}`~ros_sugar.robot.Mount` | Where a sensor sits, when nothing else publishes its frame into TF. |
 | {py:class}`~ros_sugar.robot.Transport` | Where data comes from / goes to: `UdpTransport`, `HttpTransport`, `SdkCallbackTransport`, `RosTopicTransport`, `RosServiceTransport`. |
 | {py:class}`~ros_sugar.robot.Feedback` | One telemetry stream — a standard type name, a `SupportedType`, a transport, and a decoder. |
 | {py:class}`~ros_sugar.robot.RobotCommand` | One command surface — a standard type name, a transport, and an encoder. |
@@ -63,7 +72,11 @@ arguments and perform **no I/O**. Open sockets and start threads in
 
 Use `create_supported_type()` to turn a robot's ROS message into a
 `SupportedType`, optionally with a `callback` (ROS message → Python value, for
-feedback) and/or `converter` (Python value → ROS message, for commands):
+feedback) and/or `converter` (Python value → ROS message, for commands).
+
+Both are checked against their annotations, so they must be annotated functions
+rather than bare lambdas: a `callback`'s first argument must be annotated with
+the ROS message type, and its return with a non-ROS Python type.
 
 ```python
 import numpy as np
@@ -93,7 +106,11 @@ from ros_sugar.robot import (
     UdpTransport, create_supported_type,
 )
 
-RobotBattery = create_supported_type(RosFloat32, callback=lambda m: m.data)
+def _battery_callback(msg: RosFloat32) -> float:
+    return msg.data
+
+
+RobotBattery = create_supported_type(RosFloat32, callback=_battery_callback)
 
 
 def _decode_battery(raw: bytes):
@@ -113,12 +130,20 @@ the plugin HOST runs it on a background thread while active. A transport may set
 `route_via_host=True` so commands are forwarded through the HOST (use for
 session-bound protocols where a single client must own the connection).
 
-## Step 3: Subclass `RobotPlugin`
+## Step 3: Subclass a Plugin Base
 
-Construction is **zero-argument**: a `RobotPlugin` represents a *specific* robot,
-so every endpoint and tuning knob is part of the plugin's identity — declared as
-class attributes, not constructor parameters. Recipe authors write
-`MyRobotPlugin()` and nothing more.
+A plugin represents a *specific* piece of hardware, so its endpoints and tuning
+knobs are part of its identity — declared as class attributes rather than
+constructor parameters. Recipe authors normally write `MyRobotPlugin()` and
+nothing more.
+
+Two keyword arguments are **reserved by the framework** and always available,
+whether or not your `__init__` declares them:
+
+| Argument | Purpose |
+|:--|:--|
+| `id` | Identity within a recipe. Defaults to a slug of the metadata name. Needed only when two plugins of the same kind are attached. |
+| `frame_id` | Name of the frame this hardware's data is in. Sensors default to `<id>_frame`. |
 
 ```python
 class MyRobotPlugin(RobotPlugin):
@@ -141,11 +166,15 @@ class MyRobotPlugin(RobotPlugin):
         self.transports = {"telemetry": telemetry, "commands": commands}
 
         self.feedbacks = {
-            "Float32": Feedback("Float32", RobotBattery, telemetry,
-                                decoder=_decode_battery, rate_hz=50.0),
+            "Float32": Feedback(
+                key="Float32", msg_type=RobotBattery, transport=telemetry,
+                decoder=_decode_battery, rate_hz=50.0,
+            ),
         }
         self.commands = {
-            "Twist": RobotCommand("Twist", commands, encoder=_encode_twist),
+            "Twist": RobotCommand(
+                key="Twist", transport=commands, encoder=_encode_twist,
+            ),
         }
         self.actions = ActionRegistry({
             "stand_up": lambda: Action(method=lambda: commands.send(b"\x21\x01\x02\x02")),
@@ -164,17 +193,23 @@ class MyRobotPlugin(RobotPlugin):
 
 Notes:
 
-- `feedbacks` / `commands` are keyed by the **standard message-type name** they
-  stand in for — matched against component input/output topic message types.
+- `feedbacks` / `commands` are resolved against a component topic **by name
+  first** — a topic named after one of your registry keys binds to that entry —
+  falling back to a unique match on message type. So keying by message-type name
+  (`"Twist"`, `"Odometry"`) is the convention when you expose one entry per type;
+  when you expose several of the same type (a humanoid's `"left_arm"` /
+  `"right_arm"` JointStates) use descriptive keys and have the recipe name its
+  topics to match.
 - `actions` entries are **factories** returning fresh `Action` objects; `events`
   entries are factories returning `Event` objects, so recipes can pass per-call
   arguments.
 - `Feedback.as_topic()` yields the topic events reference — the real ROS topic
   for `RosTopicTransport` feedbacks, or a synthetic bus channel for everything
   else.
-- Override `on_load(node)`, `on_activate()`, `on_deactivate()` only if you need
-  custom HOST-side setup; the defaults open transports, start the bus and run
-  heartbeats for you.
+- Override `on_attached(node, bus)` only if you need custom HOST-side setup —
+  binding a `RosServiceTransport` client is the canonical case. The HOST already
+  opens transports, wires decoders to the bus and runs heartbeats for you. It is
+  the **only** author hook.
 
 ### Overriding for non-default deployments
 
@@ -201,6 +236,123 @@ class _MyRobotForTest(MyRobotPlugin):
 The serializable plugin spec captures whichever subclass and kwargs were used,
 so the same override survives the multiprocess launch boundary.
 
+## Describing the Robot
+
+A `RobotPlugin` knows the robot it drives, so it can configure the whole stack:
+
+```python
+class MyRobotPlugin(RobotPlugin):
+    def __init__(self):
+        ...
+        self.robot_config = RobotConfig(
+            model_type=RobotType.DIFFERENTIAL_DRIVE,
+            geometry_type=RobotGeometryType.BOX,
+            geometry_params=[0.61, 0.37, 0.4],
+            ctrl_vx_limits=LinearCtrlLimits(max_vel=1.0, max_acc=2.5, max_decel=7.5),
+            ctrl_omega_limits=AngularCtrlLimits(
+                max_vel=1.5, max_acc=2.5, max_decel=4.0, max_steer=1.57
+            ),
+        )
+        self.base_frame = "base_link"
+```
+
+Both are broadcast to every component at bringup. A recipe that sets its own
+`launcher.robot` wins, but `base_frame` does **not** work that way: the plugin's
+frame always applies, because its telemetry is stamped in that frame and
+anything mounted on the plugin is placed relative to it. The two cannot
+disagree. To publish under a different name, rename it on the plugin:
+
+```python
+robot = MyRobotPlugin()
+robot.base_frame = "chassis"
+launcher.add_plugin(robot)
+```
+
+```{note}
+A robot plugin supplies only `base_frame` — the frame attached to the robot's
+body. The **world** frame describes where the robot has been *placed*, which is
+a property of the deployment rather than of the robot, so it stays with the
+recipe.
+```
+
+Name the two independently, so taking one from a plugin does not mean restating
+the other:
+
+```python
+launcher.world_frame = "odom"       # leaves the body frame to the plugin
+launcher.robot_frame = "base_link"  # only meaningful with no robot plugin attached
+```
+
+Assigning `launcher.frames = RobotFrames(...)` still works and sets both at
+once — but `RobotFrames` carries a default body frame, so naming only the world
+frame that way would hand the plugin a frame it has to override. The
+single-frame setters avoid the question.
+
+## Sensor Plugins and Frames
+
+A sensor sits somewhere, so it has a frame. Which frame is the plugin's business;
+where that frame *sits* is the recipe's.
+
+```python
+class InspectionCamera(SensorPlugin):
+    def __init__(self, host: str = "192.168.1.50"):
+        self.metadata = PluginMetadata(name="HikVision PTZ", vendor="HikVision")
+        ...
+```
+
+Every sensor gets a frame automatically — `<id>_frame` — so two of the same
+camera never collide:
+
+```python
+front = InspectionCamera(id="front_cam")                          # front_cam_frame
+rear  = InspectionCamera(id="rear_cam", frame_id="rear_optical")  # rear_optical
+```
+
+The HOST stamps that frame onto any decoded message whose `header.frame_id` is
+empty, so components can place the data without you hard-coding frame names in
+your decoders. A decoder that stamps its own frame is never overridden — a
+robot's odometry is in the localization frame, and only the decoder knows that.
+
+### Getting the frame into TF
+
+Components transform incoming data from `header.frame_id` into the robot body
+frame, which requires that transform to exist. There are two ways to provide it:
+
+**Something else already publishes it** — a URDF and `robot_state_publisher`, or
+the sensor's own driver. Declare nothing:
+
+```python
+launcher.add_plugin(InspectionCamera(id="front_cam", frame_id="front_camera_link"))
+```
+
+**Nothing publishes it** — you bolted a camera on and there is no model of it.
+Give the recipe a `Mount` and Sugarcoat publishes the static transform:
+
+```python
+from ros_sugar.robot import Mount
+
+launcher.add_plugin(
+    camera,
+    mount=Mount(parent=robot, xyz=(0.15, 0.0, 0.35), rpy=(0.0, 0.0, 1.57)),
+)
+```
+
+`parent` takes the robot plugin (using its `base_frame`), another sensor plugin,
+or a plain frame name such as the world frame for a fixed sensor. The child is
+filled in from the plugin being attached, so a recipe never repeats it.
+
+```{warning}
+Mounts are **static**. A sensor with moving parts publishes the dynamic
+transform from its own base frame to the moving one *itself*; the recipe then
+only describes where that base frame sits, and the two compose in the TF tree.
+```
+
+```{note}
+In the first form, if nothing actually publishes the frame the lookup never
+resolves and the data is used untransformed — with no error. Prefer a `Mount`
+unless you are sure the frame is in the tree.
+```
+
 ## Step 4: Use the Plugin
 
 ```python
@@ -208,7 +360,8 @@ from ros_sugar.launch import Launcher
 from my_robot_plugin import MyRobotPlugin
 
 plugin = MyRobotPlugin()                     # declarative, all args defaulted
-launcher = Launcher(robot_plugin=plugin)
+launcher = Launcher()
+launcher.add_plugin(plugin)
 launcher.add_pkg(components=[planner, controller], multiprocessing=True)
 
 # Plugin-provided event + action factories, wired with the Launcher.on() sugar
@@ -217,11 +370,54 @@ launcher.on(plugin.events.low_battery(0.15), plugin.actions.sit())
 launcher.bringup()
 ```
 
-The launcher hosts the plugin, propagates it to every component, and tears it
-down on shutdown. During activation each component looks up its input/output
-topic types in the plugin: a match on a `RosTopicTransport` re-uses the native
-subscriber/publisher-swap path, any other transport is bridged through the
-feedback bus — components remain unaware their data is not ROS.
+`add_pkg` and `add_plugin` may be called in either order — every component
+receives every plugin at bringup.
+
+The launcher hosts each plugin, propagates them to every component, and tears
+them down on shutdown. During activation each component looks up its
+input/output topics in the plugin: a match on a `RosTopicTransport` re-uses the
+native subscriber/publisher-swap path, any other transport is bridged through
+the feedback bus — components remain unaware their data is not ROS.
+
+## Recipes With Several Plugins
+
+A robot augmented with an inspection camera attaches both. Topics say which
+plugin they come from with `use_plugin`:
+
+```python
+robot  = MyRobotPlugin()
+camera = InspectionCamera(id="insp_cam")
+
+detector = VisionDetector(
+    component_name="detector",
+    inputs=[
+        # the robot plugin
+        Topic(name="odom", msg_type="Odometry", use_plugin=True),
+        # a specific plugin, by id
+        Topic(name="image", msg_type="Image", use_plugin=camera.id),
+    ],
+)
+
+launcher = Launcher()
+launcher.add_plugin(robot)
+launcher.add_plugin(camera, mount=Mount(parent=robot, xyz=(0.15, 0.0, 0.35)))
+launcher.add_pkg(components=[detector], multiprocessing=True)
+launcher.bringup()
+```
+
+`use_plugin=True` means the robot plugin, so single-robot recipes are unchanged.
+Passing `camera.id` rather than a literal string means a rename cannot leave a
+topic pointing at nothing; a name that matches no attached plugin is rejected at
+bringup, listing the plugins that are attached.
+
+Each plugin's bus channels are namespaced by its id, so two instances of the same
+camera never collide.
+
+```{note}
+Namespacing covers the feedback bus, not the ROS graph. If your plugin uses a
+`RosTopicTransport`, the topic name belongs to the driver — two instances must
+be told which topic each reads, usually with a constructor argument.
+```
 
 ## How Replacement Works
 
@@ -253,7 +449,10 @@ plugin.list_feedbacks()   # -> [FeedbackSpec, ...]
 plugin.list_commands()    # -> [CommandSpec, ...]
 plugin.list_actions()     # -> [ActionSpec, ...]
 plugin.list_events()      # -> [EventSpec, ...]
-plugin.describe()         # -> a JSON-serializable tree of all of the above
+plugin.describe()         # -> a JSON-serializable tree of all of the above,
+                          #    including the plugin's role
+plugin.id                 # -> identity within a recipe
+plugin.role               # -> PluginRole.ROBOT | PluginRole.SENSOR (read-only)
 ```
 
 ```bash

--- a/ros_sugar/condition.py
+++ b/ros_sugar/condition.py
@@ -143,6 +143,7 @@ class Condition:
         topic_name: Optional[str] = None,
         topic_msg_type: Optional[str] = None,
         topic_qos_config: Optional[Dict] = None,
+        topic_use_plugin: Union[bool, str] = False,
         attribute_path: Optional[List[str]] = None,
         operator_func: Optional[Callable] = None,
         ref_value: Any = None,
@@ -156,6 +157,9 @@ class Condition:
         self.topic_name = topic_name
         self.topic_msg_type = topic_msg_type
         self.topic_qos_config = topic_qos_config
+        # Carried so an event on a plugin-served topic resolves against the same
+        # plugin its input did
+        self.topic_use_plugin = topic_use_plugin
         self.attribute_path = attribute_path if attribute_path is not None else []
         self.operator_func = operator_func
         self.ref_value = ref_value
@@ -194,6 +198,7 @@ class Condition:
                 "topic_name": self.topic_name,
                 "topic_msg_type": self.topic_msg_type,
                 "topic_qos_config": self.topic_qos_config,
+                "topic_use_plugin": self.topic_use_plugin,
                 "attribute_path": self.attribute_path,
                 "operator": self._serialized_operator(),
                 "ref_value": self.ref_value,
@@ -220,6 +225,7 @@ class Condition:
                 topic_name=data.get("topic_name"),
                 topic_msg_type=data.get("topic_msg_type"),
                 topic_qos_config=data.get("topic_qos_config"),
+                topic_use_plugin=data.get("topic_use_plugin", False),
                 attribute_path=data.get("attribute_path", []),
                 ref_value=data.get("ref_value", None),
                 operator_func=cls._deserialized_operator(data.get("operator", "none")),
@@ -261,6 +267,7 @@ class Condition:
             self.topic_name: {
                 "msg_type": self.topic_msg_type,
                 "qos_profile": self.topic_qos_config,
+                "use_plugin": self.topic_use_plugin,
             }
         }
 
@@ -316,6 +323,7 @@ class Condition:
                     topic_name=other.name,
                     topic_msg_type=other.msg_type.__name__,
                     topic_qos_config=other.qos_profile.to_dict(),
+                    topic_use_plugin=other.use_plugin,
                     attribute_path=[],
                 )
                 return Condition(
@@ -344,6 +352,7 @@ class Condition:
                     topic_name=other.name,
                     topic_msg_type=other.msg_type.__name__,
                     topic_qos_config=other.qos_profile.to_dict(),
+                    topic_use_plugin=other.use_plugin,
                     attribute_path=[],
                 )
                 return Condition(
@@ -620,6 +629,7 @@ class MsgConditionBuilder:
             topic_name=self._topic.name,
             topic_msg_type=self._topic.msg_type.__name__,
             topic_qos_config=self._topic.qos_profile.to_dict(),
+            topic_use_plugin=self._topic.use_plugin,
             attribute_path=self._base,
             operator_func=op,
             ref_value=value,

--- a/ros_sugar/config/base_attrs.py
+++ b/ros_sugar/config/base_attrs.py
@@ -13,7 +13,7 @@ from typing import (
 import functools
 from copy import deepcopy
 import numpy as np
-from attrs import asdict, define, fields_dict
+from attrs import asdict, define, fields, fields_dict, has
 from attrs import Attribute
 import yaml
 import toml
@@ -34,6 +34,93 @@ FUNC_NAME_MAP = {
 
 def skip_no_init(a: Attribute, _) -> bool:
     return a.init
+
+
+def _json_safe_value(_inst, _field, value: Any) -> Any:
+    """`attrs.asdict` value serializer turning numpy arrays into plain lists."""
+    return value.tolist() if isinstance(value, np.ndarray) else value
+
+
+def _equal_values(value: Any, other: Any) -> bool:
+    """Compare two serialized field values, tolerating numpy arrays.
+
+    A plain `==` on arrays returns an array rather than a bool, so comparing
+    configs field by field needs this.
+    """
+    if isinstance(value, np.ndarray) or isinstance(other, np.ndarray):
+        return np.array_equal(np.asarray(value), np.asarray(other))
+    return bool(value == other)
+
+
+def explicit_fields(config: Any) -> Dict:
+    """The fields of an attrs config that differ from its class defaults.
+
+    A full `asdict` cannot tell a value the caller chose from one that is
+    simply the class default. Anything consuming such a dict has to write
+    every key back, which reverts values its consumer set for itself. This
+    keeps only the fields that were actually changed, so the result reads as
+    "these are the overrides" rather than "this is the whole config".
+
+    Values are also made JSON-safe (numpy arrays become lists), since these
+    dicts get serialized to pass configuration to launched components.
+    `BaseAttrs.from_dict` converts them back on the way in.
+
+    Takes any attrs instance rather than a `BaseAttrs`: algorithm configs come
+    from whichever library implements the algorithm, and need not derive from
+    the base class in this package.
+
+    Note a field explicitly set to a value equal to its default is
+    indistinguishable from one never set, and is dropped. That is harmless for
+    a plain override, but means it cannot be used to defend a default against a
+    consumer that would otherwise fill the field in.
+
+    :param config: Any attrs class instance
+    :type config: Any
+    :return: Fields that differ from the defaults
+    :rtype: dict
+    """
+    try:
+        defaults = config.__class__()
+    except TypeError:
+        # Not default-constructible, so there is nothing to compare against
+        return asdict(config, value_serializer=_json_safe_value)
+    return _diff_fields(config, defaults)
+
+
+def _diff_fields(config: Any, defaults: Any) -> Dict:
+    """Fields of `config` that differ from the matching ones on `defaults`.
+
+    Descends into nested attrs instances so a single changed sub-field does
+    not drag its siblings' defaults along with it. The recursion tracks what
+    `BaseAttrs.from_dict` does: a nested attrs attribute is updated field by
+    field, so a partial dict is enough, while every other kind of value --
+    including a plain dict field or a list of configs -- is assigned whole and
+    so has to be stored whole.
+    """
+    current_serialized = asdict(config, value_serializer=_json_safe_value)
+    defaults_serialized = asdict(defaults, value_serializer=_json_safe_value)
+
+    diff = {}
+    for attribute in fields(config.__class__):
+        name = attribute.name
+        if name not in current_serialized:
+            continue
+        value = getattr(config, name)
+        default = getattr(defaults, name, None)
+        # Compare the instances, not the serialized dicts, to decide whether
+        # this is a nested config: a field can serialize to a dict without
+        # from_dict treating it as one
+        if (
+            has(value.__class__)
+            and has(default.__class__)
+            and value.__class__ is default.__class__
+        ):
+            if nested := _diff_fields(value, default):
+                diff[name] = nested
+            continue
+        if not _equal_values(current_serialized[name], defaults_serialized.get(name)):
+            diff[name] = current_serialized[name]
+    return diff
 
 
 @define
@@ -159,6 +246,16 @@ class BaseAttrs:
         """
         return self.asdict()
 
+    def asdict_explicit(self) -> Dict:
+        """Convert to dict, keeping only what differs from the class defaults.
+
+        See `explicit_fields`, which this defers to.
+
+        :return: Fields that differ from the defaults
+        :rtype: dict
+        """
+        return explicit_fields(self)
+
     def __check_value_against_attr_type(
         self, key: str, value: Any, attribute_to_set: Any, attribute_type: type
     ):
@@ -193,8 +290,10 @@ class BaseAttrs:
                         f"Trying to set a Literal attribute with incompatible value. Attribute {key} expecting '{_types}' got '{value}'"
                     )
         elif isinstance(value, List) and attribute_type is np.ndarray:
-            # Turn list into numpy array
-            value = np.array(value)
+            # Turn list into numpy array, keeping the dtype the attribute
+            # already carries.
+            dtype = getattr(attribute_to_set, "dtype", None)
+            value = np.array(value, dtype=dtype) if dtype else np.array(value)
             # NOTE: Silent failures can happen if someone passes wrong
             # datatypes in YAML/TOML/JSON config files for non-generic /
             # non-Union / non-Literal types

--- a/ros_sugar/config/base_attrs.py
+++ b/ros_sugar/config/base_attrs.py
@@ -103,7 +103,10 @@ def _diff_fields(config: Any, defaults: Any) -> Dict:
     diff = {}
     for attribute in fields(config.__class__):
         name = attribute.name
-        if name not in current_serialized:
+        # `from_dict` only ever writes back init fields, so a computed one that
+        # happens to differ from its default would be carried and then silently
+        # dropped on the way in
+        if not attribute.init or name not in current_serialized:
             continue
         value = getattr(config, name)
         default = getattr(defaults, name, None)

--- a/ros_sugar/config/base_attrs.py
+++ b/ros_sugar/config/base_attrs.py
@@ -58,18 +58,16 @@ def explicit_fields(config: Any) -> Dict:
     A full `asdict` cannot tell a value the caller chose from one that is
     simply the class default. Anything consuming such a dict has to write
     every key back, which reverts values its consumer set for itself. This
-    keeps only the fields that were actually changed, so the result reads as
-    "these are the overrides" rather than "this is the whole config".
+    keeps only the fields that were actually changed.
 
-    Values are also made JSON-safe (numpy arrays become lists), since these
-    dicts get serialized to pass configuration to launched components.
+    Values are also made JSON-safe (numpy arrays become lists).
     `BaseAttrs.from_dict` converts them back on the way in.
 
     Takes any attrs instance rather than a `BaseAttrs`: algorithm configs come
     from whichever library implements the algorithm, and need not derive from
     the base class in this package.
 
-    Note a field explicitly set to a value equal to its default is
+    NOTE: a field explicitly set to a value equal to its default is
     indistinguishable from one never set, and is dropped. That is harmless for
     a plain override, but means it cannot be used to defend a default against a
     consumer that would otherwise fill the field in.
@@ -91,11 +89,7 @@ def _diff_fields(config: Any, defaults: Any) -> Dict:
     """Fields of `config` that differ from the matching ones on `defaults`.
 
     Descends into nested attrs instances so a single changed sub-field does
-    not drag its siblings' defaults along with it. The recursion tracks what
-    `BaseAttrs.from_dict` does: a nested attrs attribute is updated field by
-    field, so a partial dict is enough, while every other kind of value --
-    including a plain dict field or a list of configs -- is assigned whole and
-    so has to be stored whole.
+    not drag its siblings' defaults along with it.
     """
     current_serialized = asdict(config, value_serializer=_json_safe_value)
     defaults_serialized = asdict(defaults, value_serializer=_json_safe_value)

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -1171,7 +1171,9 @@ class BaseComponent(lifecycle.Node):
             stops once it has been acquired
         :type static_tf: bool
 
-        :return: Transform lookup handler for the pair
+        :return: Transform lookup handler for the pair. A listener whose source
+            and goal are the same frame is already resolved to the identity and
+            runs no lookup at all
         :rtype: TFListener
         """
         key = (source_frame, goal_frame)
@@ -1184,11 +1186,14 @@ class BaseComponent(lifecycle.Node):
         listener = TFListener(
             tf_config=tf_config, node_name=self.node_name, buffer=self.tf_buffer
         )
-        listener.timer = self.create_timer(
-            1 / tf_config.lookup_rate,
-            listener.timer_callback,
-            callback_group=MutuallyExclusiveCallbackGroup(),
-        )
+        # Same source and goal resolves to the identity without any lookup, so
+        # it needs no polling timer
+        if not listener.is_identity:
+            listener.timer = self.create_timer(
+                1 / tf_config.lookup_rate,
+                listener.timer_callback,
+                callback_group=MutuallyExclusiveCallbackGroup(),
+            )
         self._tf_listeners[key] = listener
         return listener
 

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -285,17 +285,21 @@ class BaseComponent(lifecycle.Node):
         return outputs
 
     def _warn_orphaned_plugin_topics(self):
-        """Emit a warning for any ``use_plugin`` flagged topic when no robot
-        plugin is attached."""
+        """Emit a warning for any ``use_plugin`` topic with no plugin to serve it.
+
+        A recipe cannot reach here: `Launcher._validate_plugin_references`
+        raises at bringup, where both the components and the plugins are known.
+        This covers a component run on its own, which is already up by the time
+        it finds out and can only carry on as plain ROS.
+        """
         in_topics = [cb.input_topic for cb in self.callbacks.values()]
         out_topics = [pub.output_topic for pub in self.publishers_dict.values()]
         orphaned = [t.name for t in in_topics + out_topics if t.use_plugin]
         if orphaned:
             self.get_logger().warning(
                 f"Component '{self.node_name}' has {len(orphaned)} topic(s) "
-                f"flagged use_plugin=True but no robot plugin "
-                f"is attached to the launcher: {orphaned}. Those topics will "
-                "behave as ordinary ROS topics."
+                f"asking for a plugin, but none is attached: {orphaned}. "
+                "Those topics will behave as ordinary ROS topics."
             )
 
     @property
@@ -329,11 +333,9 @@ class BaseComponent(lifecycle.Node):
         :param plugin: The plugin instance to attach
         :type plugin: Plugin
         """
-        from ..robot.plugin import _slug
-
-        # An unattached plugin has no id yet; key it by its name so it is still
-        # addressable, without binding an identity the launcher hasn't assigned
-        self._plugins[plugin.id or _slug(plugin.metadata.name)] = plugin
+        # `id` falls back to a slug of the plugin's name, so it is addressable
+        # whether or not the recipe named it
+        self._plugins[plugin.id] = plugin
 
     def _plugin_for_topic(self, topic) -> Optional[Any]:
         """Resolve which attached plugin serves a topic.
@@ -821,9 +823,10 @@ class BaseComponent(lifecycle.Node):
         # Init any global node variables
         self.init_variables()
 
-        # Update the component topics using the robot plugin if provided.
-        # When no plugin is attached, topics that opted in with use_plugin=True
-        # issue a warning and keep working
+        # Adapt the component's topics to whichever plugins are attached. A
+        # recipe with none never gets here -- the launcher fails at bringup --
+        # so this warns and keeps working for a standalone component, which is
+        # already running by the time it can tell.
         if self._plugins:
             self._use_robot_plugin()
         else:
@@ -1347,15 +1350,22 @@ class BaseComponent(lifecycle.Node):
         """
         from ..robot.plugin import AmbiguousPluginEntryError
 
-        plugin = self._robot_plugin
+        # Whichever plugin the topic names -- not the robot plugin. A sensor's
+        # event would otherwise resolve against the robot and fire on its
+        # telemetry, or find nothing at all in a sensor-only recipe.
+        plugin = self._plugin_for_topic(topic_obj)
         if plugin is None:
+            self.get_logger().error(
+                f"Events on '{topic_name}' will never trigger: no attached "
+                f"plugin serves it (use_plugin={topic_obj.use_plugin!r})."
+            )
             return
         try:
             feedback = plugin.resolve_feedback(topic_name, topic_obj.msg_type.__name__)
         except (TypeError, AmbiguousPluginEntryError) as e:
             self.get_logger().error(
                 f"Events on '{topic_name}' will never trigger: the topic could not "
-                f"be bound to the robot plugin: {e}"
+                f"be bound to plugin '{plugin.id}': {e}"
             )
             return
         if feedback is None:
@@ -1725,9 +1735,14 @@ class BaseComponent(lifecycle.Node):
         """
         if not self._plugins:
             return "{}"
-        # Every plugin shares one bus, so any of them carries the endpoint
-        bus = next(iter(self._plugins.values())).bus
-        endpoint = bus.endpoint if bus is not None else None
+        # Every plugin shares one bus, so the first one carrying it answers for
+        # all of them -- looked up rather than taken from an arbitrary plugin,
+        # which may not have been given the bus yet
+        endpoint = None
+        for plugin in self._plugins.values():
+            if plugin.bus is not None:
+                endpoint = plugin.bus.endpoint
+                break
         return json.dumps({
             "plugins": [plugin.to_spec() for plugin in self._plugins.values()],
             "bus_endpoint": endpoint,
@@ -1748,8 +1763,7 @@ class BaseComponent(lifecycle.Node):
             return
         endpoint = data.get("bus_endpoint")
         for spec in data.get("plugins", []):
-            plugin = Plugin.from_spec(spec, bus_endpoint=endpoint)
-            self._plugins[plugin.id] = plugin
+            self.add_plugin(Plugin.from_spec(spec, bus_endpoint=endpoint))
 
     @property
     def _events_json(self) -> Union[str, bytes]:

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -182,9 +182,10 @@ class BaseComponent(lifecycle.Node):
         # Additional types from derived packages
         self._additional_types: List[Type[SupportedType]] = []
 
-        # Robot plugin (set by the Launcher; a HOST instance in multithreaded
-        # launch or a reconstructed CLIENT instance in multiprocess launch)
-        self._robot_plugin = None
+        # Plugins attached by the Launcher, keyed by plugin id (HOST instances
+        # in multithreaded launch, reconstructed CLIENT instances in
+        # multiprocess launch)
+        self._plugins: Dict[str, Any] = {}
         # Names of input/output topics bound to non-ROS robot plugin transports
         self._external_topics: set = set()
         # Feedback-bus subscription handles to release on deactivation
@@ -298,6 +299,77 @@ class BaseComponent(lifecycle.Node):
                 "behave as ordinary ROS topics."
             )
 
+    @property
+    def _robot_plugin(self) -> Optional[Any]:
+        """The attached plugin that describes the robot, if any.
+
+        A recipe has at most one, so this stays a convenient shortcut into
+        `_plugins` for the code and tests that only care about the robot.
+        """
+        from ..robot.plugin import PluginRole
+
+        for plugin in self._plugins.values():
+            if plugin.role is PluginRole.ROBOT:
+                return plugin
+        return None
+
+    @_robot_plugin.setter
+    def _robot_plugin(self, plugin: Optional[Any]) -> None:
+        """Attach (or clear) the robot plugin, leaving other plugins alone."""
+        from ..robot.plugin import PluginRole
+
+        for key, attached in list(self._plugins.items()):
+            if attached.role is PluginRole.ROBOT:
+                del self._plugins[key]
+        if plugin is not None:
+            self.add_plugin(plugin)
+
+    def add_plugin(self, plugin: Any) -> None:
+        """Attach a plugin to this component.
+
+        :param plugin: The plugin instance to attach
+        :type plugin: Plugin
+        """
+        from ..robot.plugin import _slug
+
+        # An unattached plugin has no id yet; key it by its name so it is still
+        # addressable, without binding an identity the launcher hasn't assigned
+        self._plugins[plugin.id or _slug(plugin.metadata.name)] = plugin
+
+    def _plugin_for_topic(self, topic) -> Optional[Any]:
+        """Resolve which attached plugin serves a topic.
+
+        ``use_plugin=True`` means the robot plugin, the only one a recipe could
+        address before several could be attached. A string names a plugin by
+        its id.
+
+        :param topic: The topic to resolve
+        :type topic: Topic
+
+        :return: The plugin serving this topic, or None if it is not
+            plugin-backed or the named plugin is not attached
+        :rtype: Optional[Plugin]
+        """
+        if not topic.use_plugin:
+            return None
+        if topic.use_plugin is True:
+            plugin = self._robot_plugin
+            if plugin is None:
+                self.get_logger().error(
+                    f"Topic '{topic.name}' asks for the robot plugin but none is "
+                    "attached. Falling back to an ordinary ROS topic."
+                )
+            return plugin
+        plugin = self._plugins.get(topic.use_plugin)
+        if plugin is None:
+            self.get_logger().error(
+                f"Topic '{topic.name}' is bound to plugin '{topic.use_plugin}', "
+                f"which is not attached to this component. Attached plugins: "
+                f"{', '.join(self._plugins) or 'none'}. Falling back to an "
+                "ordinary ROS topic."
+            )
+        return plugin
+
     def _use_robot_plugin(self):
         """Adapt the component's inputs/outputs to the robot plugin.
 
@@ -316,10 +388,9 @@ class BaseComponent(lifecycle.Node):
         from ..robot.plugin import AmbiguousPluginEntryError
         from ..robot.transports.ros import RosTopicTransport
 
-        plugin = self._robot_plugin
         self.get_logger().info(
-            f"Adapting component '{self.node_name}' to robot plugin "
-            f"'{plugin.metadata.name}'"
+            f"Adapting component '{self.node_name}' to plugins: "
+            f"{', '.join(self._plugins) or 'none'}"
         )
 
         # Handle Robot Feedback (System Input Topics). Snapshot the topics
@@ -328,7 +399,8 @@ class BaseComponent(lifecycle.Node):
         for topic in [cb.input_topic for cb in list(self.callbacks.values())]:
             if topic.name in self._external_topics:
                 continue
-            if not topic.use_plugin:
+            plugin = self._plugin_for_topic(topic)
+            if plugin is None:
                 continue
             try:
                 feedback = plugin.resolve_feedback(topic.name, topic.msg_type.__name__)
@@ -361,14 +433,15 @@ class BaseComponent(lifecycle.Node):
                 if error:
                     self.get_logger().error(error)
             else:
-                self._attach_external_feedback(topic, feedback)
+                self._attach_external_feedback(topic, feedback, plugin)
 
         # Handle Robot Commands (System Output Topics). Snapshot first, as
         # _replace_output_by_transport mutates publishers_dict as we go.
         for topic in [pub.output_topic for pub in list(self.publishers_dict.values())]:
             if topic.name in self._external_topics:
                 continue
-            if not topic.use_plugin:
+            plugin = self._plugin_for_topic(topic)
+            if plugin is None:
                 continue
             try:
                 command = plugin.resolve_command(topic.name, topic.msg_type.__name__)
@@ -401,9 +474,9 @@ class BaseComponent(lifecycle.Node):
                 if error:
                     self.get_logger().error(error)
             else:
-                self._replace_output_by_transport(topic, command)
+                self._replace_output_by_transport(topic, command, plugin)
 
-    def _attach_external_feedback(self, topic: Topic, feedback) -> None:
+    def _attach_external_feedback(self, topic: Topic, feedback, plugin) -> None:
         """Bind a non-ROS robot feedback stream into the component's callback slot.
 
         No ROS subscription is created for ``topic``; instead the component
@@ -440,7 +513,7 @@ class BaseComponent(lifecycle.Node):
             self.destroy_subscription(old_callback._subscriber)
         self.callbacks[topic.name] = new_callback
         self._update_inactive_input_topic(old_callback.input_topic, new_topic)
-        handle = self._robot_plugin.subscribe_feedback(feedback, new_callback.callback)
+        handle = plugin.subscribe_feedback(feedback, new_callback.callback)
         self._robot_plugin_bus_handles.append(handle)
         self._external_topics.add(topic.name)
         self.get_logger().info(
@@ -448,7 +521,7 @@ class BaseComponent(lifecycle.Node):
             f"'{feedback.key}' via {feedback.transport.kind}"
         )
 
-    def _replace_output_by_transport(self, topic: Topic, command) -> None:
+    def _replace_output_by_transport(self, topic: Topic, command, plugin) -> None:
         """Replace a component output publisher with a robot plugin command adapter.
 
         ``Publisher`` in ``publishers_dict`` is swapped (under the same key) for
@@ -472,10 +545,10 @@ class BaseComponent(lifecycle.Node):
         if isinstance(transport, RosServiceTransport):
             transport.bind_node(self)
         # Prepare the command transport for sending
-        self._robot_plugin.open_command(command)
+        plugin.open_command(command)
 
         adapter = RobotCommandPublisher(
-            self._robot_plugin, command, topic, node_name=self.node_name
+            plugin, command, topic, node_name=self.node_name
         )
         # Preserve the original publisher's pre-processor chain
         if old_publisher is not None:
@@ -743,7 +816,7 @@ class BaseComponent(lifecycle.Node):
         # Update the component topics using the robot plugin if provided.
         # When no plugin is attached, topics that opted in with use_plugin=True
         # issue a warning and keep working
-        if self._robot_plugin is not None:
+        if self._plugins:
             self._use_robot_plugin()
         else:
             self._warn_orphaned_plugin_topics()
@@ -1312,8 +1385,11 @@ class BaseComponent(lifecycle.Node):
                 f"'{topic_obj.msg_type.__name__}'."
             )
             return
+        # The event handler is the bus subscriber: decoded messages land in
+        # __event_topic_callback exactly as they would from a ROS subscription
         handle = plugin.subscribe_feedback(
-            feedback=feedback, callback=partial(self.__event_topic_callback, topic_name)
+            feedback=feedback,
+            on_ros_msg=partial(self.__event_topic_callback, topic_name),
         )
         self._robot_plugin_bus_handles.append(handle)
         self.get_logger().info(
@@ -1642,46 +1718,95 @@ class BaseComponent(lifecycle.Node):
                 self._external_processors_json,
             ]
 
-        if self._robot_plugin is not None:
-            self.launch_cmd_args = ["--robot_plugin", self._robot_plugin_json]
+        if self._plugins:
+            self.launch_cmd_args = ["--plugins", self._plugins_json]
+            # Emitted alongside for one release: an executable built against an
+            # older ros_sugar drops the unknown --plugins arg silently (the
+            # parser uses parse_known_args), which would demote every plugin
+            # topic to a plain ROS topic with no warning.
+            self.launch_cmd_args = ["--plugins", self._plugins_json]
 
     @property
-    def _robot_plugin_json(self) -> str:
-        """Getter of the serialized robot plugin spec + feedback-bus endpoint.
+    def _plugins_json(self) -> str:
+        """Getter of every attached plugin's spec + the shared bus endpoint.
 
-        Used to carry the robot plugin across the multiprocess launch boundary:
-        each component subprocess rebuilds a CLIENT plugin from this spec and
-        connects to the HOST feedback bus at ``bus_endpoint``.
+        Carries the plugins across the multiprocess launch boundary: each
+        component subprocess rebuilds CLIENT plugins from these specs and
+        connects them to the HOST feedback bus at ``bus_endpoint``.
 
-        :return: JSON ``{"spec": <plugin spec>, "bus_endpoint": <name>}``
+        :return: JSON ``{"plugins": [<spec>, ...], "bus_endpoint": <name>}``
         :rtype: str
         """
-        if self._robot_plugin is None:
+        if not self._plugins:
             return "{}"
-        bus = self._robot_plugin.bus
-        endpoint = bus.endpoint if bus is not None else None
+        # Every plugin shares one bus, so the endpoint is taken once
+        endpoint = None
+        for plugin in self._plugins.values():
+            if plugin.bus is not None:
+                endpoint = plugin.bus.endpoint
+                break
         return json.dumps({
-            "spec": self._robot_plugin.to_spec(),
+            "plugins": [plugin.to_spec() for plugin in self._plugins.values()],
             "bus_endpoint": endpoint,
         })
 
-    @_robot_plugin_json.setter
-    def _robot_plugin_json(self, value: Union[str, bytes]):
-        """Setter that rebuilds a CLIENT robot plugin from a serialized spec.
+    @_plugins_json.setter
+    def _plugins_json(self, value: Union[str, bytes]):
+        """Setter that rebuilds CLIENT plugins from serialized specs.
 
-        :param value: JSON produced by the :attr:`_robot_plugin_json` getter
+        :param value: JSON produced by the :attr:`_plugins_json` getter
         :type value: Union[str, bytes]
         """
-        from ..robot.plugin import RobotPlugin
+        from ..robot.plugin import Plugin
 
         data = json.loads(value)
+        self._plugins = {}
         if not data:
-            self._robot_plugin = None
             return
-        self._robot_plugin = RobotPlugin.from_spec(
-            data["spec"],
-            bus_endpoint=data.get("bus_endpoint"),
-        )
+        endpoint = data.get("bus_endpoint")
+        for spec in data.get("plugins", []):
+            self.add_plugin(Plugin.from_spec(spec, bus_endpoint=endpoint))
+
+    @property
+    def _plugins_json(self) -> str:
+        """Getter of the serialized plugin specs + shared feedback-bus endpoint.
+
+        Used to carry every attached plugin across the multiprocess launch
+        boundary: each component subprocess rebuilds CLIENT plugins from these
+        specs and connects to the HOST feedback bus at ``bus_endpoint``. The
+        specs carry each plugin's id, so the channels a subprocess subscribes
+        to are the ones the hosts publish on.
+
+        :return: JSON ``{"plugins": [<spec>, ...], "bus_endpoint": <name>}``
+        :rtype: str
+        """
+        if not self._plugins:
+            return "{}"
+        # Every plugin shares one bus, so any of them carries the endpoint
+        bus = next(iter(self._plugins.values())).bus
+        endpoint = bus.endpoint if bus is not None else None
+        return json.dumps({
+            "plugins": [plugin.to_spec() for plugin in self._plugins.values()],
+            "bus_endpoint": endpoint,
+        })
+
+    @_plugins_json.setter
+    def _plugins_json(self, value: Union[str, bytes]):
+        """Setter that rebuilds CLIENT plugins from serialized specs.
+
+        :param value: JSON produced by the :attr:`_plugins_json` getter
+        :type value: Union[str, bytes]
+        """
+        from ..robot.plugin import Plugin
+
+        data = json.loads(value)
+        self._plugins = {}
+        if not data:
+            return
+        endpoint = data.get("bus_endpoint")
+        for spec in data.get("plugins", []):
+            plugin = Plugin.from_spec(spec, bus_endpoint=endpoint)
+            self._plugins[plugin.id] = plugin
 
     @property
     def _events_json(self) -> Union[str, bytes]:

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -1709,52 +1709,6 @@ class BaseComponent(lifecycle.Node):
 
         if self._plugins:
             self.launch_cmd_args = ["--plugins", self._plugins_json]
-            # Emitted alongside for one release: an executable built against an
-            # older ros_sugar drops the unknown --plugins arg silently (the
-            # parser uses parse_known_args), which would demote every plugin
-            # topic to a plain ROS topic with no warning.
-            self.launch_cmd_args = ["--plugins", self._plugins_json]
-
-    @property
-    def _plugins_json(self) -> str:
-        """Getter of every attached plugin's spec + the shared bus endpoint.
-
-        Carries the plugins across the multiprocess launch boundary: each
-        component subprocess rebuilds CLIENT plugins from these specs and
-        connects them to the HOST feedback bus at ``bus_endpoint``.
-
-        :return: JSON ``{"plugins": [<spec>, ...], "bus_endpoint": <name>}``
-        :rtype: str
-        """
-        if not self._plugins:
-            return "{}"
-        # Every plugin shares one bus, so the endpoint is taken once
-        endpoint = None
-        for plugin in self._plugins.values():
-            if plugin.bus is not None:
-                endpoint = plugin.bus.endpoint
-                break
-        return json.dumps({
-            "plugins": [plugin.to_spec() for plugin in self._plugins.values()],
-            "bus_endpoint": endpoint,
-        })
-
-    @_plugins_json.setter
-    def _plugins_json(self, value: Union[str, bytes]):
-        """Setter that rebuilds CLIENT plugins from serialized specs.
-
-        :param value: JSON produced by the :attr:`_plugins_json` getter
-        :type value: Union[str, bytes]
-        """
-        from ..robot.plugin import Plugin
-
-        data = json.loads(value)
-        self._plugins = {}
-        if not data:
-            return
-        endpoint = data.get("bus_endpoint")
-        for spec in data.get("plugins", []):
-            self.add_plugin(Plugin.from_spec(spec, bus_endpoint=endpoint))
 
     @property
     def _plugins_json(self) -> str:

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -1160,7 +1160,9 @@ class BaseComponent(lifecycle.Node):
         """
         if not source_frame or not goal_frame or source_frame == goal_frame:
             return None
-        return self.get_transform_listener(source_frame, goal_frame, static_tf).transform
+        return self.get_transform_listener(
+            source_frame, goal_frame, static_tf
+        ).transform
 
     def transform_input_to(
         self, topic_name: str, goal_frame: str, static_tf: bool = False
@@ -1256,6 +1258,10 @@ class BaseComponent(lifecycle.Node):
         # Create ONE subscription per Topic
         self.__event_listeners = []
         for name, topic_obj in unique_topics.items():
+            # Handle events for non-ROS inputs served by the robot plugin
+            if name in self._external_topics:
+                self._subscribe_event_to_plugin_feedback(name, topic_obj)
+                continue
             listener = self.create_subscription(
                 msg_type=topic_obj.ros_msg_type,
                 topic=topic_obj.name,
@@ -1264,6 +1270,55 @@ class BaseComponent(lifecycle.Node):
                 callback_group=MutuallyExclusiveCallbackGroup(),
             )
             self.__event_listeners.append(listener)
+
+    def _subscribe_event_to_plugin_feedback(self, topic_name: str, topic_obj) -> None:
+        """Drive an event from the robot plugin's feedback bus.
+
+        Events are otherwise fed by ROS subscriptions. For a topic the plugin
+        serves over its own transport there is no ROS traffic to subscribe to,
+        so the event is fed from the feedback bus instead.
+
+        :param topic_name: Name of the event topic
+        :type topic_name: str
+        :param topic_obj: The event's declared topic
+        :type topic_obj: Topic
+        """
+        from ..robot.plugin import AmbiguousPluginEntryError
+
+        plugin = self._robot_plugin
+        if plugin is None:
+            return
+        try:
+            feedback = plugin.resolve_feedback(topic_name, topic_obj.msg_type.__name__)
+        except (TypeError, AmbiguousPluginEntryError) as e:
+            self.get_logger().error(
+                f"Events on '{topic_name}' will never trigger: the topic could not "
+                f"be bound to the robot plugin: {e}"
+            )
+            return
+        if feedback is None:
+            self.get_logger().error(
+                f"Events on '{topic_name}' will never trigger: the topic is served by "
+                "the robot plugin but no matching feedback was found."
+            )
+            return
+        # The plugin may decode to a different message type than the recipe
+        # declared. Event conditions read attributes off the declared type, so
+        # a mismatched stream would misfire rather than simply not fire.
+        if feedback.msg_type is not topic_obj.msg_type:
+            self.get_logger().error(
+                f"Events on '{topic_name}' will never trigger: the plugin publishes "
+                f"'{feedback.msg_type.__name__}' but the event expects "
+                f"'{topic_obj.msg_type.__name__}'."
+            )
+            return
+        handle = plugin.subscribe_feedback(
+            feedback=feedback, callback=partial(self.__event_topic_callback, topic_name)
+        )
+        self._robot_plugin_bus_handles.append(handle)
+        self.get_logger().info(
+            f"Events on '{topic_name}' bound to robot plugin feedback '{feedback.key}'"
+        )
 
     def _turn_on_fallbacks_subscribers(self):
         # Create ONE subscription per Topic

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -3,8 +3,6 @@
 import os
 import time
 import json
-import yaml
-import toml
 import socket
 from copy import deepcopy
 from contextlib import contextmanager
@@ -40,6 +38,7 @@ from automatika_ros_sugar.srv import (
 from .action import Action
 from .event import Event, EventBlackboardEntry
 from ..io.callbacks import GenericCallback
+from ..config.base_attrs import explicit_fields
 from ..config.base_config import (
     BaseComponentConfig,
     ComponentRunType,
@@ -586,11 +585,20 @@ class BaseComponent(lifecycle.Node):
         if not isinstance(configs, List):
             configs = [configs]
         for config in configs:
-            # Add new config
-            self._algorithms_config[config.__class__.__name__] = config.asdict()
+            # Only the fields actually set, not a full snapshot: a snapshot
+            # cannot be told apart from the class defaults, so applying it
+            # would write defaults over anything the component set for itself
+            self._algorithms_config[config.__class__.__name__] = explicit_fields(
+                config
+            )
 
     def _configure_algorithm(self, algo_config: BaseAttrs) -> BaseAttrs:
         """Configure an algorithm from the user defined configuration classes
+
+        Applied in increasing order of precedence: whatever the caller passed
+        in, then the configuration set on the component in code, then the
+        configuration file. The file wins, so a deployment can retune an
+        algorithm without editing the code that launched it.
 
         :param algo_config: Algorithm base configuration class
         :type algo_config: BaseAttrs
@@ -598,11 +606,11 @@ class BaseComponent(lifecycle.Node):
         :rtype: BaseAttrs
         """
         algo_config_name = algo_config.__class__.__name__
-        if algo_config_name in self.algorithms_config.keys():
-            config_dict = self.algorithms_config[algo_config_name]
+        if config_dict := self.algorithms_config.get(algo_config_name):
             algo_config.from_dict(config_dict)
-        elif self._config_file:
-            # configure directly from file if available
+        if self._config_file:
+            # Overlaid on top rather than instead: `from_file` only writes the
+            # keys the file actually declares
             algo_config.from_file(
                 self._config_file,
                 nested_root_name=f"{self.node_name}.{algo_config_name.partition('Config')[0]}",
@@ -1090,30 +1098,6 @@ class BaseComponent(lifecycle.Node):
         self.config.from_file(
             config_file, nested_root_name=self.node_name, get_common=True
         )
-        # Update algorithms config from file
-        if self.algorithms_config:
-            # Load the file
-            ext: str = os.path.splitext(config_file)[1].lower()
-
-            with open(config_file, "r", encoding="utf-8") as f:
-                if ext in [".yaml", ".yml"]:
-                    raw_config: Dict[str, Any] = yaml.safe_load(f)
-                elif ext == ".json":
-                    raw_config = json.load(f)
-                elif ext == ".toml":
-                    raw_config = toml.load(f)
-                else:
-                    raise ValueError(f"Unsupported config format: {ext}")
-
-            for algo_name, algo_conf in self._algorithms_config.items():
-                config = raw_config
-                for key in [self.node_name, algo_name.partition("Config")[0]]:
-                    config = config.get(key, {})
-                if not config:
-                    continue
-                for item_key in algo_conf.keys():
-                    if hasattr(config, item_key):
-                        algo_conf[item_key] = getattr(config, item_key)
 
     def create_tf_listener(self, tf_config: TFListenerConfig) -> TFListener:
         """

--- a/ros_sugar/core/component.py
+++ b/ros_sugar/core/component.py
@@ -304,10 +304,8 @@ class BaseComponent(lifecycle.Node):
 
     @property
     def _robot_plugin(self) -> Optional[Any]:
-        """The attached plugin that describes the robot, if any.
-
-        A recipe has at most one, so this stays a convenient shortcut into
-        `_plugins` for the code and tests that only care about the robot.
+        """Convenience method to get attached plugin that describes the robot,
+        if any. A recipe has at most one.
         """
         from ..robot.plugin import PluginRole
 
@@ -340,9 +338,8 @@ class BaseComponent(lifecycle.Node):
     def _plugin_for_topic(self, topic) -> Optional[Any]:
         """Resolve which attached plugin serves a topic.
 
-        ``use_plugin=True`` means the robot plugin, the only one a recipe could
-        address before several could be attached. A string names a plugin by
-        its id.
+        ``use_plugin=True`` means the robot plugin, one per recipe.
+        A string names a plugin by its id.
 
         :param topic: The topic to resolve
         :type topic: Topic
@@ -374,13 +371,13 @@ class BaseComponent(lifecycle.Node):
     def _use_robot_plugin(self):
         """Adapt the component's inputs/outputs to the robot plugin.
 
-        Only topics that opt in with ``use_plugin=True`` are rewired. The
-        plugin entry is resolved by ``topic.name`` first (so a recipe can
-        disambiguate sibling feedbacks of the same type by naming the topic
-        after the plugin's registry key) and falls back to a unique-type
-        match when no key matches. ``use_plugin=False`` (the default) means
-        the topic is internal, never claimed by the plugin even if a
-        matching type exists.
+        Only topics that opt in with ``use_plugin=True`` or
+        ``use_plugin=<plugin.id>`` are rewired. The plugin entry is resolved by
+        ``topic.name`` first (so a recipe can disambiguate sibling feedbacks
+        of the same type by naming the topic after the plugin's registry key) and
+        falls back to a unique-type match when no key matches.
+        ``use_plugin=False`` (the default) means the topic is internal,
+        never claimed by the plugin even if a matching type exists.
 
         ROS-topic transports re-use the native subscriber/publisher swap
         path; non-ROS transports are bound through the feedback bus or the
@@ -447,8 +444,8 @@ class BaseComponent(lifecycle.Node):
             try:
                 command = plugin.resolve_command(topic.name, topic.msg_type.__name__)
             except (TypeError, AmbiguousPluginEntryError) as e:
-                # See the feedback loop above: contain a mis-wired topic to
-                # itself, log loudly, fall back to an ordinary ROS publisher.
+                # Contains a mis-wired topic to itself, fall back to an ordinary
+                # ROS publisher.
                 self.get_logger().error(
                     f"Topic '{topic.name}' could not be bound to the robot "
                     f"plugin: {e} Falling back to an ordinary ROS publisher."
@@ -587,9 +584,8 @@ class BaseComponent(lifecycle.Node):
         if not isinstance(configs, List):
             configs = [configs]
         for config in configs:
-            # Only the fields actually set, not a full snapshot: a snapshot
-            # cannot be told apart from the class defaults, so applying it
-            # would write defaults over anything the component set for itself
+            # Only apply fields actually set, not a full snapshot. So fields set
+            # by the component itself are not written over
             self._algorithms_config[config.__class__.__name__] = explicit_fields(
                 config
             )
@@ -611,8 +607,7 @@ class BaseComponent(lifecycle.Node):
         if config_dict := self.algorithms_config.get(algo_config_name):
             algo_config.from_dict(config_dict)
         if self._config_file:
-            # Overlaid on top rather than instead: `from_file` only writes the
-            # keys the file actually declares
+            # only write the keys the file actually declares
             algo_config.from_file(
                 self._config_file,
                 nested_root_name=f"{self.node_name}.{algo_config_name.partition('Config')[0]}",
@@ -824,9 +819,8 @@ class BaseComponent(lifecycle.Node):
         self.init_variables()
 
         # Adapt the component's topics to whichever plugins are attached. A
-        # recipe with none never gets here -- the launcher fails at bringup --
-        # so this warns and keeps working for a standalone component, which is
-        # already running by the time it can tell.
+        # recipe with none should never get here as the launcher fails at bringup.
+        # So this warns and keeps working for a standalone component.
         if self._plugins:
             self._use_robot_plugin()
         else:
@@ -1339,9 +1333,8 @@ class BaseComponent(lifecycle.Node):
     def _subscribe_event_to_plugin_feedback(self, topic_name: str, topic_obj) -> None:
         """Drive an event from the robot plugin's feedback bus.
 
-        Events are otherwise fed by ROS subscriptions. For a topic the plugin
-        serves over its own transport there is no ROS traffic to subscribe to,
-        so the event is fed from the feedback bus instead.
+        For a topic the plugin serves over its own transport there is no ROS
+        traffic to subscribe to, so the event is fed from the feedback bus instead.
 
         :param topic_name: Name of the event topic
         :type topic_name: str
@@ -1350,9 +1343,8 @@ class BaseComponent(lifecycle.Node):
         """
         from ..robot.plugin import AmbiguousPluginEntryError
 
-        # Whichever plugin the topic names -- not the robot plugin. A sensor's
-        # event would otherwise resolve against the robot and fire on its
-        # telemetry, or find nothing at all in a sensor-only recipe.
+        # Use whichever plugin the topic names (not just the robot plugin). So
+        # sensor plugin topics are resolved
         plugin = self._plugin_for_topic(topic_obj)
         if plugin is None:
             self.get_logger().error(
@@ -1374,7 +1366,7 @@ class BaseComponent(lifecycle.Node):
                 "the robot plugin but no matching feedback was found."
             )
             return
-        # The plugin may decode to a different message type than the recipe
+        # NOTE: The plugin may decode to a different message type than the recipe
         # declared. Event conditions read attributes off the declared type, so
         # a mismatched stream would misfire rather than simply not fire.
         if feedback.msg_type is not topic_obj.msg_type:
@@ -1384,7 +1376,7 @@ class BaseComponent(lifecycle.Node):
                 f"'{topic_obj.msg_type.__name__}'."
             )
             return
-        # The event handler is the bus subscriber: decoded messages land in
+        # The event handler is the bus subscriber and decoded messages land in
         # __event_topic_callback exactly as they would from a ROS subscription
         handle = plugin.subscribe_feedback(
             feedback=feedback,
@@ -1724,8 +1716,7 @@ class BaseComponent(lifecycle.Node):
     def _plugins_json(self) -> str:
         """Getter of the serialized plugin specs + shared feedback-bus endpoint.
 
-        Used to carry every attached plugin across the multiprocess launch
-        boundary: each component subprocess rebuilds CLIENT plugins from these
+        Each component subprocess rebuilds CLIENT plugins from these
         specs and connects to the HOST feedback bus at ``bus_endpoint``. The
         specs carry each plugin's id, so the channels a subprocess subscribes
         to are the ones the hosts publish on.
@@ -1736,8 +1727,7 @@ class BaseComponent(lifecycle.Node):
         if not self._plugins:
             return "{}"
         # Every plugin shares one bus, so the first one carrying it answers for
-        # all of them -- looked up rather than taken from an arbitrary plugin,
-        # which may not have been given the bus yet
+        # all of them
         endpoint = None
         for plugin in self._plugins.values():
             if plugin.bus is not None:

--- a/ros_sugar/core/event.py
+++ b/ros_sugar/core/event.py
@@ -293,6 +293,7 @@ class Event:
                 topic_name=event_condition.name,
                 topic_msg_type=event_condition.msg_type.__name__,
                 topic_qos_config=event_condition.qos_profile.to_dict(),
+                topic_use_plugin=event_condition.use_plugin,
                 attribute_path=[],
                 operator_func=None,
                 ref_value=None,

--- a/ros_sugar/core/event.py
+++ b/ros_sugar/core/event.py
@@ -516,7 +516,7 @@ class Event:
                 time.sleep(self._keep_event_delay)
 
         except Exception as e:
-            logger.error(f"Error executing actions for event '{self.name}': {e}")
+            logger.error(f"Error executing actions for event '{self}': {e}")
         finally:
             # Reset the flag only after work + delay are done
             self.under_processing = False

--- a/ros_sugar/core/monitor.py
+++ b/ros_sugar/core/monitor.py
@@ -128,6 +128,9 @@ class Monitor(Node):
         # downstream API
         self._additional_internal_actions = {}
 
+        # Static transforms coming from mounted plugins, to be broadcast once the node is up.
+        self._static_transforms: Optional[List] = None
+
         # Emit exit all to the launcher
         self._emit_exit_to_launcher: Optional[Callable] = None
 
@@ -159,6 +162,33 @@ class Monitor(Node):
         self._pure_internal_events.append(event_id)
         self._additional_internal_actions[event_id] = action
 
+    def set_static_transforms(self, transforms) -> None:
+        """Static transforms to broadcast once this node is up.
+
+        The Monitor is constructed while the launch description is still being
+        built, before ``rclpy_init_node``, so it has no clock to stamp with and
+        no publisher to send on yet. They are held here and sent from
+        :meth:`activate`. ``/tf_static`` is latched, so arriving late costs
+        nothing -- subscribers that come up afterwards still receive them.
+
+        :param transforms: ``TransformStamped`` list, stamped on broadcast
+        """
+        self._static_transforms = list(transforms)
+
+    def _broadcast_static_transforms(self) -> None:
+        """Send the registered static transforms, stamped with the node clock."""
+        if not self._static_transforms:
+            return
+        from tf2_ros import StaticTransformBroadcaster
+
+        stamp = self.get_clock().now().to_msg()
+        for transform in self._static_transforms:
+            transform.header.stamp = stamp
+        # Held on the node: a broadcaster that goes out of scope takes its
+        # latched publisher, and the transform, with it
+        self._static_tf_broadcaster = StaticTransformBroadcaster(self)
+        self._static_tf_broadcaster.sendTransform(self._static_transforms)
+
     def rclpy_init_node(self, *args, **kwargs):
         """
         To init the node with rclpy and activate default services
@@ -171,6 +201,8 @@ class Monitor(Node):
 
     def activate(self):
         """Activate all subscribers/publishers/etc..."""
+        self._broadcast_static_transforms()
+
         # Poll the ROS graph for all components to activate and emit
         # activate_all once they are up, as a single atomic barrier.
         if self._components_to_activate_on_start:

--- a/ros_sugar/core/monitor.py
+++ b/ros_sugar/core/monitor.py
@@ -168,8 +168,8 @@ class Monitor(Node):
         The Monitor is constructed while the launch description is still being
         built, before ``rclpy_init_node``, so it has no clock to stamp with and
         no publisher to send on yet. They are held here and sent from
-        :meth:`activate`. ``/tf_static`` is latched, so arriving late costs
-        nothing -- subscribers that come up afterwards still receive them.
+        `activate`. ``/tf_static`` is latched, so subscribers that come up
+        afterwards still receive them.
 
         :param transforms: ``TransformStamped`` list, stamped on broadcast
         """

--- a/ros_sugar/io/callbacks.py
+++ b/ros_sugar/io/callbacks.py
@@ -1074,26 +1074,26 @@ class OccupancyGridCallback(GenericCallback):
             np.array(np.where(grid_data != 0), dtype=np.float32) + 0.5
         ) * self.msg.info.resolution
 
-        rotation_matrix = np.array([
-            [np.cos(origin_yaw), -np.sin(origin_yaw)],
-            [np.sin(origin_yaw), np.cos(origin_yaw)],
-        ])
-
-        transformed_coordinates = np.array([origin_x, origin_y]) + np.transpose(
-            rotation_matrix @ occupied_coordinates
+        # create a flaot32 rotation matrix
+        rotation_matrix = np.array(
+            [
+                [np.cos(origin_yaw), -np.sin(origin_yaw)],
+                [np.sin(origin_yaw), np.cos(origin_yaw)],
+            ],
+            dtype=np.float32,
         )
 
-        if not get_three_d:
-            return transformed_coordinates
+        # Build the output C-contiguous
+        num_points = occupied_coordinates.shape[1]
+        num_coordinates = 2 if not get_three_d else 3
+        coordinates = np.empty((num_points, num_coordinates), dtype=np.float32)
+        coordinates[:, :2] = (rotation_matrix @ occupied_coordinates).T
+        coordinates[:, 0] += origin_x
+        coordinates[:, 1] += origin_y
+        if get_three_d:
+            coordinates[:, 2] = self.__twoD_to_threeD_conversion_height
 
-        threeD_coordinates = np.pad(
-            transformed_coordinates,
-            ((0, 0), (0, 1)),
-            mode="constant",
-            constant_values=self.__twoD_to_threeD_conversion_height,
-        )
-
-        return threeD_coordinates
+        return coordinates
 
     def _get_ui_content(self, **_) -> Optional[Dict]:
         """Get UI content for an occupancy grid.

--- a/ros_sugar/io/callbacks.py
+++ b/ros_sugar/io/callbacks.py
@@ -1102,20 +1102,39 @@ class OccupancyGridCallback(GenericCallback):
         node_name: str = '',
         to_numpy: bool = True,
         twoD_to_threeD_conversion_height: float = 0.01,
+        transformation: Optional[TransformStamped] = None,
     ) -> None:
         super().__init__(input_topic, node_name)
         self.__to_numpy = to_numpy
         self.__twoD_to_threeD_conversion_height = twoD_to_threeD_conversion_height
+        self._transformation = transformation
 
     def _get_output(
         self,
         get_metadata: bool = False,
         get_obstacles: bool = True,
         get_three_d: bool = True,
-        **_,
+        transformation: Optional[TransformStamped] = None,
     ) -> Optional[Union[OccupancyGrid, np.ndarray, Dict]]:
         """
         Gets the OccupancyGrid message raw or as a numpy array
+
+        The grid's own `info.origin` is always applied to the obstacle
+        coordinates: cell indices mean nothing without it, and it is what
+        places them in the frame the message declares. `transformation` is
+        applied on top of that, to carry them into a different frame.
+
+        :param get_metadata: Return the grid metadata instead of its content.
+            The origin it reports is the message's own, never transformed
+        :type get_metadata: bool
+        :param get_obstacles: Return the occupied cells' coordinates rather
+            than the raw 2D grid. Only these are transformed
+        :type get_obstacles: bool
+        :param get_three_d: Pad the coordinates to 3D at a fixed height
+        :type get_three_d: bool
+        :param transformation: Transform to the goal frame, overriding the one
+            set on the callback
+        :type transformation: Optional[TransformStamped]
 
         :returns:   Map as an OccupancyGrid or numpy array
         :rtype:     Optional[Union[OccupancyGrid, np.ndarray]]
@@ -1178,6 +1197,25 @@ class OccupancyGridCallback(GenericCallback):
         coordinates[:, 1] += origin_y
         if get_three_d:
             coordinates[:, 2] = self.__twoD_to_threeD_conversion_height
+
+        transform = transformation or self.transformation
+        if transform and transform.header.frame_id != self.msg.header.frame_id:
+            trans = transform.transform.translation
+            quat = transform.transform.rotation
+            # A 2D request has already dropped z, so it can only carry the
+            # planar block of the rotation
+            goal_rotation = _rotation_matrix_from_quaternion([
+                quat.x,
+                quat.y,
+                quat.z,
+                quat.w,
+            ])[:num_coordinates, :num_coordinates]
+            # Written back in place so the output stays C-contiguous
+            coordinates[:] = coordinates @ goal_rotation.T
+            coordinates[:, 0] += trans.x
+            coordinates[:, 1] += trans.y
+            if get_three_d:
+                coordinates[:, 2] += trans.z
 
         return coordinates
 

--- a/ros_sugar/io/callbacks.py
+++ b/ros_sugar/io/callbacks.py
@@ -12,7 +12,7 @@ import numpy as np
 from geometry_msgs.msg import Pose
 from jinja2.environment import Template
 from nav_msgs.msg import OccupancyGrid, Odometry
-from sensor_msgs.msg import Imu, JointState, LaserScan, NavSatFix
+from sensor_msgs.msg import Imu, JointState, LaserScan, NavSatFix, Range
 from std_msgs.msg import Header
 from rclpy.logging import get_logger
 from rclpy.subscription import Subscription
@@ -710,6 +710,35 @@ class NavSatFixCallback(GenericCallback):
         """
         output = self.get_output()
         return {"data": output.tolist() if output is not None else None}
+
+
+class RangeCallback(GenericCallback):
+    """
+    sensor_msgs/Range callback.
+
+    Returns the measured distance in metres (the message's ``range`` field).
+    """
+
+    def _get_output(self, **_) -> Optional[float]:
+        """
+        Gets the measured range as a float.
+
+        :returns:   distance in metres
+        :rtype:     Optional[float]
+        """
+        if not self.msg:
+            return None
+
+        return float(self.msg.range)
+
+    def _get_ui_content(self, **_) -> Dict:
+        """
+        Utility method to get UI compatible content.
+        To be used with external callbacks in UI Node
+        :returns:   Topic content
+        :rtype:     Any
+        """
+        return {"data": self.get_output()}
 
 
 class PointStampedCallback(GenericCallback):

--- a/ros_sugar/io/callbacks.py
+++ b/ros_sugar/io/callbacks.py
@@ -9,9 +9,9 @@ import base64
 
 import cv2
 import numpy as np
-from geometry_msgs.msg import Pose
+from geometry_msgs.msg import Pose, PoseStamped
 from jinja2.environment import Template
-from nav_msgs.msg import OccupancyGrid, Odometry
+from nav_msgs.msg import OccupancyGrid, Odometry, Path
 from sensor_msgs.msg import Imu, JointState, LaserScan, NavSatFix, Range
 from std_msgs.msg import Header
 from rclpy.logging import get_logger
@@ -23,6 +23,8 @@ from .datatypes import (
     LaserScanData,
     PointCloudData,
     _get_laserscan_transformed_polar_coordinates,
+    _quaternion_multiply,
+    _rotation_matrix_from_quaternion,
 )
 
 
@@ -954,15 +956,99 @@ class PoseArrayCallback(GenericCallback):
 
 class PathCallback(GenericCallback):
     """
-    Ros PoseStamped Callback Handler to get the robot state in 2D
+    Ros Path Callback Handler to get a navigation path
     """
 
     def __init__(
         self,
         input_topic,
-        node_name: str = '',
+        node_name: str = "",
+        transformation: Optional[TransformStamped] = None,
     ) -> None:
         super().__init__(input_topic, node_name)
+        self._transformation = transformation
+
+    def _get_output(
+        self,
+        transformation: Optional[TransformStamped] = None,
+    ) -> Optional[Path]:
+        """
+        Gets the path by applying the transformation if given.
+
+        :param transformation: Transform to the goal frame, overriding the one
+            set on the callback
+        :type transformation: Optional[TransformStamped]
+
+        :returns:   Topic content
+        :rtype:     Optional[Path]
+        """
+        if not self.msg:
+            return None
+        transform = transformation or self.transformation
+        if not transform or transform.header.frame_id == self.msg.header.frame_id:
+            # Nothing asked for, or the path is already in the goal frame and
+            # rebuilding every pose would be an expensive no-op
+            return self.msg
+        return self._transform(self.msg, transform)
+
+    def _transform(self, msg: Path, transform: TransformStamped) -> Path:
+        """
+        Applies a transform to every pose of a given Path message
+
+        A path can carry hundreds of poses, so the positions are transformed
+        as one array rather than pose by pose. Orientations are composed with
+        the transform's rotation so headings stay consistent with positions.
+
+        :param msg: Path message in source frame
+        :type msg: Path
+        :param transform: Path transform from current to goal frame
+        :type transform: TransformStamped
+
+        :return: Path in goal frame
+        :rtype: Path
+        """
+        trans = transform.transform.translation
+        quat = transform.transform.rotation
+        rotation = [quat.x, quat.y, quat.z, quat.w]
+
+        positions = (
+            np.array(
+                [
+                    [pose.pose.position.x, pose.pose.position.y, pose.pose.position.z]
+                    for pose in msg.poses
+                ],
+                dtype=np.float32,
+            ).reshape(-1, 3)
+            @ _rotation_matrix_from_quaternion(rotation).T
+            + np.array([trans.x, trans.y, trans.z], dtype=np.float32)
+        )
+
+        transformed = Path()
+        transformed.header.stamp = msg.header.stamp
+        transformed.header.frame_id = transform.header.frame_id
+        for pose_in, position in zip(msg.poses, positions):
+            pose_out = PoseStamped()
+            pose_out.header.stamp = pose_in.header.stamp
+            pose_out.header.frame_id = transform.header.frame_id
+            pose_out.pose.position.x = float(position[0])
+            pose_out.pose.position.y = float(position[1])
+            pose_out.pose.position.z = float(position[2])
+            orientation = _quaternion_multiply(
+                rotation,
+                [
+                    pose_in.pose.orientation.x,
+                    pose_in.pose.orientation.y,
+                    pose_in.pose.orientation.z,
+                    pose_in.pose.orientation.w,
+                ],
+            )
+            pose_out.pose.orientation.x = float(orientation[0])
+            pose_out.pose.orientation.y = float(orientation[1])
+            pose_out.pose.orientation.z = float(orientation[2])
+            pose_out.pose.orientation.w = float(orientation[3])
+            transformed.poses.append(pose_out)
+
+        return transformed
 
     def _get_ui_content(self, **_) -> Dict:
         """
@@ -1134,10 +1220,13 @@ class LaserScanCallback(GenericCallback):
     def _get_output(
         self,
         transformation: Optional[TransformStamped] = None,
-        **_,
     ) -> Optional[LaserScanData]:
         """
         Gets the laserscan data by applying the transformation if given.
+
+        :param transformation: Transform to the goal frame, overriding the one
+            set on the callback
+        :type transformation: Optional[TransformStamped]
 
         :returns:   Topic content
         :rtype:     Optional[LaserScanData]
@@ -1243,21 +1332,89 @@ class PointCloudCallback(GenericCallback):
         self,
         input_topic,
         node_name: str = "",
+        transformation: Optional[TransformStamped] = None,
     ) -> None:
         super().__init__(input_topic, node_name)
+        self._transformation = transformation
 
-    def _get_output(self, **_) -> Optional[PointCloudData]:
+    def _get_output(
+        self,
+        transformation: Optional[TransformStamped] = None,
+        min_z: Optional[float] = None,
+        max_z: Optional[float] = None,
+        discard_underground: bool = False,
+        get_2d: bool = False,
+    ) -> Optional[PointCloudData]:
         """Gets the PointCloud2 message data as a PointCloudData container
         with the raw buffer, layout metadata and lazy cartesian decoding.
+
+
+        :param transformation: Transform to the goal frame, overriding the one
+            set on the callback
+        :type transformation: Optional[TransformStamped]
+        :param min_z: Drop points below this height, in the goal frame
+        :type min_z: Optional[float]
+        :param max_z: Drop points above this height, in the goal frame
+        :type max_z: Optional[float]
+        :param discard_underground: Drop points below the ground plane, which
+            the transform's z translation locates
+        :type discard_underground: bool
+        :param get_2d: Flatten the surviving points onto z = 0
+        :type get_2d: bool
 
         :return: Return PointCloudData
         :rtype: Optional[PointCloudData]
         """
-        if not self.msg:
+        pc = self._container()
+        if pc is None:
             return None
 
-        # Empty clouds
-        if self.msg.width == 0 or self.msg.height == 0:
+        transform = transformation or self.transformation
+        if not (
+            transform
+            or min_z is not None
+            or max_z is not None
+            or discard_underground
+            or get_2d
+        ):
+            # Nothing asked for: hand back the raw buffer, decoding nothing
+            return pc
+
+        if discard_underground and transform is None:
+            get_logger(self.node_name or "PointCloudCallback").warning(
+                f"'discard_underground' was requested for topic "
+                f"'{self.input_topic.name}' but no transform to the robot body "
+                "is set, so the ground plane cannot be located. Ignoring it. "
+                "Call 'transform_input_to' on the component to provide one.",
+                once=True,
+            )
+
+        translation = rotation = goal_frame = None
+        if transform:
+            trans = transform.transform.translation
+            quat = transform.transform.rotation
+            translation = [trans.x, trans.y, trans.z]
+            rotation = [quat.x, quat.y, quat.z, quat.w]
+            goal_frame = transform.header.frame_id
+
+        return pc.filtered(
+            translation=translation,
+            rotation=rotation,
+            frame_id=goal_frame,
+            min_z=min_z,
+            max_z=max_z,
+            discard_underground=discard_underground,
+            get_2d=get_2d,
+        )
+
+    def _container(self) -> Optional[PointCloudData]:
+        """Wrap the current message's raw buffer and layout, without decoding.
+
+        :return: The cloud as received, or None if it is empty or has no
+            x/y/z fields
+        :rtype: Optional[PointCloudData]
+        """
+        if not self.msg or self.msg.width == 0 or self.msg.height == 0:
             return None
 
         pc = PointCloudData(

--- a/ros_sugar/io/callbacks.py
+++ b/ros_sugar/io/callbacks.py
@@ -1179,7 +1179,7 @@ class OccupancyGridCallback(GenericCallback):
             np.array(np.where(grid_data != 0), dtype=np.float32) + 0.5
         ) * self.msg.info.resolution
 
-        # create a flaot32 rotation matrix
+        # create a float32 rotation matrix
         rotation_matrix = np.array(
             [
                 [np.cos(origin_yaw), -np.sin(origin_yaw)],
@@ -1203,7 +1203,9 @@ class OccupancyGridCallback(GenericCallback):
             trans = transform.transform.translation
             quat = transform.transform.rotation
             # A 2D request has already dropped z, so it can only carry the
-            # planar block of the rotation
+            # planar block of the rotation. That block is the whole rotation
+            # only for a yaw-only transform; roll or pitch would move points
+            # out of the plane, which a 2D map cannot represent anyway
             goal_rotation = _rotation_matrix_from_quaternion([
                 quat.x,
                 quat.y,

--- a/ros_sugar/io/datatypes.py
+++ b/ros_sugar/io/datatypes.py
@@ -1,7 +1,7 @@
 """Data containers for ROS message payloads processed by callbacks."""
 
 import math
-from typing import List, Optional, Union
+from typing import List, Optional, Sequence, Union
 
 import numpy as np
 from attrs import Factory, define, field
@@ -21,6 +21,54 @@ _POINTFIELD_NP_FORMATS = {
     PointField.FLOAT32: "f4",
     PointField.FLOAT64: "f8",
 }
+
+
+def _rotation_matrix_from_quaternion(quaternion: Sequence[float]) -> np.ndarray:
+    """Rotation matrix for a ROS quaternion.
+
+    :param quaternion: Quaternion as [x, y, z, w]
+    :type quaternion: Sequence[float]
+    :return: 3x3 rotation matrix
+    :rtype: np.ndarray
+    """
+    x, y, z, w = (float(value) for value in quaternion)
+    norm = math.sqrt(x * x + y * y + z * z + w * w)
+    if norm == 0.0:
+        return np.eye(3, dtype=np.float32)
+    x, y, z, w = x / norm, y / norm, z / norm, w / norm
+    return np.array(
+        [
+            [1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+            [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+            [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)],
+        ],
+        dtype=np.float32,
+    )
+
+
+def _quaternion_multiply(
+    quaternion_1: Sequence[float], quaternion_2: Sequence[float]
+) -> np.ndarray:
+    """Compose two ROS quaternions, applying the first after the second.
+
+    :param quaternion_1: Left hand quaternion as [x, y, z, w]
+    :type quaternion_1: Sequence[float]
+    :param quaternion_2: Right hand quaternion as [x, y, z, w]
+    :type quaternion_2: Sequence[float]
+    :return: Composed quaternion as [x, y, z, w]
+    :rtype: np.ndarray
+    """
+    x1, y1, z1, w1 = (float(value) for value in quaternion_1)
+    x2, y2, z2, w2 = (float(value) for value in quaternion_2)
+    return np.array(
+        [
+            w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+            w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+            w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+            w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+        ],
+        dtype=np.float32,
+    )
 
 
 @define
@@ -63,6 +111,49 @@ class PointCloudData(BaseAttrs):
         default=None, init=False, repr=False, eq=False
     )
 
+    def _point_dtype(self) -> np.dtype:
+        """Structured dtype addressing the x/y/z fields inside a point record."""
+        np_format = _POINTFIELD_NP_FORMATS.get(self.x_field_datatype, "f4")
+        endianness = ">" if self.is_bigendian else "<"
+        return np.dtype(
+            {
+                "names": ["x", "y", "z"],
+                "formats": [endianness + np_format] * 3,
+                "offsets": [self.x_offset, self.y_offset, self.z_offset],
+                "itemsize": self.point_step,
+            }
+        )
+
+    def _unpadded(self) -> np.ndarray:
+        """The raw buffer with row padding removed, so records sit contiguously."""
+        raw = self.data
+        row_bytes = self.width * self.point_step
+        if self.row_step != row_bytes and self.height > 1:
+            raw = np.ascontiguousarray(
+                raw[: self.height * self.row_step].reshape(self.height, self.row_step)[
+                    :, :row_bytes
+                ]
+            ).reshape(-1)
+        return raw
+
+    def _decode_all(self) -> Optional[np.ndarray]:
+        """Every point in the buffer, in order, non-finite ones included.
+
+        Row ``i`` is point record ``i``, which is what lets a mask computed
+        from these coordinates be applied back to the raw buffer.
+
+        :return: Nx3 float32 array, or None if the cloud has no x/y/z fields
+        :rtype: Optional[np.ndarray]
+        """
+        if self.x_offset is None or self.y_offset is None or self.z_offset is None:
+            return None
+        points = np.frombuffer(
+            self._unpadded(), dtype=self._point_dtype(), count=self.height * self.width
+        )
+        return np.column_stack((points["x"], points["y"], points["z"])).astype(
+            np.float32, copy=False
+        )
+
     @property
     def xyz(self) -> Optional[np.ndarray]:
         """Cartesian points decoded from the raw buffer, lazily and cached.
@@ -75,36 +166,99 @@ class PointCloudData(BaseAttrs):
         """
         if self._xyz_cache is not None:
             return self._xyz_cache
-        if self.x_offset is None or self.y_offset is None or self.z_offset is None:
+        xyz = self._decode_all()
+        if xyz is None:
             return None
-
-        np_format = _POINTFIELD_NP_FORMATS.get(self.x_field_datatype, "f4")
-        endianness = ">" if self.is_bigendian else "<"
-        point_dtype = np.dtype(
-            {
-                "names": ["x", "y", "z"],
-                "formats": [endianness + np_format] * 3,
-                "offsets": [self.x_offset, self.y_offset, self.z_offset],
-                "itemsize": self.point_step,
-            }
-        )
-
-        raw = self.data
-        row_bytes = self.width * self.point_step
-        if self.row_step != row_bytes and self.height > 1:
-            # drop row padding to get a contiguous array of points
-            raw = np.ascontiguousarray(
-                raw[: self.height * self.row_step].reshape(self.height, self.row_step)[
-                    :, :row_bytes
-                ]
-            ).reshape(-1)
-
-        points = np.frombuffer(raw, dtype=point_dtype, count=self.height * self.width)
-        xyz = np.column_stack((points["x"], points["y"], points["z"])).astype(
-            np.float32, copy=False
-        )
         self._xyz_cache = xyz[np.isfinite(xyz).all(axis=1)]
         return self._xyz_cache
+
+    def filtered(
+        self,
+        translation: Optional[Sequence[float]] = None,
+        rotation: Optional[Sequence[float]] = None,
+        frame_id: Optional[str] = None,
+        min_z: Optional[float] = None,
+        max_z: Optional[float] = None,
+        discard_underground: bool = False,
+        get_2d: bool = False,
+    ) -> Optional["PointCloudData"]:
+        """A new cloud with the transform and the height filters applied.
+
+        The raw buffer is rebuilt rather than only the decoded `xyz`, because
+        consumers that read `data` directly -- collision checking, mapping --
+        would otherwise still be handed sensor-frame, unfiltered points while
+        believing they had been transformed.
+
+        Whole point records are kept or dropped and only x/y/z are rewritten,
+        so every other field (intensity, rgb, ...) survives intact.
+
+        :param translation: Sensor-to-target translation [x, y, z]
+        :param rotation: Sensor-to-target rotation quaternion [x, y, z, w]
+        :param frame_id: Frame the points end up in once transformed
+        :param min_z: Drop points below this height, in the target frame
+        :param max_z: Drop points above this height, in the target frame
+        :param discard_underground: Drop points below the ground plane. The
+            transform's z translation is the sensor's height above the target
+            frame, so the ground sits at z = 0 once transformed. Without a
+            transform the ground cannot be located and this is ignored.
+        :param get_2d: Flatten the surviving points onto z = 0
+        :return: A new container, or None if no point survives
+        :rtype: Optional[PointCloudData]
+        """
+        xyz = self._decode_all()
+        if xyz is None:
+            return None
+
+        # Organized clouds pad with NaN/inf; those are never real returns
+        keep = np.isfinite(xyz).all(axis=1)
+
+        if rotation is not None:
+            xyz = xyz @ _rotation_matrix_from_quaternion(rotation).T
+        if translation is not None:
+            xyz = xyz + np.asarray(translation, dtype=np.float32)
+
+        if min_z is not None:
+            keep &= xyz[:, 2] >= min_z
+        if max_z is not None:
+            keep &= xyz[:, 2] <= max_z
+        if discard_underground and translation is not None:
+            keep &= xyz[:, 2] >= 0.0
+
+        # After the height filters, so the band is judged on the real heights
+        if get_2d:
+            xyz[:, 2] = 0.0
+
+        n_kept = int(np.count_nonzero(keep))
+        if not n_kept:
+            return None
+
+        records = self._unpadded()[: self.height * self.width * self.point_step]
+        kept = np.ascontiguousarray(
+            records.reshape(-1, self.point_step)[keep]
+        ).reshape(-1)
+
+        # Write the transformed coordinates back into the surviving records
+        struct = kept.view(self._point_dtype())
+        struct["x"] = xyz[keep, 0]
+        struct["y"] = xyz[keep, 1]
+        struct["z"] = xyz[keep, 2]
+
+        out = PointCloudData(
+            data=kept,
+            point_step=self.point_step,
+            row_step=n_kept * self.point_step,
+            height=1,  # filtering cannot preserve the row layout
+            width=n_kept,
+            x_offset=self.x_offset,
+            y_offset=self.y_offset,
+            z_offset=self.z_offset,
+            x_field_datatype=self.x_field_datatype,
+            is_bigendian=self.is_bigendian,
+            frame_id=frame_id or self.frame_id,
+            timestamp=self.timestamp,
+        )
+        out._xyz_cache = xyz[keep]
+        return out
 
 
 def _convert_to_0_2pi(value: Union[float, np.ndarray]) -> Union[float, np.ndarray]:

--- a/ros_sugar/io/datatypes.py
+++ b/ros_sugar/io/datatypes.py
@@ -290,10 +290,10 @@ def _get_polar_transformation_vector(
     :return: Polar transformation [radius, angle]
     :rtype: list
     """
-    # Plain floats, not numpy scalars: numpy treats its own scalars as strong
-    # types, so a np.float64 here would promote the float32 ranges it is
-    # combined with to float64 and cost the zero-copy path downstream. A
-    # Python float is weak and leaves the array dtype alone.
+    # NOTE: numpy treats its own scalars as strong types, so a np.float64 here
+    # would promote the float32 ranges it is combined with to float64 and cost
+    # the zero-copy path downstream. A Python float is weak and leaves the array
+    # dtype alone.
     r_tr = float(np.sqrt(translation_x**2 + translation_y**2))
     if r_tr > 0:
         ang_tr = float(np.arccos(translation_x / r_tr))

--- a/ros_sugar/io/datatypes.py
+++ b/ros_sugar/io/datatypes.py
@@ -290,9 +290,13 @@ def _get_polar_transformation_vector(
     :return: Polar transformation [radius, angle]
     :rtype: list
     """
-    r_tr = np.sqrt(translation_x**2 + translation_y**2)
+    # Plain floats, not numpy scalars: numpy treats its own scalars as strong
+    # types, so a np.float64 here would promote the float32 ranges it is
+    # combined with to float64 and cost the zero-copy path downstream. A
+    # Python float is weak and leaves the array dtype alone.
+    r_tr = float(np.sqrt(translation_x**2 + translation_y**2))
     if r_tr > 0:
-        ang_tr = np.arccos(translation_x / r_tr)
+        ang_tr = float(np.arccos(translation_x / r_tr))
         return [r_tr, ang_tr]
     return [0.0, 0.0]
 

--- a/ros_sugar/io/datatypes.py
+++ b/ros_sugar/io/datatypes.py
@@ -401,8 +401,8 @@ class LaserScanData(BaseAttrs):
             )
 
         if self.ranges.size == 0:
-            # default to max range
-            self.ranges = np.full(self.angles.size, self.range_max)
+            # default to max range; float32 is a downstream zero-copy fast path
+            self.ranges = np.full(self.angles.size, self.range_max, dtype=np.float32)
 
         if self.angles.size != self.ranges.size:
             minimum_size = min(self.angles.size, self.ranges.size)

--- a/ros_sugar/io/datatypes.py
+++ b/ros_sugar/io/datatypes.py
@@ -238,10 +238,12 @@ class LaserScanData(BaseAttrs):
 
     def __attrs_post_init__(self):
         if self.angles.size == 0:
+            # float32 is a downstream zero-copy fast path
             self.angles = np.arange(
                 self.angle_min,
                 self.angle_max + self.angle_increment,
                 self.angle_increment,
+                dtype=np.float32,
             )
 
         if self.ranges.size == 0:
@@ -336,8 +338,8 @@ def _get_laserscan_transformed_polar_coordinates(
     :rtype: LaserScanData
     """
     angles: np.ndarray = np.arange(
-        angle_min, angle_max + angle_increment, angle_increment
-    )  # create list of angles
+        angle_min, angle_max + angle_increment, angle_increment, dtype=np.float32
+    )  # create list of angles, float32 to keep transformed ranges float32
 
     if len(angles) < len(laser_scan_ranges):
         raise ValueError(

--- a/ros_sugar/io/datatypes.py
+++ b/ros_sugar/io/datatypes.py
@@ -184,10 +184,8 @@ class PointCloudData(BaseAttrs):
     ) -> Optional["PointCloudData"]:
         """A new cloud with the transform and the height filters applied.
 
-        The raw buffer is rebuilt rather than only the decoded `xyz`, because
-        consumers that read `data` directly -- collision checking, mapping --
-        would otherwise still be handed sensor-frame, unfiltered points while
-        believing they had been transformed.
+        Rebuilds raw buffer rather than only the decoded `xyz`, for downstream
+        consumers of it.
 
         Whole point records are kept or dropped and only x/y/z are rewritten,
         so every other field (intensity, rgb, ...) survives intact.

--- a/ros_sugar/io/supported_types.py
+++ b/ros_sugar/io/supported_types.py
@@ -27,6 +27,7 @@ from sensor_msgs.msg import JointState as ROSJointState
 from sensor_msgs.msg import LaserScan as ROSLaserScan
 from sensor_msgs.msg import NavSatFix as ROSNavSatFix
 from sensor_msgs.msg import PointCloud2 as ROSPointCloud2
+from sensor_msgs.msg import Range as ROSRange
 
 # STD_MSGS SUPPORTED ROS TYPES
 from std_msgs.msg import ByteMultiArray
@@ -573,6 +574,13 @@ class NavSatFix(SupportedType):
 
     _ros_type = ROSNavSatFix
     callback = callbacks.NavSatFixCallback
+
+
+class Range(SupportedType):
+    """Range"""
+
+    _ros_type = ROSRange
+    callback = callbacks.RangeCallback
 
 
 class Path(SupportedType):

--- a/ros_sugar/io/topic.py
+++ b/ros_sugar/io/topic.py
@@ -118,6 +118,20 @@ def _make_qos_config(qos_profile: Union[Dict, QoSConfig]) -> QoSConfig:
     return QoSConfig(**qos_profile)
 
 
+def _validate_use_plugin(_, __, value) -> None:
+    """Reject an empty plugin id.
+
+    ``use_plugin`` is tested for truthiness throughout the component, so an
+    empty string would silently mean "not plugin-backed" rather than failing.
+    """
+    if isinstance(value, str) and not isinstance(value, bool) and not value:
+        raise ValueError(
+            "Topic 'use_plugin' cannot be an empty string. Pass the id of an "
+            "attached plugin (e.g. use_plugin=my_camera.id), True for the "
+            "robot plugin, or False."
+        )
+
+
 @define(kw_only=True)
 class Topic(BaseAttrs, Generic[MsgT]):
     """
@@ -157,7 +171,9 @@ class Topic(BaseAttrs, Generic[MsgT]):
         default=Factory(QoSConfig), converter=_make_qos_config
     )
     data_timeout: float = field(default=1.0, validator=base_validators.gt(0.0))
-    use_plugin: bool = field(default=False)
+    use_plugin: Union[bool, str] = field(
+        default=False, validator=_validate_use_plugin
+    )
     ros_msg_type: Type[MsgT] = field(init=False)
     additional_types: List[Type[supported_types.SupportedType]] = field(
         default=Factory(list)

--- a/ros_sugar/launch/executable.py
+++ b/ros_sugar/launch/executable.py
@@ -59,11 +59,6 @@ def _parse_args() -> Tuple[argparse.Namespace, List[str]]:
         help="Additional type modules from derived packages",
     )
     parser.add_argument(
-        "--robot_plugin",
-        type=str,
-        help="Serialized robot plugin spec and feedback-bus endpoint (legacy)",
-    )
-    parser.add_argument(
         "--plugins",
         type=str,
         help="Serialized plugin specs and shared feedback-bus endpoint",
@@ -233,12 +228,9 @@ def setup_component(
         component._external_processors_json = args.external_processors
 
     # Rebuild plugins as CLIENTs and connect them to the HOST feedback bus
-    # running in the launcher process. --robot_plugin is the older single-plugin
-    # form, still accepted so a mixed-version workspace keeps working.
-    if getattr(args, "plugins", None):
+    # running in the launcher process
+    if args.plugins:
         component._plugins_json = args.plugins
-    elif args.robot_plugin:
-        component._robot_plugin_json = args.robot_plugin
 
     return component
 

--- a/ros_sugar/launch/executable.py
+++ b/ros_sugar/launch/executable.py
@@ -61,7 +61,12 @@ def _parse_args() -> Tuple[argparse.Namespace, List[str]]:
     parser.add_argument(
         "--robot_plugin",
         type=str,
-        help="Serialized robot plugin spec and feedback-bus endpoint",
+        help="Serialized robot plugin spec and feedback-bus endpoint (legacy)",
+    )
+    parser.add_argument(
+        "--plugins",
+        type=str,
+        help="Serialized plugin specs and shared feedback-bus endpoint",
     )
     return parser.parse_known_args()
 
@@ -227,9 +232,12 @@ def setup_component(
     if args.external_processors:
         component._external_processors_json = args.external_processors
 
-    # Rebuild the robot plugin as a CLIENT and connect it to the HOST
-    # feedback bus running in the launcher process
-    if args.robot_plugin:
+    # Rebuild plugins as CLIENTs and connect them to the HOST feedback bus
+    # running in the launcher process. --robot_plugin is the older single-plugin
+    # form, still accepted so a mixed-version workspace keeps working.
+    if getattr(args, "plugins", None):
+        component._plugins_json = args.plugins
+    elif args.robot_plugin:
         component._robot_plugin_json = args.robot_plugin
 
     return component

--- a/ros_sugar/launch/launcher.py
+++ b/ros_sugar/launch/launcher.py
@@ -712,9 +712,9 @@ class Launcher:
             named = ", ".join(f"'{frame}'" for frame in sorted(replaced))
             logger.warning(
                 f"The recipe set the robot body frame to {named}, but plugin "
-                f"'{plugin_name}' reports '{base_frame}'. Using the plugin frame name."
-                "To publish under a different name, set it on the plugin "
-                "itself before bringup."
+                f"'{plugin_name}' reports '{base_frame}'. Using the plugin's "
+                "frame name. To publish under a different name, set it on the "
+                "plugin itself before bringup."
             )
         else:
             logger.info(

--- a/ros_sugar/launch/launcher.py
+++ b/ros_sugar/launch/launcher.py
@@ -582,23 +582,17 @@ class Launcher:
             self._mounts.append(mount)
 
     def _publish_mounts(self) -> None:
-        """Broadcast every declared mount as a static transform.
-
-        Published in-process from the Monitor node, which is a live node for
-        the whole run, rather than as one ``static_transform_publisher`` per
-        mount: those would land under the recipe's namespace (the launch
-        description pushes one), and their positional CLI form is deprecated.
+        """Hand every declared mount to the Monitor as a static transform to be published to /tf_static.
         """
         if not self._mounts:
             return
-        from tf2_ros import StaticTransformBroadcaster
         from geometry_msgs.msg import TransformStamped
+
         from ..robot.mount import quaternion_from_euler
 
         transforms = []
         for mount in self._mounts:
             transform = TransformStamped()
-            transform.header.stamp = self.monitor_node.get_clock().now().to_msg()
             transform.header.frame_id = mount.parent_frame
             transform.child_frame_id = mount.child_frame
             (
@@ -618,10 +612,7 @@ class Launcher:
                 f"'{transform.header.frame_id}'"
             )
 
-        # Held on the launcher: a StaticTransformBroadcaster that goes out of
-        # scope takes its latched publisher with it
-        self._static_tf_broadcaster = StaticTransformBroadcaster(self.monitor_node)
-        self._static_tf_broadcaster.sendTransform(transforms)
+        self.monitor_node.set_static_transforms(transforms)
 
     def _validate_plugin_references(self) -> None:
         """Check every topic's ``use_plugin`` against the attached plugins.

--- a/ros_sugar/launch/launcher.py
+++ b/ros_sugar/launch/launcher.py
@@ -65,7 +65,11 @@ from ..base_clients import ServiceClientConfig, ActionClientConfig
 from ..utils import InvalidAction, action_handler, has_decorator, SomeEntitiesType
 from ..ui_node import UINode, UINodeConfig
 from ..robot import (
+    FeedbackBus,
+    Mount,
     InProcessFeedbackBus,
+    Plugin,
+    PluginRole,
     RobotPlugin,
     RobotPluginHost,
     SocketFeedbackBus,
@@ -171,8 +175,13 @@ class Launcher:
         self._config_file: Optional[str] = config_file
         self._launch_group = []
         self._enable_ui = False
-        self._robot_plugin = robot_plugin
-        self._robot_plugin_host: Optional[RobotPluginHost] = None
+        self._plugins: Dict[str, Plugin] = {}
+        self._plugin_hosts: List[RobotPluginHost] = []
+        self._mounts: List[Mount] = []
+        if robot_plugin is not None:
+            self.add_plugin(robot_plugin)
+        # Shared by every attached plugin host, so the launcher owns it
+        self._plugin_bus: Optional[FeedbackBus] = None
         # Tracks whether the recipe explicitly set robot config. If not config
         # is pulled from a plugin. In case both present, recipe wins.
         self._robot_explicitly_set: bool = False
@@ -306,11 +315,9 @@ class Launcher:
 
         # Configure components from config_file
         for component in components:
-            # Hand each component the robot plugin instance.
-            # NOTE: In multithreaded launch the component thread uses this HOST
-            # instance directly; in multiprocess launch it is only used to
-            # serialize the plugin spec into the component's launch args
-            component._robot_plugin = self._robot_plugin
+            # NOTE: plugins are handed out at bringup by `_distribute_plugins`,
+            # not here, so that a recipe may call add_pkg and add_plugin in
+            # either order and still have every component receive every plugin
             if rclpy_log_level:
                 self._rclpy_log_level[component.node_name] = rclpy_log_level
             if ros_log_level:
@@ -513,6 +520,155 @@ class Launcher:
                     logger.error(
                         f"Cannot set component {component.node_name} 'robot' configuration parameter of type '{type(component.config.robot)}' to provided value of type '{type(robot_config)}'. Skipping setting robot configuration for '{component.node_name}'"
                     )
+
+    @property
+    def _robot_plugin(self) -> Optional[RobotPlugin]:
+        """The attached plugin describing the robot, if any."""
+        for plugin in self._plugins.values():
+            if plugin.role is PluginRole.ROBOT:
+                return plugin
+        return None
+
+    @_robot_plugin.setter
+    def _robot_plugin(self, plugin: Optional[RobotPlugin]) -> None:
+        """Attach (or clear) the robot plugin, leaving other plugins alone."""
+        for key, attached in list(self._plugins.items()):
+            if attached.role is PluginRole.ROBOT:
+                del self._plugins[key]
+        if plugin is not None:
+            self.add_plugin(plugin)
+
+    def add_plugin(self, plugin: Plugin, mount: Optional[Mount] = None) -> None:
+        """Attach a plugin to the recipe.
+
+        Every component in the recipe is given every attached plugin, whatever
+        order ``add_pkg`` and ``add_plugin`` are called in.
+
+        :param plugin: The plugin to attach. Its ``id`` -- set with ``id=`` at
+            construction, or derived from its name -- is how a topic addresses
+            it and how its channels are namespaced.
+        :type plugin: Plugin
+
+        :param mount: Where this sensor sits, when nothing else publishes its
+            frame into TF. Omit it if a URDF, a ``robot_state_publisher`` or
+            the sensor's own driver already does.
+        :type mount: Optional[Mount]
+
+        :raises ValueError: If a second robot plugin is attached, or if the id
+            is already taken by another plugin.
+        """
+        plugin_id = plugin.id
+
+        if plugin.role is PluginRole.ROBOT and (existing := self._robot_plugin):
+            raise ValueError(
+                f"Cannot attach robot plugin '{plugin.metadata.name}': a recipe "
+                f"describes one robot and '{existing.metadata.name}' is already "
+                "attached."
+            )
+        if plugin_id in self._plugins:
+            raise ValueError(
+                f"Cannot attach plugin as '{plugin_id}': that id is already taken "
+                f"by '{self._plugins[plugin_id].metadata.name}'. Give one of them "
+                "a distinct id at construction, e.g. "
+                f"{type(plugin).__name__}(id='front_cam')."
+            )
+        # Identity has to be final now, not at bringup: events are built from
+        # plugins in the recipe, and their topic names are frozen before plugin
+        # setup runs
+        plugin._bind_identity()
+        self._plugins[plugin_id] = plugin
+        if mount is not None:
+            mount.child = plugin
+            self._mounts.append(mount)
+
+    def _publish_mounts(self) -> None:
+        """Broadcast every declared mount as a static transform.
+
+        Published in-process from the Monitor node, which is a live node for
+        the whole run, rather than as one ``static_transform_publisher`` per
+        mount: those would land under the recipe's namespace (the launch
+        description pushes one), and their positional CLI form is deprecated.
+        """
+        if not self._mounts:
+            return
+        from tf2_ros import StaticTransformBroadcaster
+        from geometry_msgs.msg import TransformStamped
+        from ..robot.mount import quaternion_from_euler
+
+        transforms = []
+        for mount in self._mounts:
+            transform = TransformStamped()
+            transform.header.stamp = self.monitor_node.get_clock().now().to_msg()
+            transform.header.frame_id = mount.parent_frame
+            transform.child_frame_id = mount.child_frame
+            (
+                transform.transform.translation.x,
+                transform.transform.translation.y,
+                transform.transform.translation.z,
+            ) = (float(v) for v in mount.xyz)
+            (
+                transform.transform.rotation.x,
+                transform.transform.rotation.y,
+                transform.transform.rotation.z,
+                transform.transform.rotation.w,
+            ) = quaternion_from_euler(*(float(v) for v in mount.rpy))
+            transforms.append(transform)
+            logger.info(
+                f"Mounting '{transform.child_frame_id}' on "
+                f"'{transform.header.frame_id}'"
+            )
+
+        # Held on the launcher: a StaticTransformBroadcaster that goes out of
+        # scope takes its latched publisher with it
+        self._static_tf_broadcaster = StaticTransformBroadcaster(self.monitor_node)
+        self._static_tf_broadcaster.sendTransform(transforms)
+
+    def _validate_plugin_references(self) -> None:
+        """Check every topic's ``use_plugin`` against the attached plugins.
+
+        A topic naming a plugin that is not attached would otherwise fall back
+        to an ordinary ROS topic that nothing publishes: the component comes up
+        looking healthy and simply receives nothing. Catch it here, where both
+        the components and the plugins are known, and say what is available.
+
+        :raises ValueError: If a topic names a plugin that is not attached, or
+            asks for the robot plugin when none is.
+        """
+        for component in self._components:
+            # A component declares outputs only if it has any
+            topics = list(getattr(component, "in_topics", None) or []) + list(
+                getattr(component, "out_topics", None) or []
+            )
+            for topic in topics:
+                if not topic.use_plugin:
+                    continue
+                if topic.use_plugin is True:
+                    if self._robot_plugin is None:
+                        raise ValueError(
+                            f"Component '{component.node_name}' topic "
+                            f"'{topic.name}' asks for the robot plugin "
+                            "(use_plugin=True) but no robot plugin is attached "
+                            "to this recipe."
+                        )
+                    continue
+                if topic.use_plugin not in self._plugins:
+                    raise ValueError(
+                        f"Component '{component.node_name}' topic '{topic.name}' "
+                        f"is bound to plugin '{topic.use_plugin}', which is not "
+                        "attached to this recipe. Attached plugins: "
+                        f"{', '.join(self._plugins) or 'none'}."
+                    )
+
+    def _distribute_plugins(self) -> None:
+        """Hand every attached plugin to every component.
+
+        NOTE: In multithreaded launch the component thread uses these HOST
+        instances directly; in multiprocess launch they are only used to
+        serialize the plugin specs into each component's launch args.
+        """
+        for component in self._components:
+            for plugin in self._plugins.values():
+                component.add_plugin(plugin)
 
     def _apply_plugin_robot_config(self) -> None:
         """Pull ``robot_config`` from the attached plugin and broadcast it to
@@ -1526,40 +1682,48 @@ class Launcher:
             RegisterEventHandler(OnShutdown(on_shutdown=_mark_shutting_down))
         )
 
-    def _setup_robot_plugin(self) -> None:
-        """Bring up the robot plugin HOST in the launcher process.
+    def _setup_plugins(self) -> None:
+        """Bring every attached plugin up HOST-side in the launcher process.
 
-        Opens the plugin's transports, starts its feedback bus and heartbeats,
-        and wires decoded feedback into the Monitor's event blackboard. Must run
-        after `_setup_monitor_node` (the Monitor must exist) and before the
-        component group is built, so multiprocess components serialize a plugin
-        spec that points at an already-started feedback bus.
+        Opens each plugin's transports, starts the shared feedback bus and the
+        plugins' heartbeats, and wires decoded feedback into the Monitor's
+        event blackboard. Must run after `_setup_monitor_node` (the Monitor
+        must exist) and before the component group is built, so multiprocess
+        components serialize plugin specs that point at an already-started
+        feedback bus.
         """
-        if self._robot_plugin is None:
+        if not self._plugins:
             return
-        plugin = self._robot_plugin
         # A socket feedback bus is needed when any component runs as its own
         # process; otherwise an in-process bus avoids the socket round trip.
         use_socket_bus = bool(self._pkg_executable)
         bus = SocketFeedbackBus() if use_socket_bus else InProcessFeedbackBus()
-        self._robot_plugin_host = RobotPluginHost(
-            plugin,
-            node=self.monitor_node,
-            bus=bus,
-            monitor_feed=self.monitor_node.feed_external_topic,
-        )
-        self._robot_plugin_host.open()
-        # Register every non-ROS feedback's synthetic topic with the Monitor so
-        # events over it are tracked without a ROS subscription. ROS-topic
-        # feedbacks keep a normal ROS subscription (their as_topic() is the real
-        # robot topic), so they are NOT registered as external.
-        for feedback in plugin.feedbacks.values():
-            if not feedback.is_ros_topic:
-                self.monitor_node.register_external_topic(feedback.as_topic())
-        logger.info(
-            f"Robot plugin '{plugin.metadata.name}' active "
-            f"({'socket' if use_socket_bus else 'in-process'} feedback bus)"
-        )
+        # The launcher owns the bus, not the hosts: one bus is shared by every
+        # attached plugin, so it has to outlive any single host
+        self._plugin_bus = bus
+        bus.start()
+
+        for plugin in self._plugins.values():
+            host = RobotPluginHost(
+                plugin,
+                node=self.monitor_node,
+                bus=bus,
+                monitor_feed=self.monitor_node.feed_external_topic,
+                owns_bus=False,
+            )
+            host.open()
+            self._plugin_hosts.append(host)
+            # Register every non-ROS feedback's synthetic topic with the Monitor
+            # so events over it are tracked without a ROS subscription.
+            # ROS-topic feedbacks keep a normal ROS subscription (their
+            # as_topic() is the real robot topic), so they are NOT external.
+            for feedback in plugin.feedbacks.values():
+                if not feedback.is_ros_topic:
+                    self.monitor_node.register_external_topic(feedback.as_topic())
+            logger.info(
+                f"Plugin '{plugin.metadata.name}' active as '{plugin.id}' "
+                f"({'socket' if use_socket_bus else 'in-process'} feedback bus)"
+            )
 
     def setup_launch_description(
         self,
@@ -1591,7 +1755,9 @@ class Launcher:
 
         # Bring up the robot plugin HOST after the Monitor exists and before the
         # component group is built
-        self._setup_robot_plugin()
+        self._setup_plugins()
+
+        self._publish_mounts()
 
         # Add configured components to launcher
         for component in self._components:
@@ -1628,6 +1794,10 @@ class Launcher:
 
         # If the attached plugin carries a robot_config and the recipe didn't
         # set one, broadcast it to every component
+        self._validate_plugin_references()
+
+        self._distribute_plugins()
+
         self._apply_plugin_robot_config()
 
         self._apply_plugin_base_frame()
@@ -1639,9 +1809,13 @@ class Launcher:
 
         self._start_ros_launch(introspect, launch_debug)
 
-        # Tear down the robot plugin HOST
-        if self._robot_plugin_host is not None:
-            self._robot_plugin_host.close()
+        # Tear down every plugin HOST, then the bus they shared
+        for host in self._plugin_hosts:
+            host.close()
+        self._plugin_hosts.clear()
+        if self._plugin_bus is not None:
+            self._plugin_bus.close()
+            self._plugin_bus = None
 
         if self._thread_pool:
             self._thread_pool.shutdown()

--- a/ros_sugar/launch/launcher.py
+++ b/ros_sugar/launch/launcher.py
@@ -678,25 +678,49 @@ class Launcher:
         self._broadcast_robot_config(robot_config)
 
     def _apply_plugin_base_frame(self) -> None:
-        """Pull the robot's base frame from the attached plugin and apply it to
-        every component, unless the recipe already set frames explicitly.
+        """Apply the attached robot plugin's body frame to every component.
 
         Only ``robot_base`` is taken from the robot plugin: it is the one frame
         the robot itself defines. The world frame describes where the robot has
         been placed, so it stays with the recipe (or, later, an environment
         plugin) rather than being dictated by the robot.
+
+        The plugin's frame wins over whatever the recipe holds. `RobotFrames`
+        carries a default body frame, so a recipe that only wanted to name the
+        world frame would otherwise silently discard the plugin's -- leaving
+        anything mounted on the plugin parented to a frame no component looks
+        up. To publish under a different name, rename it on the plugin, which
+        keeps its telemetry and its mounts in agreement::
+
+            lite3.base_frame = "base_link"
         """
-        if self._frames_explicitly_set:
-            return
         if self._robot_plugin is None:
             return
         base_frame = self._robot_plugin.base_frame
         if base_frame is None:
             return
-        logger.info(
-            f"Applying robot base frame '{base_frame}' from plugin "
-            f"'{self._robot_plugin.metadata.name}'"
-        )
+        replaced = {
+            component.config.frames.robot_base
+            for component in self._components
+            if hasattr(component.config, "frames")
+            and component.config.frames.robot_base != base_frame
+        }
+        if not replaced:
+            return
+        plugin_name = self._robot_plugin.metadata.name
+        if self._frames_explicitly_set:
+            named = ", ".join(f"'{frame}'" for frame in sorted(replaced))
+            logger.warning(
+                f"The recipe set the robot body frame to {named}, but plugin "
+                f"'{plugin_name}' reports '{base_frame}'. Using the plugin frame name."
+                "To publish under a different name, set it on the plugin "
+                "itself before bringup."
+            )
+        else:
+            logger.info(
+                f"Applying robot base frame '{base_frame}' from plugin "
+                f"'{plugin_name}'"
+            )
         for component in self._components:
             if hasattr(component.config, "frames"):
                 component.config.frames.robot_base = base_frame
@@ -732,6 +756,74 @@ class Launcher:
                     logger.error(
                         f"Cannot set component {component.node_name} 'frames' configuration parameter of type '{type(component.config.frames)}' to provided value of type '{type(frames_config)}' Skipping setting frames configuration for '{component.node_name}'"
                     )
+
+    def _set_frame(self, attribute: str, frame: str) -> None:
+        """Set one frame on every component that has a frames configuration."""
+        if not isinstance(frame, str) or not frame:
+            raise ValueError(
+                f"Frame name must be a non-empty string, got {frame!r}"
+            )
+        for component in self._components:
+            if hasattr(component.config, "frames"):
+                setattr(component.config.frames, attribute, frame)
+
+    @property
+    def robot_frame(self) -> Dict[str, str]:
+        """
+        Getter of the robot body frame of all components
+
+        :return: Robot body frame per component
+        :rtype: Dict[str, str]
+        """
+        return {
+            component.node_name: component.config.frames.robot_base
+            for component in self._components
+            if hasattr(component.config, "frames")
+        }
+
+    @robot_frame.setter
+    def robot_frame(self, frame: str) -> None:
+        """
+        Setter of the robot body frame for all components
+
+        Sets that one frame, so naming it does not disturb the world frame.
+        An attached robot plugin reports the frame its own telemetry is
+        stamped in and that takes precedence at bringup -- rename the frame on
+        the plugin rather than here when one is attached.
+
+        :param frame: Frame rigidly attached to the robot body
+        :type frame: str
+        """
+        self._frames_explicitly_set = True
+        self._set_frame("robot_base", frame)
+
+    @property
+    def world_frame(self) -> Dict[str, str]:
+        """
+        Getter of the world frame of all components
+
+        :return: World frame per component
+        :rtype: Dict[str, str]
+        """
+        return {
+            component.node_name: component.config.frames.world
+            for component in self._components
+            if hasattr(component.config, "frames")
+        }
+
+    @world_frame.setter
+    def world_frame(self, frame: str) -> None:
+        """
+        Setter of the world frame for all components
+
+        Sets that one frame, so naming it does not disturb the robot body
+        frame -- which is what lets a recipe take the body frame from a plugin
+        while still choosing where the robot has been placed.
+
+        :param frame: Global reference frame the robot operates in
+        :type frame: str
+        """
+        self._set_frame("world", frame)
 
     def inputs(self, **kwargs):
         """

--- a/ros_sugar/launch/launcher.py
+++ b/ros_sugar/launch/launcher.py
@@ -176,6 +176,7 @@ class Launcher:
         # Tracks whether the recipe explicitly set robot config. If not config
         # is pulled from a plugin. In case both present, recipe wins.
         self._robot_explicitly_set: bool = False
+        self._frames_explicitly_set: bool = False
 
         # Components list and package/executable
         self._components: List[BaseComponent] = []
@@ -521,13 +522,37 @@ class Launcher:
             return
         if self._robot_plugin is None:
             return
-        robot_config = getattr(self._robot_plugin, "robot_config", None)
+        robot_config = self._robot_plugin.robot_config
         if robot_config is None:
             return
         logger.info(
             f"Applying robot config from plugin '{self._robot_plugin.metadata.name}'"
         )
         self._broadcast_robot_config(robot_config)
+
+    def _apply_plugin_base_frame(self) -> None:
+        """Pull the robot's base frame from the attached plugin and apply it to
+        every component, unless the recipe already set frames explicitly.
+
+        Only ``robot_base`` is taken from the robot plugin: it is the one frame
+        the robot itself defines. The world frame describes where the robot has
+        been placed, so it stays with the recipe (or, later, an environment
+        plugin) rather than being dictated by the robot.
+        """
+        if self._frames_explicitly_set:
+            return
+        if self._robot_plugin is None:
+            return
+        base_frame = self._robot_plugin.base_frame
+        if base_frame is None:
+            return
+        logger.info(
+            f"Applying robot base frame '{base_frame}' from plugin "
+            f"'{self._robot_plugin.metadata.name}'"
+        )
+        for component in self._components:
+            if hasattr(component.config, "frames"):
+                component.config.frames.robot_base = base_frame
 
     @property
     def frames(self) -> Dict[str, Any]:
@@ -551,6 +576,7 @@ class Launcher:
         :param frames_config: Robot frames configuration
         :type frames_config: RobotFrames
         """
+        self._frames_explicitly_set = True
         for component in self._components:
             if hasattr(component.config, "frames"):
                 try:
@@ -1603,6 +1629,8 @@ class Launcher:
         # If the attached plugin carries a robot_config and the recipe didn't
         # set one, broadcast it to every component
         self._apply_plugin_robot_config()
+
+        self._apply_plugin_base_frame()
 
         if config_file:
             self.configure(config_file)

--- a/ros_sugar/launch/launcher.py
+++ b/ros_sugar/launch/launcher.py
@@ -541,8 +541,7 @@ class Launcher:
     def add_plugin(self, plugin: Plugin, mount: Optional[Mount] = None) -> None:
         """Attach a plugin to the recipe.
 
-        Every component in the recipe is given every attached plugin, whatever
-        order ``add_pkg`` and ``add_plugin`` are called in.
+        Every component in the recipe is given every attached plugin.
 
         :param plugin: The plugin to attach. Its ``id`` -- set with ``id=`` at
             construction, or derived from its name -- is how a topic addresses
@@ -572,7 +571,7 @@ class Launcher:
                 "a distinct id at construction, e.g. "
                 f"{type(plugin).__name__}(id='front_cam')."
             )
-        # Identity has to be final now, not at bringup: events are built from
+        # NOTE: Identity has to be final now, not at bringup. Events are built from
         # plugins in the recipe, and their topic names are frozen before plugin
         # setup runs
         plugin._bind_identity()
@@ -618,8 +617,7 @@ class Launcher:
         """Check every topic's ``use_plugin`` against the attached plugins.
 
         A topic naming a plugin that is not attached would otherwise fall back
-        to an ordinary ROS topic that nothing publishes: the component comes up
-        looking healthy and simply receives nothing. Catch it here, where both
+        to an ordinary ROS topic that nothing publishes. Catch it here, where both
         the components and the plugins are known, and say what is available.
 
         :raises ValueError: If a topic names a plugin that is not attached, or
@@ -680,19 +678,17 @@ class Launcher:
     def _apply_plugin_base_frame(self) -> None:
         """Apply the attached robot plugin's body frame to every component.
 
-        Only ``robot_base`` is taken from the robot plugin: it is the one frame
-        the robot itself defines. The world frame describes where the robot has
-        been placed, so it stays with the recipe (or, later, an environment
-        plugin) rather than being dictated by the robot.
+        Only ``robot_base`` is taken from the robot plugin. It is the one frame
+        the robot itself defines.
 
-        The plugin's frame wins over whatever the recipe holds. `RobotFrames`
+        NOTE: The plugin's frame wins over whatever the recipe holds. `RobotFrames`
         carries a default body frame, so a recipe that only wanted to name the
-        world frame would otherwise silently discard the plugin's -- leaving
+        world frame would otherwise silently discard the plugin's, leaving
         anything mounted on the plugin parented to a frame no component looks
         up. To publish under a different name, rename it on the plugin, which
         keeps its telemetry and its mounts in agreement::
 
-            lite3.base_frame = "base_link"
+            plugin.base_frame = "base_link"
         """
         if self._robot_plugin is None:
             return
@@ -788,8 +784,7 @@ class Launcher:
 
         Sets that one frame, so naming it does not disturb the world frame.
         An attached robot plugin reports the frame its own telemetry is
-        stamped in and that takes precedence at bringup -- rename the frame on
-        the plugin rather than here when one is attached.
+        stamped in and that takes precedence at bringup.
 
         :param frame: Frame rigidly attached to the robot body
         :type frame: str
@@ -817,8 +812,7 @@ class Launcher:
         Setter of the world frame for all components
 
         Sets that one frame, so naming it does not disturb the robot body
-        frame -- which is what lets a recipe take the body frame from a plugin
-        while still choosing where the robot has been placed.
+        frame.
 
         :param frame: Global reference frame the robot operates in
         :type frame: str
@@ -1781,8 +1775,8 @@ class Launcher:
         # process; otherwise an in-process bus avoids the socket round trip.
         use_socket_bus = bool(self._pkg_executable)
         bus = SocketFeedbackBus() if use_socket_bus else InProcessFeedbackBus()
-        # The launcher owns the bus, not the hosts: one bus is shared by every
-        # attached plugin, so it has to outlive any single host
+        # The launcher owns the bus. One bus is shared by every attached plugin,
+        # so it has to outlive any single host
         self._plugin_bus = bus
         bus.start()
 

--- a/ros_sugar/robot/__init__.py
+++ b/ros_sugar/robot/__init__.py
@@ -11,10 +11,14 @@ Authors subclass `RobotPlugin`; see ``docs/development/custom_robot_plugin.md``.
 from .bus import FeedbackBus, InProcessFeedbackBus, SocketFeedbackBus
 from .command import CommandSpec, RobotCommand
 from .feedback import Feedback, FeedbackSpec
+from .mount import Mount
 from .plugin import (
     AmbiguousPluginEntryError,
+    Plugin,
     PluginMetadata,
+    PluginRole,
     RobotPlugin,
+    SensorPlugin,
     RobotPluginHost,
 )
 from .registries import (
@@ -33,7 +37,11 @@ from .types import create_supported_type
 
 __all__ = [
     # plugin
+    "Mount",
+    "Plugin",
+    "PluginRole",
     "RobotPlugin",
+    "SensorPlugin",
     "RobotPluginHost",
     "PluginMetadata",
     "AmbiguousPluginEntryError",

--- a/ros_sugar/robot/command.py
+++ b/ros_sugar/robot/command.py
@@ -14,8 +14,14 @@ from ..io.supported_types import SupportedType
 from .transports import Transport
 
 
-def _command_channel(key: str) -> str:
-    """Bus channel for a command routed through the plugin HOST."""
+def _command_channel(key: str, owner_id: str = "") -> str:
+    """Bus channel for a command routed through the plugin HOST.
+
+    Namespaced by the owning plugin's id once attached; an unattached plugin
+    keeps the bare form.
+    """
+    if owner_id:
+        return f"plugin/{owner_id}/command/{key}"
     return f"robot/command/{key}"
 
 
@@ -46,11 +52,13 @@ class RobotCommand(BaseAttrs):
     encoder: Callable[[Any], Any] = field()
     msg_type: Optional[Type[SupportedType]] = field(default=None)
     description: str = field(default="")
+    #: Id of the owning plugin, stamped by ``Plugin._bind_identity``.
+    owner_id: str = field(default="", init=False, repr=False)
 
     @property
     def channel(self) -> str:
         """Command bus channel, used when ``transport.route_via_host`` is set."""
-        return _command_channel(self.key)
+        return _command_channel(self.key, self.owner_id)
 
     def spec(self) -> "CommandSpec":
         """Return the introspection spec for this command."""

--- a/ros_sugar/robot/feedback.py
+++ b/ros_sugar/robot/feedback.py
@@ -15,8 +15,15 @@ from ..io.topic import Topic
 from .transports import Transport
 
 
-def _feedback_channel(key: str) -> str:
-    """Bus channel / synthetic topic name for a feedback stream."""
+def _feedback_channel(key: str, owner_id: str = "") -> str:
+    """Bus channel / synthetic topic name for a feedback stream.
+
+    Several plugins share one bus, so a channel is namespaced by the id of the
+    plugin that owns it. An unattached plugin has no id yet and keeps the bare
+    form, which is also what a recipe with a single plugin has always used.
+    """
+    if owner_id:
+        return f"plugin/{owner_id}/feedback/{key}"
     return f"robot/feedback/{key}"
 
 
@@ -50,12 +57,22 @@ class Feedback(BaseAttrs):
     decoder: Optional[Callable[[Any], Optional[Any]]] = field(default=None)
     rate_hz: Optional[float] = field(default=None)
     description: str = field(default="")
+    #: Frame this stream's data is expressed in. Stamped onto decoded messages
+    #: that carry a header but no frame, so components can place the data
+    #: without the decoder hard-coding a frame name. Falls back to the owning
+    #: plugin's frame when unset; a decoder that stamps its own is never
+    #: overridden.
+    frame_id: str = field(default="")
+    #: Id of the owning plugin, stamped by ``Plugin._bind_identity`` when the
+    #: plugin is attached. Declared rather than set dynamically because
+    #: ``@define`` classes are slotted.
+    owner_id: str = field(default="", init=False, repr=False)
     _topic: Optional[Topic] = field(default=None, init=False, repr=False)
 
     @property
     def channel(self) -> str:
         """Feedback bus channel / synthetic topic name for this stream."""
-        return _feedback_channel(self.key)
+        return _feedback_channel(self.key, self.owner_id)
 
     def as_topic(self) -> Topic:
         """Return the `io.topic.Topic` that Events, Conditions

--- a/ros_sugar/robot/feedback.py
+++ b/ros_sugar/robot/feedback.py
@@ -64,8 +64,7 @@ class Feedback(BaseAttrs):
     #: overridden.
     frame_id: str = field(default="")
     #: Id of the owning plugin, stamped by ``Plugin._bind_identity`` when the
-    #: plugin is attached. Declared rather than set dynamically because
-    #: ``@define`` classes are slotted.
+    #: plugin is attached.
     owner_id: str = field(default="", init=False, repr=False)
     _topic: Optional[Topic] = field(default=None, init=False, repr=False)
 

--- a/ros_sugar/robot/mount.py
+++ b/ros_sugar/robot/mount.py
@@ -1,0 +1,121 @@
+"""Where a sensor sits on the robot.
+
+A `Mount` is a recipe-level statement: *this* sensor is mounted *there* on *this*
+robot.
+
+Mounts describe **static** transforms only. A sensor with moving parts (a pan-tilt head) publishes the dynamic transform from its own base frame to the
+moving one itself; the recipe then only has to say where that base frame sits,
+and the two compose in the TF tree.
+"""
+
+import math
+from typing import Any, Optional, Tuple
+
+from attrs import define, field
+
+from ..config import BaseAttrs
+
+
+def quaternion_from_euler(
+    roll: float, pitch: float, yaw: float
+) -> Tuple[float, float, float, float]:
+    """Convert roll/pitch/yaw (radians) to a quaternion ``(x, y, z, w)``.
+
+    ROS transforms carry quaternions while people describe mounts in roll,
+    pitch and yaw, so a recipe states the readable form and this converts.
+    Rotations compose in the ROS convention: yaw about Z, then pitch about Y,
+    then roll about X.
+
+    :param roll: Rotation about X, in radians
+    :param pitch: Rotation about Y, in radians
+    :param yaw: Rotation about Z, in radians
+    :return: Quaternion as ``(x, y, z, w)``
+    :rtype: Tuple[float, float, float, float]
+    """
+    cr, sr = math.cos(roll * 0.5), math.sin(roll * 0.5)
+    cp, sp = math.cos(pitch * 0.5), math.sin(pitch * 0.5)
+    cy, sy = math.cos(yaw * 0.5), math.sin(yaw * 0.5)
+    return (
+        sr * cp * cy - cr * sp * sy,
+        cr * sp * cy + sr * cp * sy,
+        cr * cp * sy - sr * sp * cy,
+        cr * cp * cy + sr * sp * sy,
+    )
+
+
+def _resolve_frame(value: Any) -> str:
+    """Get the frame a mount endpoint refers to.
+
+    Accepts a plain frame name, or a plugin -- a robot plugin contributes its
+    ``base_frame``, a sensor plugin its ``frame_id``. Passing the plugin is
+    preferred: it cannot be mistyped, and it keeps the recipe honest if the
+    plugin's frame is later renamed.
+
+    :param value: Frame name, robot plugin, or sensor plugin
+    :return: The frame name
+    :rtype: str
+    """
+    if isinstance(value, str):
+        if not value:
+            raise ValueError("A mount frame cannot be an empty string")
+        return value
+    # RobotPlugin names the frame attached to the robot body; SensorPlugin
+    # names its own. Neither is required to be a plugin -- a plain frame works.
+    for attribute in ("base_frame", "frame_id"):
+        frame = getattr(value, attribute, None)
+        if frame:
+            return frame
+    raise ValueError(
+        f"Cannot mount against {value!r}: expected a frame name, a robot plugin "
+        "with a base_frame, or a sensor plugin."
+    )
+
+
+@define(kw_only=True)
+class Mount(BaseAttrs):
+    """A static placement of a sensor relative to something else.
+
+    ```{list-table}
+    :widths: 10 20 70
+    :header-rows: 1
+
+    * - Name
+      - Type, Default
+      - Description
+
+    * - **parent**
+      - `str | Plugin`
+      - What the sensor is mounted on: the robot plugin, another sensor
+        plugin, or a frame name such as the world frame for a fixed sensor.
+
+    * - **xyz**
+      - `tuple`, `(0, 0, 0)`
+      - Translation from the parent frame to the sensor frame, in metres.
+
+    * - **rpy**
+      - `tuple`, `(0, 0, 0)`
+      - Rotation from the parent frame to the sensor frame, in radians.
+    ```
+    """
+
+    parent: Any = field()
+    xyz: Tuple[float, float, float] = field(default=(0.0, 0.0, 0.0))
+    rpy: Tuple[float, float, float] = field(default=(0.0, 0.0, 0.0))
+    #: Frame being mounted. Filled in from the plugin the mount is attached to,
+    #: so a recipe never has to repeat it.
+    child: Optional[Any] = field(default=None)
+
+    @property
+    def parent_frame(self) -> str:
+        """Frame this mount is relative to."""
+        return _resolve_frame(self.parent)
+
+    @property
+    def child_frame(self) -> str:
+        """Frame being placed."""
+        if self.child is None:
+            raise ValueError(
+                "This mount is not attached to a sensor yet, so there is "
+                "nothing to place. Pass it to 'Launcher.add_plugin'."
+            )
+        return _resolve_frame(self.child)

--- a/ros_sugar/robot/mount.py
+++ b/ros_sugar/robot/mount.py
@@ -3,7 +3,7 @@
 A `Mount` is a recipe-level statement: *this* sensor is mounted *there* on *this*
 robot.
 
-Mounts describe **static** transforms only. A sensor with moving parts (a pan-tilt head) publishes the dynamic transform from its own base frame to the
+Mounts only describe **static** transforms. A sensor with moving parts (a pan-tilt head) publishes the dynamic transform from its own base frame to the
 moving one itself; the recipe then only has to say where that base frame sits,
 and the two compose in the TF tree.
 """
@@ -46,10 +46,9 @@ def quaternion_from_euler(
 def _resolve_frame(value: Any) -> str:
     """Get the frame a mount endpoint refers to.
 
-    Accepts a plain frame name, or a plugin -- a robot plugin contributes its
+    Accepts a plain frame name, or a plugin. A robot plugin contributes its
     ``base_frame``, a sensor plugin its ``frame_id``. Passing the plugin is
-    preferred: it cannot be mistyped, and it keeps the recipe honest if the
-    plugin's frame is later renamed.
+    preferred.
 
     :param value: Frame name, robot plugin, or sensor plugin
     :return: The frame name
@@ -60,7 +59,7 @@ def _resolve_frame(value: Any) -> str:
             raise ValueError("A mount frame cannot be an empty string")
         return value
     # RobotPlugin names the frame attached to the robot body; SensorPlugin
-    # names its own. Neither is required to be a plugin -- a plain frame works.
+    # names its own. Also works with a plain frame name.
     for attribute in ("base_frame", "frame_id"):
         frame = getattr(value, attribute, None)
         if frame:

--- a/ros_sugar/robot/plugin.py
+++ b/ros_sugar/robot/plugin.py
@@ -320,6 +320,25 @@ class Plugin:
         # No-op by default — see the docstring.
         pass
 
+    # host-side teardown hook
+    def on_detached(self, node: Any, bus: FeedbackBus) -> None:
+        """Optional host-side teardown hook — override in subclasses.
+
+        `RobotPluginHost` calls this once on close, **before** the transports
+        are shut, so the plugin can still talk to the device. Override it to
+        leave hardware in a safe state: a lidar has to be told to stop its
+        motor, which keeps spinning otherwise, and closing the port does not
+        do it.
+
+        Anything raised here is logged and does not stop teardown.
+
+        :param node: rclpy node owned by the launcher (may be ``None`` in
+            standalone/test contexts).
+        :param bus: the feedback bus still attached to the plugin.
+        """
+        # No-op by default — see the docstring.
+        pass
+
     # consumer API (used by components)
     def resolve_feedback(
         self, topic_name: str, msg_type_name: str
@@ -628,6 +647,14 @@ class RobotPluginHost:
         if not self._active:
             return
         self._stop_keep_alive()
+        # Before the transports go, so the plugin can still reach the device to
+        # leave it in a safe state
+        try:
+            self.plugin.on_detached(self.node, self.bus)
+        except Exception as e:  # pragma: no cover - defensive
+            get_logger(LOGGER_NAME).error(
+                f"Error in on_detached for plugin '{self.plugin.id}': {e}"
+            )
         for handle in self._transport_handles:
             handle.unsubscribe()
         self._transport_handles.clear()

--- a/ros_sugar/robot/plugin.py
+++ b/ros_sugar/robot/plugin.py
@@ -16,6 +16,7 @@ import functools
 import importlib
 import inspect
 import json
+import re
 import threading
 from typing import Any, Callable, Dict, List, Optional
 
@@ -23,7 +24,7 @@ from attrs import define, field
 from rclpy.logging import get_logger
 from rclpy.serialization import deserialize_message, serialize_message
 
-from ..config import BaseAttrs, RobotConfig
+from ..config import BaseAttrs, RobotConfig, StrEnum
 from .bus import LOGGER_NAME, BusHandle, FeedbackBus, SocketFeedbackBus
 from .command import CommandSpec, RobotCommand
 from .feedback import Feedback, FeedbackSpec
@@ -56,22 +57,77 @@ class PluginMetadata(BaseAttrs):
     description: str = field(default="")
 
 
+#: Plugin ids end up inside ROS topic names, which reject hyphens, dots and
+#: leading digits -- and would do so at activation, long after the recipe ran.
+_VALID_PLUGIN_ID = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _slug(name: str) -> str:
+    """Turn a plugin's display name into a usable id.
+
+    ``"Name Version-2"`` becomes ``"name_version_2"``.
+
+    :param name: Plugin display name
+    :type name: str
+    :return: A valid plugin id
+    :rtype: str
+    """
+    cleaned = re.sub(r"[^A-Za-z0-9]+", "_", name).strip("_").lower()
+    if not cleaned:
+        raise ValueError(f"Cannot derive a plugin id from '{name}'")
+    # A leading digit is not a valid ROS name start
+    if cleaned[0].isdigit():
+        cleaned = f"_{cleaned}"
+    return cleaned
+
+
 def _is_ros_transport(transport: Transport) -> bool:
     return isinstance(transport, (RosTopicTransport, RosServiceTransport))
 
 
-class RobotPlugin:
-    """Base class for robot plugins.
+class PluginRole(StrEnum):
+    """What a plugin represents in a recipe.
 
-    Subclass and populate the registries in a declarative ``init``. Keep
-    ``init`` free of I/O and accept only JSON-serializable keyword
-    arguments - the launcher serializes those into a spec so each component
-    subprocess can rebuild the plugin. Open sockets, start threads and bind
-    nodes through `RobotPluginHost`, not from ``init``.
+    The role is intrinsic to the plugin, to determine its type: a robot or a sensor. The launcher uses it to
+    enforce that a recipe describes exactly one robot, and to decide what each
+    plugin is allowed to contribute to the components.
+
     """
+
+    ROBOT = "robot"
+    SENSOR = "sensor"
+
+
+class Plugin:
+    """Base class for plugins.
+
+    Subclass `RobotPlugin` or `SensorPlugin` rather than this class directly,
+    so the plugin carries the right `PluginRole`.
+    """
+
+    #: Overridden by each role base class below. A plugin that subclasses
+    #: ``Plugin`` directly is treated as a sensor: something that contributes
+    #: feedback and commands but describes no robot.
+    _role: PluginRole = PluginRole.SENSOR
+
+    @property
+    def role(self) -> PluginRole:
+        """What this plugin represents -- read-only.
+
+        A plugin *is* a robot or a sensor by construction, so the role follows
+        from the base class the author subclassed and cannot be reassigned by
+        a recipe.
+        """
+        return self._role
 
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)
+        # The role base classes in this module are part of the framework, not
+        # user plugins. Leaving their __init__ unwrapped means a user subclass
+        # that defines no __init__ of its own still gets wrapped against
+        # itself, and so reports its own name rather than its base's.
+        if cls.__module__ == __name__:
+            return
         orig_init = cls.__init__
         if getattr(orig_init, "_robotplugin_wrapped", False):
             return
@@ -85,6 +141,8 @@ class RobotPlugin:
             # they would clobber the outer subclass's ``_init_kwargs`` and
             # reset the registries to their base defaults.
             if not hasattr(self, "_init_kwargs"):
+                explicit_id = kw.pop("id", None)
+                explicit_frame = kw.pop("frame_id", None)
                 try:
                     bound = sig.bind(self, *args, **kw)
                     bound.apply_defaults()
@@ -95,6 +153,10 @@ class RobotPlugin:
                     init_kwargs = dict(kw)
                 object.__setattr__(self, "_init_kwargs", init_kwargs)
                 self._base_init(cls)
+                if explicit_id is not None:
+                    self._set_id(explicit_id)
+                if explicit_frame is not None:
+                    self._set_frame_id(explicit_frame)
             orig_init(self, *args, **kw)
 
         _wrapped_init._robotplugin_wrapped = True
@@ -110,13 +172,69 @@ class RobotPlugin:
         self.commands: Dict[str, RobotCommand] = {}
         self.actions: ActionRegistry = ActionRegistry({})
         self.events: EventRegistry = EventRegistry({})
-        # Robot geometry and kinematic description
-        self.robot_config: Optional[RobotConfig] = None
-        # Name of the rigid frame attached to the robot body
-        self.base_frame: Optional[str] = None
         self.metadata: PluginMetadata = getattr(
             cls, "metadata", None
         ) or PluginMetadata(name=cls.__name__)
+        # Explicit identity, if the recipe passed ``id=``; otherwise ``id``
+        # derives from the metadata name (see the property below).
+        self._id: str = ""
+
+    # identity
+    @property
+    def id(self) -> str:
+        """Identity of this plugin within a recipe.
+
+        A recipe addresses a plugin from a topic by this id
+        (``Topic(..., use_plugin=cam.id)``), so it is available from the moment
+        the plugin is constructed.
+
+        Defaults to a slug of the plugin's metadata name, which is enough
+        unless two plugins of the same kind are used; those are told apart by
+        passing ``id=`` to the constructor.
+        """
+        return self._id or _slug(self.metadata.name)
+
+    def _set_id(self, plugin_id: str) -> None:
+        """Set an explicit identity. Called from ``__init__`` via ``id=``.
+
+        :param plugin_id: Identity to use, unique within the recipe.
+        :type plugin_id: str
+        :raises ValueError: If the id is not a usable ROS name token.
+        """
+        if not isinstance(plugin_id, str) or not _VALID_PLUGIN_ID.match(plugin_id):
+            raise ValueError(
+                f"'{plugin_id}' is not a usable plugin id. Plugin ids become part "
+                "of ROS topic names, so they must start with a letter or "
+                "underscore and contain only letters, digits and underscores."
+            )
+        self._id = plugin_id
+
+    def _bind_identity(self) -> None:
+        """Namespace this plugin's channels by its id, once it is attached.
+
+        Channels stay in their un-namespaced form until this runs, so a plugin
+        used standalone behaves exactly as it did before ids existed.
+
+        :raises ValueError: If a feedback topic was already handed out under a
+            different id.
+        """
+        for feedback in self.feedbacks.values():
+            if (
+                feedback._topic is not None
+                and not feedback.is_ros_topic
+                and feedback.owner_id != self.id
+            ):
+                raise ValueError(
+                    f"Plugin '{self.metadata.name}' cannot be attached as "
+                    f"'{self.id}': its feedback '{feedback.key}' has already "
+                    "been referenced (usually by building an event from it) and "
+                    f"is bound to channel '{feedback.channel}'. Attach the "
+                    "plugin to the launcher before building events from it."
+                )
+        for feedback in self.feedbacks.values():
+            feedback.owner_id = self.id
+        for command in self.commands.values():
+            command.owner_id = self.id
 
     # spec serialization
     def to_spec(self) -> Dict[str, Any]:
@@ -132,13 +250,18 @@ class RobotPlugin:
                 f"constructor arguments {list(kwargs)}: {e}. Plugin __init__ "
                 "must accept only JSON-serializable keyword arguments."
             ) from e
-        return {"class": f"{cls.__module__}:{cls.__qualname__}", "kwargs": kwargs}
+        return {
+            "class": f"{cls.__module__}:{cls.__qualname__}",
+            "kwargs": kwargs,
+            "id": self._id,
+            "frame_id": getattr(self, "_frame_id", ""),
+        }
 
     @staticmethod
     def from_spec(
         spec: Dict[str, Any],
         bus_endpoint: Optional[Any] = None,
-    ) -> "RobotPlugin":
+    ) -> "Plugin":
         """Rebuild a plugin from a `to_spec` dict.
 
         :param spec: The spec dict produced by `to_spec`.
@@ -152,7 +275,15 @@ class RobotPlugin:
         obj: Any = module
         for part in qualname.split("."):
             obj = getattr(obj, part)
-        plugin: RobotPlugin = obj(**spec.get("kwargs", {}))
+        plugin: Plugin = obj(**spec.get("kwargs", {}))
+        # Rebind the identity the launcher assigned, so the channels this
+        # plugin subscribes to in the component process match the ones the
+        # host publishes on
+        if plugin_id := spec.get("id"):
+            plugin._set_id(plugin_id)
+        if frame_id := spec.get("frame_id"):
+            plugin._set_frame_id(frame_id)
+        plugin._bind_identity()
         if bus_endpoint is not None:
             bus = SocketFeedbackBus(bus_endpoint)
             bus.connect()
@@ -334,7 +465,68 @@ class RobotPlugin:
             "commands": [s.asdict() for s in self.list_commands()],
             "actions": [s.asdict() for s in self.list_actions()],
             "events": [s.asdict() for s in self.list_events()],
+            "role": str(self.role),
         }
+
+
+class RobotPlugin(Plugin):
+    """A plugin for the robot itself: what moves, and what drives it.
+
+    Exactly one robot plugin may be attached to a recipe. Beyond the transports
+    and registries every plugin carries, a robot plugin can describe the robot
+    it drives, and every component is configured from that description unless
+    the recipe overrides it.
+    """
+
+    _role: PluginRole = PluginRole.ROBOT
+
+    def _base_init(self, cls: type) -> None:
+        super()._base_init(cls)
+        # Robot geometry and kinematic description
+        self.robot_config: Optional[RobotConfig] = None
+        # Name of the rigid frame attached to the robot body. The world frame
+        # is deliberately absent: where the robot has been placed is described
+        # by the environment, not by the robot.
+        self.base_frame: Optional[str] = None
+
+
+class SensorPlugin(Plugin):
+    """A plugin for a sensor that is not part of the robot's own hardware.
+
+    An inspection camera bolted onto a robot, or a fixed camera watching a
+    room. Several may be attached to one recipe.
+
+    A sensor sits somewhere, so it has a frame. Where that frame sits relative
+    to the robot is the recipe's business (see ``Mount``); the plugin only
+    names it. A sensor with moving parts publishes the dynamic transform from
+    this base frame to the moving one itself -- the recipe then only has to
+    describe the static mount, and the two compose in the TF tree.
+    """
+
+    _role: PluginRole = PluginRole.SENSOR
+
+    def _base_init(self, cls: type) -> None:
+        super()._base_init(cls)
+        # Explicit frame, if the recipe passed ``frame_id=``; otherwise derived
+        # from the plugin id (see the property below).
+        self._frame_id: str = ""
+
+    @property
+    def frame_id(self) -> str:
+        """Name of the frame this sensor's data is expressed in.
+
+        Defaults to ``<id>_frame``, so two instances of the same sensor get
+        distinct frames without the plugin author doing anything.
+        """
+        return self._frame_id or f"{self.id}_frame"
+
+    def _set_frame_id(self, frame_id: str) -> None:
+        """Set an explicit frame. Called from ``__init__`` via ``frame_id=``."""
+        if not isinstance(frame_id, str) or not frame_id:
+            raise ValueError(
+                f"'{frame_id}' is not a usable frame id for plugin '{self.id}'."
+            )
+        self._frame_id = frame_id
 
 
 class RobotPluginHost:
@@ -356,19 +548,27 @@ class RobotPluginHost:
         receives every decoded feedback message — the launcher wires this to
         ``Monitor.feed_external_topic`` so plugin events fire on the same
         machinery as ROS-topic events.
+    :param owns_bus: Whether this host is responsible for starting and closing
+        the bus. Several plugins share one bus, and a shared bus outlives any
+        single host: the second host to open would re-bind the same address,
+        and the first to close would tear the bus down for everyone. The
+        launcher therefore owns the shared bus and passes ``False``. Defaults
+        to ``True`` so a lone host still works standalone.
     """
 
     def __init__(
         self,
-        plugin: RobotPlugin,
+        plugin: Plugin,
         node: Any,
         bus: FeedbackBus,
         monitor_feed: Optional[Callable[[str, Any], None]] = None,
+        owns_bus: bool = True,
     ) -> None:
         self.plugin = plugin
         self.node = node
         self.bus = bus
         self.monitor_feed = monitor_feed
+        self._owns_bus = owns_bus
         self._active = False
         self._keep_alive_threads: List[threading.Thread] = []
         self._keep_alive_stop: Optional[threading.Event] = None
@@ -386,7 +586,8 @@ class RobotPluginHost:
         if self._active:
             return
         self.plugin.set_bus(self.bus)
-        self.bus.start()
+        if self._owns_bus:
+            self.bus.start()
 
         # Open every non-ROS transport (ROS transports are handled by the
         # component's own pub/sub machinery).
@@ -441,7 +642,8 @@ class RobotPluginHost:
                     get_logger(LOGGER_NAME).error(
                         f"Error closing transport '{transport.name}': {e}"
                     )
-        self.bus.close()
+        if self._owns_bus:
+            self.bus.close()
         self._active = False
 
     # internals
@@ -461,9 +663,30 @@ class RobotPluginHost:
             return
         if msg is None:
             return
+        self._stamp_frame(feedback, msg)
         self.bus.publish(feedback.channel, serialize_message(msg))
         if self.monitor_feed is not None:
             self.monitor_feed(feedback.channel, msg)
+
+    def _stamp_frame(self, feedback: Feedback, msg: Any) -> None:
+        """Stamp a decoded message with the frame its data is in.
+
+        Components look up ``header.frame_id -> robot base`` to place incoming
+        data, so an unstamped message is silently never transformed. Rather
+        than making every plugin author hard-code frame names in their
+        decoders, the frame is taken from the feedback (or the plugin) and
+        applied here.
+
+        An author who stamps the message themselves is never overridden: a
+        robot's odometry is in the localization frame, not in a frame attached
+        to the robot's body, and only the decoder knows that.
+        """
+        header = getattr(msg, "header", None)
+        if header is None or getattr(header, "frame_id", None):
+            return
+        frame_id = feedback.frame_id or getattr(self.plugin, "frame_id", "")
+        if frame_id:
+            header.frame_id = frame_id
 
     def _forward_command(self, command: RobotCommand, payload: bytes) -> None:
         """Host-side handler for ``route_via_host`` commands."""

--- a/ros_sugar/robot/plugin.py
+++ b/ros_sugar/robot/plugin.py
@@ -142,7 +142,14 @@ class Plugin:
             # reset the registries to their base defaults.
             if not hasattr(self, "_init_kwargs"):
                 explicit_id = kw.pop("id", None)
-                explicit_frame = kw.pop("frame_id", None)
+                # Only a sensor has a frame of its own. Leaving the kwarg in
+                # place for anything else lets the wrapped __init__ raise
+                # Python's own unexpected-keyword TypeError
+                explicit_frame = (
+                    kw.pop("frame_id", None)
+                    if isinstance(self, SensorPlugin)
+                    else None
+                )
                 try:
                     bound = sig.bind(self, *args, **kw)
                     bound.apply_defaults()

--- a/ros_sugar/robot/plugin.py
+++ b/ros_sugar/robot/plugin.py
@@ -23,7 +23,7 @@ from attrs import define, field
 from rclpy.logging import get_logger
 from rclpy.serialization import deserialize_message, serialize_message
 
-from ..config import BaseAttrs
+from ..config import BaseAttrs, RobotConfig
 from .bus import LOGGER_NAME, BusHandle, FeedbackBus, SocketFeedbackBus
 from .command import CommandSpec, RobotCommand
 from .feedback import Feedback, FeedbackSpec
@@ -110,6 +110,10 @@ class RobotPlugin:
         self.commands: Dict[str, RobotCommand] = {}
         self.actions: ActionRegistry = ActionRegistry({})
         self.events: EventRegistry = EventRegistry({})
+        # Robot geometry and kinematic description
+        self.robot_config: Optional[RobotConfig] = None
+        # Name of the rigid frame attached to the robot body
+        self.base_frame: Optional[str] = None
         self.metadata: PluginMetadata = getattr(
             cls, "metadata", None
         ) or PluginMetadata(name=cls.__name__)

--- a/ros_sugar/robot/plugin.py
+++ b/ros_sugar/robot/plugin.py
@@ -58,7 +58,7 @@ class PluginMetadata(BaseAttrs):
 
 
 #: Plugin ids end up inside ROS topic names, which reject hyphens, dots and
-#: leading digits -- and would do so at activation, long after the recipe ran.
+#: leading digits at activation.
 _VALID_PLUGIN_ID = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
@@ -88,9 +88,9 @@ def _is_ros_transport(transport: Transport) -> bool:
 class PluginRole(StrEnum):
     """What a plugin represents in a recipe.
 
-    The role is intrinsic to the plugin, to determine its type: a robot or a sensor. The launcher uses it to
-    enforce that a recipe describes exactly one robot, and to decide what each
-    plugin is allowed to contribute to the components.
+    The role is intrinsic to the plugin, to determine its type: a robot or a sensor.
+    The launcher uses it to enforce that a recipe describes exactly one robot, and
+    to decide what each plugin is allowed to contribute to the components.
 
     """
 
@@ -106,23 +106,22 @@ class Plugin:
     """
 
     #: Overridden by each role base class below. A plugin that subclasses
-    #: ``Plugin`` directly is treated as a sensor: something that contributes
+    #: ``Plugin`` directly is treated as a sensor i.e something that contributes
     #: feedback and commands but describes no robot.
     _role: PluginRole = PluginRole.SENSOR
 
     @property
     def role(self) -> PluginRole:
-        """What this plugin represents -- read-only.
+        """What this plugin represents. Read-only.
 
         A plugin *is* a robot or a sensor by construction, so the role follows
-        from the base class the author subclassed and cannot be reassigned by
-        a recipe.
+        from the base class the author subclassed.
         """
         return self._role
 
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)
-        # The role base classes in this module are part of the framework, not
+        # NOTE: The role base classes in this module are part of the framework, not
         # user plugins. Leaving their __init__ unwrapped means a user subclass
         # that defines no __init__ of its own still gets wrapped against
         # itself, and so reports its own name rather than its base's.
@@ -142,7 +141,7 @@ class Plugin:
             # reset the registries to their base defaults.
             if not hasattr(self, "_init_kwargs"):
                 explicit_id = kw.pop("id", None)
-                # Only a sensor has a frame of its own. Leaving the kwarg in
+                # NOTE: Only a sensor has a frame of its own. Leaving the kwarg in
                 # place for anything else lets the wrapped __init__ raise
                 # Python's own unexpected-keyword TypeError
                 explicit_frame = (
@@ -218,9 +217,6 @@ class Plugin:
 
     def _bind_identity(self) -> None:
         """Namespace this plugin's channels by its id, once it is attached.
-
-        Channels stay in their un-namespaced form until this runs, so a plugin
-        used standalone behaves exactly as it did before ids existed.
 
         :raises ValueError: If a feedback topic was already handed out under a
             different id.
@@ -496,7 +492,7 @@ class Plugin:
 
 
 class RobotPlugin(Plugin):
-    """A plugin for the robot itself: what moves, and what drives it.
+    """A plugin for the robot itself. What moves, and what drives it.
 
     Exactly one robot plugin may be attached to a recipe. Beyond the transports
     and registries every plugin carries, a robot plugin can describe the robot
@@ -525,7 +521,7 @@ class SensorPlugin(Plugin):
     A sensor sits somewhere, so it has a frame. Where that frame sits relative
     to the robot is the recipe's business (see ``Mount``); the plugin only
     names it. A sensor with moving parts publishes the dynamic transform from
-    this base frame to the moving one itself -- the recipe then only has to
+    this base frame to the moving one itself. The recipe then only has to
     describe the static mount, and the two compose in the TF tree.
     """
 

--- a/ros_sugar/tf.py
+++ b/ros_sugar/tf.py
@@ -6,7 +6,12 @@ from attrs import define, field
 from rclpy.logging import get_logger
 from rclpy.time import Time
 from rclpy.timer import Timer
-from tf2_ros import ConnectivityException, ExtrapolationException, LookupException
+from tf2_ros import (
+    ConnectivityException,
+    ExtrapolationException,
+    LookupException,
+    TransformStamped,
+)
 from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener
 
@@ -69,6 +74,32 @@ class TFListener:
         # result
         self.transform = None
         self.got_transform = False
+
+        # Source and goal being the same frame is a normal configuration, not a
+        # missing transform: it means the data already arrives where it is
+        # wanted. Resolve it to the identity up front so nothing waits on, or
+        # warns about, a lookup that would only ever return the identity.
+        if self.is_identity:
+            self.transform = TransformStamped()
+            self.transform.header.frame_id = tf_config.goal_frame
+            self.transform.child_frame_id = tf_config.source_frame
+            self.transform.transform.rotation.w = 1.0
+            self.got_transform = True
+
+    @property
+    def is_identity(self) -> bool:
+        """Whether this listener resolves without any TF lookup.
+
+        True when source and goal are the same frame, in which case the
+        transform is the identity and no timer needs to run.
+
+        :return: Whether the lookup is a no-op
+        :rtype: bool
+        """
+        return bool(
+            self.config.source_frame
+            and self.config.source_frame == self.config.goal_frame
+        )
 
     @property
     def translation(self) -> Optional[np.ndarray]:

--- a/ros_sugar/ui_node/static/video_manager.js
+++ b/ros_sugar/ui_node/static/video_manager.js
@@ -19,10 +19,15 @@ document.addEventListener("DOMContentLoaded", () => {
         };
 
         ws.onmessage = (event) => {
+            // NOTE: Resolve the target element by id at message time: a DOM swap
+            // (e.g. an htmx panel re-render on goal send) can replace the
+            // node while keeping its id — the connect-time `img` reference
+            // then points at a detached node and frames render into the void.
+            const el = document.getElementById(img.id) || img;
             try {
                 const data = JSON.parse(event.data);
                 if (data.payload) {
-                    img.src = "data:image/jpeg;base64," + data.payload;
+                    el.src = "data:image/jpeg;base64," + data.payload;
                     return;
                 }
             } catch {
@@ -33,7 +38,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 const bytes = new Uint8Array(event.data);
                 let binary = '';
                 bytes.forEach(b => binary += String.fromCharCode(b));
-                img.src = "data:image/jpeg;base64," + btoa(binary);
+                el.src = "data:image/jpeg;base64," + btoa(binary);
             }
         };
 

--- a/ros_sugar/ui_node/static/video_manager.js
+++ b/ros_sugar/ui_node/static/video_manager.js
@@ -10,6 +10,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Create connection for a given <img> element
     function connectImageWebSocket(img, wsUrl, attempt = 0) {
+        // Stamp the element so the ensure-pass can detect DOM swaps: a
+        // replacement node (same id, e.g. after an htmx panel update) won't
+        // carry this property.
+        img._videoStreamBound = true;
         const ws = new WebSocket(wsUrl);
         ws.binaryType = "arraybuffer";
 
@@ -77,14 +81,29 @@ document.addEventListener("DOMContentLoaded", () => {
         const frames = Array.from(document.getElementsByName("video-frame"));
         const presentIds = new Set(frames.map(f => f.id));
 
-        // Add missing connections
+        // Add missing connections; re-init swapped elements (same id, new
+        // node — the element won't carry the _videoStreamBound stamp)
         frames.forEach((img) => {
             if (!img.id) return;
-            if (!wsConnections.has(img.id)) {
-                const wsUrl = `${videoWsProtocol}//${window.location.host}/api/outputs/${img.id}`;
-                const conn = connectImageWebSocket(img, wsUrl, 0);
-                wsConnections.set(img.id, conn);
+            const tracked = wsConnections.has(img.id);
+            if (tracked && img._videoStreamBound) return; // same element, connected
+            if (tracked) {
+                // A swap happened: clean up the old connection and re-init on
+                // the new element
+                const entry = wsConnections.get(img.id);
+                try {
+                    if (entry.timer) clearTimeout(entry.timer);
+                    if (entry.ws) {
+                        entry.ws.onclose = null;
+                        entry.ws.close();
+                    }
+                } catch (e) { }
+                wsConnections.delete(img.id);
+                console.log(`[${img.id}] Element swapped; rebinding stream to new node`);
             }
+            const wsUrl = `${videoWsProtocol}//${window.location.host}/api/outputs/${img.id}`;
+            const conn = connectImageWebSocket(img, wsUrl, 0);
+            wsConnections.set(img.id, conn);
         });
 
         // Remove connections whose elements are gone

--- a/test/base_attrs_test.py
+++ b/test/base_attrs_test.py
@@ -11,7 +11,7 @@ import numpy as np
 import pytest
 from attrs import define, field
 
-from ros_sugar.config.base_attrs import BaseAttrs
+from ros_sugar.config.base_attrs import BaseAttrs, explicit_fields
 from ros_sugar.config import base_validators
 
 
@@ -261,3 +261,127 @@ def test_from_file_json_happy_path(tmp_path):
     assert ok is True
     assert cfg.rate == 77.0
     assert cfg.name == "json-cfg"
+
+
+# ---- explicit_fields / asdict_explicit ------------------------------------
+
+
+def test_explicit_fields_keeps_only_what_differs_from_the_defaults():
+    """A full asdict cannot tell a caller's choice from a class default, so
+    writing it back reverts whatever its consumer set for itself."""
+    assert explicit_fields(SampleCfg()) == {}
+    assert explicit_fields(SampleCfg(rate=42.0)) == {"rate": 42.0}
+
+
+def test_explicit_fields_is_json_safe():
+    """These dicts are serialized to configure launched components, and a
+    numpy field used to make json.dumps raise."""
+    stored = explicit_fields(SampleCfg(array=np.array([1.0, 2.0])))
+    assert stored == {"array": [1.0, 2.0]}
+    json.dumps(stored)
+
+
+def test_explicit_fields_does_not_flag_an_untouched_array():
+    """np.ndarray == np.ndarray is an array, not a bool, so the default
+    comparison needs to handle it or every array field looks changed."""
+    assert "array" not in explicit_fields(SampleCfg())
+
+
+def test_explicit_fields_survives_a_json_round_trip():
+    stored = explicit_fields(SampleCfg(rate=42.0, array=np.array([1.0, 2.0])))
+    cfg = SampleCfg()
+    cfg.from_dict(json.loads(json.dumps(stored)))
+    assert cfg.rate == 42.0
+    assert isinstance(cfg.array, np.ndarray)
+    assert cfg.array.tolist() == [1.0, 2.0]
+
+
+def test_explicit_fields_does_not_overwrite_values_set_by_the_consumer():
+    """The bug this exists for: a partial dict must leave alone the fields a
+    consumer filled in for itself."""
+    stored = explicit_fields(SampleCfg(rate=42.0))
+
+    cfg = SampleCfg(array=np.array([9.0, 9.0]))  # set by the consumer
+    cfg.from_dict(stored)
+
+    assert cfg.rate == 42.0, "the caller's override must still apply"
+    assert cfg.array.tolist() == [9.0, 9.0], "consumer's value was reverted"
+
+
+def test_explicit_fields_accepts_any_attrs_class():
+    """Algorithm configs come from whichever library implements the algorithm
+    and need not derive from this package's BaseAttrs."""
+
+    @define(kw_only=True)
+    class Foreign:
+        value: int = field(default=3)
+
+    assert explicit_fields(Foreign()) == {}
+    assert explicit_fields(Foreign(value=7)) == {"value": 7}
+
+
+def test_explicit_fields_falls_back_when_not_default_constructible():
+    @define(kw_only=True)
+    class NeedsArgs:
+        required: int = field()
+
+    assert explicit_fields(NeedsArgs(required=5)) == {"required": 5}
+
+
+def test_asdict_explicit_method_matches_the_helper():
+    cfg = SampleCfg(rate=42.0)
+    assert cfg.asdict_explicit() == explicit_fields(cfg)
+
+
+def test_from_dict_preserves_the_ndarray_dtype():
+    """JSON turns a float32 array into Python floats; reading them back
+    without a dtype silently widens the field to float64."""
+
+    @define(kw_only=True)
+    class Float32Cfg(BaseAttrs):
+        array: np.ndarray = field(default=np.zeros(3, dtype=np.float32))
+
+    cfg = Float32Cfg()
+    cfg.from_dict({"array": [0.5, 0.0, 0.9]})
+    assert cfg.array.dtype == np.float32
+
+
+def test_explicit_fields_descends_into_nested_configs():
+    """One changed sub-field must not drag its siblings' defaults with it:
+    from_dict recurses into nested attrs, so a full nested dict would write
+    those defaults back over whatever the consumer set."""
+    cfg = SampleCfg()
+    cfg.nested.count = 7
+
+    assert explicit_fields(cfg) == {"nested": {"count": 7}}
+
+
+def test_explicit_fields_drops_an_untouched_nested_config():
+    assert "nested" not in explicit_fields(SampleCfg(rate=1.0))
+
+
+def test_nested_diff_does_not_overwrite_a_consumer_value():
+    cfg = SampleCfg()
+    cfg.nested.count = 7
+    stored = explicit_fields(cfg)
+
+    target = SampleCfg()
+    target.nested.label = "set-by-consumer"
+    target.from_dict(stored)
+
+    assert target.nested.count == 7, "the caller's override must still apply"
+    assert target.nested.label == "set-by-consumer", "nested value was reverted"
+
+
+def test_explicit_fields_keeps_a_plain_dict_field_whole():
+    """from_dict assigns a non-attrs dict wholesale, so diffing inside one
+    would silently drop the keys that happened to match the default."""
+
+    @define(kw_only=True)
+    class WithPlainDict(BaseAttrs):
+        mapping: dict = field(factory=lambda: {"a": 1, "b": 2})
+
+    cfg = WithPlainDict()
+    cfg.mapping = {"a": 5, "b": 2}
+
+    assert explicit_fields(cfg) == {"mapping": {"a": 5, "b": 2}}

--- a/test/io_types_test.py
+++ b/test/io_types_test.py
@@ -12,6 +12,8 @@ Sections, one per message type:
 - MultiArray: layout-driven reshaping
 - Image: raw buffer decoding
 - Path: UI downsampling
+- Zero-copy contract: dtype/contiguity the kompass-core bindings map
+  without copying
 """
 
 from typing import List, Optional, Tuple
@@ -1006,3 +1008,99 @@ def test_empty_path_transform_returns_an_empty_path():
     path = _transformed_path(_make_path([]), transformation=_tf((1.0, 1.0, 0.0)))
     assert path.poses == []
     assert path.header.frame_id == "base_link"
+
+
+# ---------------------------------------------------------------------------
+# Zero-copy contract
+# ---------------------------------------------------------------------------
+# kompass-core's bindings map these arrays without copying only when they
+# arrive as float32 (scan vectors, Nx3 cartesian points) or uint8 (raw cloud
+# buffers), C-contiguous. Anything else is converted silently with a per-call
+# copy, so a dtype drift here never fails downstream -- it just quietly costs
+# the optimization. These tests pin the contract on the producer side.
+
+
+def _assert_scan_hot_arrays(data: LaserScanData):
+    for name in ("ranges", "angles"):
+        array = getattr(data, name)
+        assert array.dtype == np.float32, f"{name} must stay float32"
+        assert array.flags["C_CONTIGUOUS"], f"{name} must stay contiguous"
+
+
+def _assert_cartesian_points(xyz: np.ndarray):
+    assert xyz.dtype == np.float32, "points must stay float32"
+    assert xyz.ndim == 2 and xyz.shape[1] == 3, "points must be an Nx3 array"
+    assert xyz.flags["C_CONTIGUOUS"], "points must stay row-major contiguous"
+
+
+def _assert_raw_cloud_buffer(data: np.ndarray):
+    assert data.dtype == np.uint8, "raw cloud buffer must stay uint8"
+    assert data.ndim == 1, "raw cloud buffer must stay flat"
+    assert data.flags["C_CONTIGUOUS"], "raw cloud buffer must stay contiguous"
+
+
+def test_zero_copy_scan_from_message():
+    output = _scan_callback(_make_scan([1.0, np.nan, 2.5])).get_output()
+    _assert_scan_hot_arrays(output)
+
+
+def test_zero_copy_scan_survives_polar_transform():
+    output = _scan_callback(
+        _make_scan([1.0, 2.0, 3.0]),
+        transformation=_make_transform(x=0.5, yaw=np.pi / 3),
+    ).get_output()
+    _assert_scan_hot_arrays(output)
+
+
+def test_zero_copy_scan_container_generated_arrays():
+    # Both the generated angles and the default max-range fill
+    data = LaserScanData(angle_min=0.0, angle_max=np.pi, angle_increment=np.pi / 4)
+    _assert_scan_hot_arrays(data)
+
+
+def test_zero_copy_cloud_raw_buffer():
+    output = _cloud_output(_make_cloud(CLOUD_POINTS, point_padding=4))
+    _assert_raw_cloud_buffer(output.data)
+
+
+def test_zero_copy_cloud_filtered_buffer():
+    # The rebuilt buffer feeds the same raw-buffer consumers as the original
+    output = _filtered(_make_cloud([(1.0, 0.0, 0.5), (2.0, 0.0, 9.0)]), max_z=1.0)
+    _assert_raw_cloud_buffer(output.data)
+
+
+def test_zero_copy_cloud_xyz():
+    _assert_cartesian_points(_cloud_output(_make_cloud(CLOUD_POINTS)).xyz)
+
+
+def test_zero_copy_cloud_xyz_from_float64_source():
+    # A float64 cloud decodes once into the float32 the bindings map
+    output = _cloud_output(_make_cloud(CLOUD_POINTS, np_type=np.float64))
+    _assert_cartesian_points(output.xyz)
+
+
+def test_zero_copy_cloud_xyz_survives_transform():
+    quarter_turn = (0.0, 0.0, math.sin(math.pi / 4), math.cos(math.pi / 4))
+    output = _filtered(
+        _make_cloud(CLOUD_POINTS),
+        transformation=_tf((0.5, -1.0, 0.25), quarter_turn),
+    )
+    _assert_cartesian_points(output.xyz)
+
+
+def test_zero_copy_grid_obstacles():
+    callback = _fed_callback(
+        OccupancyGridCallback, "OccupancyGrid", _occupied_grid_at(2, 1)
+    )
+    _assert_cartesian_points(callback.get_output())
+
+
+def test_zero_copy_grid_obstacles_survive_transform():
+    quarter_turn = (0.0, 0.0, math.sin(math.pi / 4), math.cos(math.pi / 4))
+    callback = _fed_callback(
+        OccupancyGridCallback, "OccupancyGrid", _occupied_grid_at(2, 1)
+    )
+    output = callback.get_output(
+        transformation=_tf((1.0, 2.0, 0.0), quarter_turn)
+    )
+    _assert_cartesian_points(output)

--- a/test/io_types_test.py
+++ b/test/io_types_test.py
@@ -16,6 +16,7 @@ Sections, one per message type:
 
 from typing import List, Optional, Tuple
 
+import math
 import base64
 import numpy as np
 import pytest
@@ -206,6 +207,190 @@ def test_cloud_ui_content():
 
 
 # ---------------------------------------------------------------------------
+# PointCloud2 filtering and transformation (issue #59)
+# ---------------------------------------------------------------------------
+
+
+def _tf(
+    translation=(0.0, 0.0, 0.0), rotation=(0.0, 0.0, 0.0, 1.0), frame_id="base_link"
+) -> TransformStamped:
+    transform = TransformStamped()
+    transform.header.frame_id = frame_id
+    (
+        transform.transform.translation.x,
+        transform.transform.translation.y,
+        transform.transform.translation.z,
+    ) = translation
+    (
+        transform.transform.rotation.x,
+        transform.transform.rotation.y,
+        transform.transform.rotation.z,
+        transform.transform.rotation.w,
+    ) = rotation
+    return transform
+
+
+def _filtered(msg, **kwargs) -> Optional[PointCloudData]:
+    return _fed_callback(PointCloudCallback, "PointCloud2", msg).get_output(**kwargs)
+
+
+def test_cloud_rejects_unknown_kwargs():
+    """The silent-swallow this issue is about: an unrecognised filter name must
+    not quietly return an unfiltered cloud."""
+    with pytest.raises(TypeError):
+        _filtered(_make_cloud(CLOUD_POINTS), not_a_filter=True)
+
+
+def test_cloud_unfiltered_request_returns_the_raw_buffer():
+    """Asking for nothing must stay free: same buffer, nothing decoded."""
+    msg = _make_cloud(CLOUD_POINTS)
+    pc = _filtered(msg)
+    assert pc is not None
+    assert pc.width == 4 and pc.height == 1
+    assert pc.frame_id == "lidar_link"
+    assert bytes(pc.data) == bytes(msg.data)
+
+
+def test_cloud_z_band_filter():
+    points = [(1.0, 0.0, -0.5), (1.0, 0.0, 0.1), (1.0, 0.0, 0.9), (1.0, 0.0, 5.0)]
+    pc = _filtered(_make_cloud(points), min_z=0.0, max_z=1.0)
+    assert pc is not None
+    assert pc.width == 2
+    np.testing.assert_allclose(pc.xyz[:, 2], [0.1, 0.9], atol=1e-6)
+
+
+def test_cloud_filtering_rewrites_the_raw_buffer():
+    """Raw-buffer consumers (collision checking) must see the filtered cloud,
+    not just users of the decoded `xyz`."""
+    points = [(1.0, 0.0, -0.5), (2.0, 0.0, 0.5), (3.0, 0.0, 9.0)]
+    pc = _filtered(_make_cloud(points), min_z=0.0, max_z=1.0)
+    assert pc is not None
+    assert pc.width == 1 and pc.height == 1
+    assert pc.row_step == pc.width * pc.point_step
+    assert len(pc.data) == pc.width * pc.point_step
+    # decoded straight from the rebuilt buffer, bypassing the cache
+    rebuilt = PointCloudData(
+        data=pc.data,
+        point_step=pc.point_step,
+        row_step=pc.row_step,
+        height=pc.height,
+        width=pc.width,
+        x_offset=pc.x_offset,
+        y_offset=pc.y_offset,
+        z_offset=pc.z_offset,
+        x_field_datatype=pc.x_field_datatype,
+    )
+    np.testing.assert_allclose(rebuilt.xyz, [[2.0, 0.0, 0.5]], atol=1e-6)
+
+
+def test_cloud_filtering_preserves_other_fields():
+    """Whole records are kept, so padding/intensity bytes survive intact."""
+    points = [(1.0, 0.0, 0.5), (2.0, 0.0, 9.0)]
+    msg = _make_cloud(points, point_padding=4)
+    original = bytes(msg.data)
+    pc = _filtered(msg, max_z=1.0)
+    assert pc is not None and pc.width == 1
+    assert pc.point_step == 16
+    # trailing 4 padding bytes of the surviving record are carried over
+    assert bytes(pc.data)[12:16] == original[12:16]
+
+
+def test_cloud_translation_is_applied():
+    pc = _filtered(_make_cloud([(1.0, 2.0, 3.0)]), transformation=_tf((0.5, 0.0, 0.25)))
+    assert pc is not None
+    np.testing.assert_allclose(pc.xyz, [[1.5, 2.0, 3.25]], atol=1e-6)
+    assert pc.frame_id == "base_link", "cloud must report the frame it now sits in"
+
+
+def test_cloud_rotation_is_applied():
+    """90 degrees about z: (1, 0, 0) -> (0, 1, 0)."""
+    quarter_turn = (0.0, 0.0, math.sin(math.pi / 4), math.cos(math.pi / 4))
+    pc = _filtered(
+        _make_cloud([(1.0, 0.0, 0.0)]), transformation=_tf(rotation=quarter_turn)
+    )
+    assert pc is not None
+    np.testing.assert_allclose(pc.xyz, [[0.0, 1.0, 0.0]], atol=1e-6)
+
+
+def test_cloud_transform_set_on_the_callback_is_used():
+    """A component calling transform_input_to sets it on the callback, not per
+    call -- that path was the silent no-op."""
+    callback = _fed_callback(
+        PointCloudCallback, "PointCloud2", _make_cloud([(1.0, 2.0, 3.0)])
+    )
+    callback.transformation = _tf((0.0, 0.0, 1.0))
+    pc = callback.get_output()
+    assert pc is not None
+    np.testing.assert_allclose(pc.xyz, [[1.0, 2.0, 4.0]], atol=1e-6)
+
+
+def test_cloud_discard_underground_uses_the_mount_height():
+    """The sensor sits 0.2 above the body, so ground is z = -0.2 in the sensor
+    frame and z = 0 once transformed."""
+    points = [(1.0, 0.0, -0.25), (1.0, 0.0, -0.15), (1.0, 0.0, 0.5)]
+    pc = _filtered(
+        _make_cloud(points),
+        transformation=_tf((0.0, 0.0, 0.2)),
+        discard_underground=True,
+    )
+    assert pc is not None
+    assert pc.width == 2, "only the point below the ground plane is dropped"
+    np.testing.assert_allclose(pc.xyz[:, 2], [0.05, 0.7], atol=1e-6)
+
+
+def test_cloud_discard_underground_without_a_transform_is_ignored():
+    points = [(1.0, 0.0, -0.5), (1.0, 0.0, 0.5)]
+    pc = _filtered(_make_cloud(points), discard_underground=True)
+    assert pc is not None
+    assert pc.width == 2, "the ground cannot be located, so nothing is dropped"
+
+
+def test_cloud_get_2d_flattens_after_filtering():
+    points = [(1.0, 0.0, 0.9), (2.0, 0.0, 5.0)]
+    pc = _filtered(_make_cloud(points), max_z=1.0, get_2d=True)
+    assert pc is not None
+    assert pc.width == 1, "the height filter still sees the real z"
+    np.testing.assert_allclose(pc.xyz, [[1.0, 0.0, 0.0]], atol=1e-6)
+
+
+def test_cloud_filtering_everything_out_returns_none():
+    pc = _filtered(_make_cloud([(1.0, 0.0, 5.0)]), max_z=1.0)
+    assert pc is None
+
+
+def test_cloud_filter_drops_non_finite_points():
+    points = [(1.0, 0.0, 0.5), (float("nan"), 0.0, 0.5), (float("inf"), 0.0, 0.5)]
+    pc = _filtered(_make_cloud(points), max_z=1.0)
+    assert pc is not None
+    assert pc.width == 1
+
+
+def test_cloud_filter_handles_row_padding():
+    """Organized clouds pad each row; the mask must still line up with records."""
+    points = [(1.0, 0.0, 0.5), (2.0, 0.0, 9.0), (3.0, 0.0, 0.7), (4.0, 0.0, 9.0)]
+    pc = _filtered(_make_cloud(points, height=2, row_padding=8), max_z=1.0)
+    assert pc is not None
+    np.testing.assert_allclose(pc.xyz[:, 0], [1.0, 3.0], atol=1e-6)
+
+
+def test_cloud_filter_handles_big_endian_and_float64():
+    points = [(1.0, 0.0, 0.5), (2.0, 0.0, 9.0)]
+    pc = _filtered(
+        _make_cloud(points, np_type=np.float64, bigendian=True),
+        transformation=_tf((1.0, 0.0, 0.0)),
+        max_z=1.0,
+    )
+    assert pc is not None
+    assert pc.is_bigendian
+    np.testing.assert_allclose(pc.xyz, [[2.0, 0.0, 0.5]], atol=1e-6)
+
+
+def test_cloud_filter_without_xyz_fields_returns_none():
+    msg = _make_cloud(CLOUD_POINTS, drop_fields=["z"])
+    assert _filtered(msg, max_z=1.0) is None
+
+
+# ---------------------------------------------------------------------------
 # LaserScan
 # ---------------------------------------------------------------------------
 
@@ -307,6 +492,14 @@ def test_scan_transform_via_get_output_kwarg():
         [1.0, 2.0, 3.0],
         rtol=1e-6,
     )
+
+
+def test_scan_rejects_unknown_kwargs():
+    """Same contract as the point cloud: an unrecognised argument is a caller
+    bug, not something to swallow and return unprocessed data for."""
+    callback = _scan_callback(_make_scan([1.0, 2.0, 3.0]))
+    with pytest.raises(TypeError):
+        callback.get_output(min_z=0.0)
 
 
 def test_scan_degenerate():
@@ -648,3 +841,78 @@ def test_path_ui_content_downsampling():
     content = _fed_callback(PathCallback, "Path", msg)._get_ui_content()
     assert content["frame_id"] == "map"
     assert content["data"] == [0.0, 0.0, 0.2, 0.0, 1.0, 0.0]
+
+
+def _make_path(poses: List[Tuple[float, float]], frame_id="odom") -> Path:
+    msg = Path()
+    msg.header.frame_id = frame_id
+    for x, y in poses:
+        pose = PoseStamped()
+        pose.header.frame_id = frame_id
+        pose.pose.position.x = x
+        pose.pose.position.y = y
+        pose.pose.orientation.w = 1.0
+        msg.poses.append(pose)
+    return msg
+
+
+def _transformed_path(msg, **kwargs) -> Optional[Path]:
+    return _fed_callback(PathCallback, "Path", msg).get_output(**kwargs)
+
+
+def test_path_without_a_transform_is_handed_back_untouched():
+    """No transform asked for must stay free: the same message, not a copy."""
+    msg = _make_path([(1.0, 2.0)])
+    assert _transformed_path(msg) is msg
+
+
+def test_path_already_in_the_goal_frame_is_not_rebuilt():
+    """A transform onto the frame the path is already in is an identity, so
+    rebuilding hundreds of poses would be pure waste."""
+    msg = _make_path([(1.0, 2.0)], frame_id="map")
+    assert _transformed_path(msg, transformation=_tf(frame_id="map")) is msg
+
+
+def test_path_translation_is_applied():
+    path = _transformed_path(
+        _make_path([(1.0, 2.0), (3.0, 4.0)]), transformation=_tf((0.5, -1.0, 0.0))
+    )
+    positions = [(p.pose.position.x, p.pose.position.y) for p in path.poses]
+    assert positions == pytest.approx([(1.5, 1.0), (3.5, 3.0)])
+
+
+def test_path_rotation_is_applied_to_positions_and_headings():
+    quarter_turn = (0.0, 0.0, math.sin(math.pi / 4), math.cos(math.pi / 4))
+    path = _transformed_path(
+        _make_path([(1.0, 0.0), (2.0, 0.0)]),
+        transformation=_tf((5.0, 1.0, 0.0), quarter_turn),
+    )
+    positions = [(p.pose.position.x, p.pose.position.y) for p in path.poses]
+    assert positions == pytest.approx([(5.0, 2.0), (5.0, 3.0)])
+    # a pose facing +x in the source frame must face +y after a quarter turn
+    heading = 2 * math.atan2(
+        path.poses[0].pose.orientation.z, path.poses[0].pose.orientation.w
+    )
+    assert heading == pytest.approx(math.pi / 2)
+
+
+def test_path_transform_relabels_every_frame_to_the_goal():
+    path = _transformed_path(
+        _make_path([(1.0, 0.0)]), transformation=_tf(frame_id="map")
+    )
+    assert path.header.frame_id == "map"
+    assert all(pose.header.frame_id == "map" for pose in path.poses)
+
+
+def test_path_transform_set_on_the_callback_is_used():
+    """A component calling transform_input_to sets it on the callback, not per
+    get_output call."""
+    callback = _fed_callback(PathCallback, "Path", _make_path([(1.0, 0.0)]))
+    callback.transformation = _tf((0.0, 3.0, 0.0))
+    assert callback.get_output().poses[0].pose.position.y == pytest.approx(3.0)
+
+
+def test_empty_path_transform_returns_an_empty_path():
+    path = _transformed_path(_make_path([]), transformation=_tf((1.0, 1.0, 0.0)))
+    assert path.poses == []
+    assert path.header.frame_id == "base_link"

--- a/test/io_types_test.py
+++ b/test/io_types_test.py
@@ -757,6 +757,96 @@ def test_grid_obstacles_in_world_frame():
     )
 
 
+def _occupied_grid_at(x: int, y: int, **kwargs) -> OccupancyGrid:
+    """A 3x2 grid whose only occupied cell sits at grid position (x, y)."""
+    data = [0] * 6
+    data[y * 3 + x] = 100
+    return _make_grid(data, width=3, height=2, **kwargs)
+
+
+def test_grid_without_a_transform_stays_in_the_map_frame():
+    callback = _fed_callback(
+        OccupancyGridCallback, "OccupancyGrid", _occupied_grid_at(2, 1)
+    )
+    np.testing.assert_allclose(callback.get_output(get_three_d=False), [[2.5, 1.5]])
+
+
+def test_grid_already_in_the_goal_frame_is_not_transformed():
+    """The origin still applies -- it is the message's own geometry -- but a
+    transform onto the frame the grid is already in must be a no-op."""
+    callback = _fed_callback(
+        OccupancyGridCallback, "OccupancyGrid", _occupied_grid_at(2, 1)
+    )
+    np.testing.assert_allclose(
+        callback.get_output(get_three_d=False, transformation=_tf((9.0, 9.0, 9.0),
+                                                                 frame_id="map")),
+        [[2.5, 1.5]],
+    )
+
+
+def test_grid_transform_is_applied_after_the_origin():
+    # origin puts the cell at (3.5, 3.5); the transform then shifts it
+    msg = _occupied_grid_at(2, 1, origin_x=1.0, origin_y=2.0)
+    callback = _fed_callback(OccupancyGridCallback, "OccupancyGrid", msg)
+    np.testing.assert_allclose(
+        callback.get_output(get_three_d=False, transformation=_tf((0.5, -1.0, 0.0))),
+        [[4.0, 2.5]],
+    )
+
+
+def test_grid_transform_rotation_is_applied():
+    quarter_turn = (0.0, 0.0, math.sin(math.pi / 4), math.cos(math.pi / 4))
+    callback = _fed_callback(
+        OccupancyGridCallback, "OccupancyGrid", _occupied_grid_at(2, 1)
+    )
+    # origin leaves the cell at (2.5, 1.5); a quarter turn sends it to (-1.5, 2.5)
+    np.testing.assert_allclose(
+        callback.get_output(
+            get_three_d=False, transformation=_tf((0.0, 0.0, 0.0), quarter_turn)
+        ),
+        [[-1.5, 2.5]],
+        atol=1e-6,
+    )
+
+
+def test_grid_transform_carries_the_padded_height_in_3d():
+    callback = _fed_callback(
+        OccupancyGridCallback, "OccupancyGrid", _occupied_grid_at(2, 1)
+    )
+    output = callback.get_output(transformation=_tf((0.0, 0.0, 0.25)))
+    np.testing.assert_allclose(output, [[2.5, 1.5, 0.26]])
+    assert output.flags["C_CONTIGUOUS"]
+
+
+def test_grid_transform_set_on_the_callback_is_used():
+    """A component calling transform_input_to sets it on the callback, not per
+    get_output call."""
+    callback = _fed_callback(
+        OccupancyGridCallback, "OccupancyGrid", _occupied_grid_at(2, 1)
+    )
+    callback.transformation = _tf((0.0, 4.0, 0.0))
+    np.testing.assert_allclose(callback.get_output(get_three_d=False), [[2.5, 5.5]])
+
+
+def test_grid_transform_leaves_metadata_and_raw_grid_alone():
+    msg = _occupied_grid_at(2, 1, origin_x=1.0, origin_y=2.0)
+    callback = _fed_callback(OccupancyGridCallback, "OccupancyGrid", msg)
+    callback.transformation = _tf((5.0, 5.0, 0.0))
+    metadata = callback.get_output(get_metadata=True)
+    assert metadata["origin_x"] == pytest.approx(1.0)
+    assert metadata["origin_y"] == pytest.approx(2.0)
+    assert callback.get_output(get_obstacles=False).shape == (3, 2)
+
+
+def test_grid_rejects_unknown_kwargs():
+    """A misspelled filter must not quietly return an untransformed grid."""
+    callback = _fed_callback(
+        OccupancyGridCallback, "OccupancyGrid", _occupied_grid_at(2, 1)
+    )
+    with pytest.raises(TypeError):
+        callback.get_output(get_threed=False)
+
+
 def test_grid_ui_content():
     data = [0, 100, 50, 0, -1, 0]
     msg = _make_grid(data, width=3, height=2, resolution=0.5)

--- a/test/robot_plugin_test.py
+++ b/test/robot_plugin_test.py
@@ -28,6 +28,7 @@ from ros_sugar.robot import (
     RobotCommand,
     RobotPlugin,
     RobotPluginHost,
+    SensorPlugin,
     SdkCallbackTransport,
     SocketFeedbackBus,
     UdpTransport,
@@ -118,6 +119,32 @@ class MockPlugin(RobotPlugin):
         return Action(method=lambda: self.commands["Int32"].transport.send(
             _encode_int32(value)
         ))
+
+
+class MockSensor(SensorPlugin):
+    """A sensor plugin with no I/O of its own -- enough to be attached."""
+
+    def __init__(self, cam_name: str = "camera"):
+        self.metadata = PluginMetadata(name=cam_name)
+
+
+class MockUdpSensor(SensorPlugin):
+    """A sensor plugin with one UDP feedback -- a camera-shaped stand-in."""
+
+    def __init__(self, host: str = "127.0.0.1", state_port: int = 0):
+        self.metadata = PluginMetadata(name="MockSensor", vendor="test")
+        transport = UdpTransport(
+            "state", send_to=(host, state_port), bind=(host, state_port)
+        )
+        self.transports = {"state": transport}
+        self.feedbacks = {
+            "Int32": Feedback(
+                key="Int32",
+                msg_type=RobotInt32,
+                transport=transport,
+                decoder=_decode_int32,
+            )
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -1188,3 +1215,915 @@ def test_plugin_without_base_frame_leaves_frames_untouched():
     launcher._apply_plugin_base_frame()
 
     assert comp.config.frames.robot_base == "base_link"
+
+
+# ---------------------------------------------------------------------------
+# plugin taxonomy
+# ---------------------------------------------------------------------------
+
+
+def test_role_comes_from_the_base_class_not_the_recipe():
+    """Role is intrinsic: a plugin *is* a robot or a sensor by construction, so
+    a recipe cannot attach one under the wrong role."""
+    from ros_sugar.robot import Plugin, PluginRole, RobotPlugin, SensorPlugin
+
+    assert RobotPlugin._role is PluginRole.ROBOT
+    assert SensorPlugin._role is PluginRole.SENSOR
+    assert Plugin._role is PluginRole.SENSOR
+
+    class MyRobot(RobotPlugin):
+        pass
+
+    class MyCamera(SensorPlugin):
+        pass
+
+    assert MyRobot().role is PluginRole.ROBOT
+    assert MyCamera().role is PluginRole.SENSOR
+
+    # read-only: a recipe cannot reassign what a plugin is
+    with pytest.raises(AttributeError):
+        MyCamera().role = PluginRole.ROBOT
+
+
+def test_only_robot_plugins_describe_a_robot():
+    """A camera has no geometry or velocity envelope of its own, so those slots
+    exist only where they mean something."""
+    from ros_sugar.robot import RobotPlugin, SensorPlugin
+
+    class MyRobot(RobotPlugin):
+        pass
+
+    class MyCamera(SensorPlugin):
+        pass
+
+    robot = MyRobot()
+    assert robot.robot_config is None and robot.base_frame is None
+
+    camera = MyCamera()
+    assert not hasattr(camera, "robot_config")
+    assert not hasattr(camera, "base_frame")
+
+
+def test_subclass_without_its_own_init_still_reports_its_own_name():
+    """Regression guard for the __init_subclass__ move: the framework's own
+    base classes must stay unwrapped, or a plugin that defines no ``__init__``
+    would be initialized against its base and take the base's name."""
+    from ros_sugar.robot import RobotPlugin, SensorPlugin
+
+    class BareRobot(RobotPlugin):
+        pass
+
+    class BareSensor(SensorPlugin):
+        pass
+
+    assert BareRobot().metadata.name == "BareRobot"
+    assert BareSensor().metadata.name == "BareSensor"
+
+
+def test_describe_reports_the_role():
+    plugin = MockPlugin(state_port=_free_port(), cmd_port=_free_port())
+    assert plugin.describe()["role"] == "robot"
+
+
+def test_role_survives_the_spec_round_trip():
+    """Components rebuild plugins from a spec in their own process; the role
+    has to come back with them."""
+    from ros_sugar.robot import Plugin, PluginRole
+
+    plugin = MockPlugin(state_port=_free_port(), cmd_port=_free_port())
+    rebuilt = Plugin.from_spec(plugin.to_spec())
+    assert rebuilt.role is PluginRole.ROBOT
+
+
+# ---------------------------------------------------------------------------
+# shared bus lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_second_host_on_a_shared_bus_opens(rclpy_context):
+    """Regression: with each host starting the bus itself, the second one
+    re-bound the same address and died with 'Address already in use'."""
+    bus = SocketFeedbackBus()
+    bus.start()
+    hosts = []
+    try:
+        for _ in range(2):
+            plugin = MockPlugin(state_port=_free_port(), cmd_port=_free_port())
+            host = RobotPluginHost(plugin, node=None, bus=bus, owns_bus=False)
+            host.open()
+            hosts.append(host)
+        assert all(h._active for h in hosts)
+    finally:
+        for host in hosts:
+            host.close()
+        bus.close()
+
+
+def test_one_host_closing_leaves_the_shared_bus_up(rclpy_context):
+    """Regression: the first host to close tore the bus down for every other
+    plugin still using it."""
+    state_port = _free_port()
+    bus = InProcessFeedbackBus()
+    bus.start()
+
+    first = MockPlugin(state_port=_free_port(), cmd_port=_free_port())
+    second = MockPlugin(state_port=state_port, cmd_port=_free_port())
+    host_a = RobotPluginHost(first, node=None, bus=bus, owns_bus=False)
+    host_b = RobotPluginHost(second, node=None, bus=bus, owns_bus=False)
+    host_a.open()
+    host_b.open()
+
+    received = []
+    handle = bus.subscribe(second.feedbacks["Int32"].channel, received.append)
+    try:
+        host_a.close()  # the other plugin must keep working
+
+        robot_tx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        robot_tx.sendto(b"77", ("127.0.0.1", state_port))
+        deadline = time.time() + 2.0
+        while not received and time.time() < deadline:
+            time.sleep(0.02)
+        robot_tx.close()
+        assert received, "closing one host silenced the surviving plugin"
+    finally:
+        handle.unsubscribe()
+        host_b.close()
+        bus.close()
+
+
+def test_standalone_host_still_owns_its_bus(rclpy_context):
+    """A lone host with no launcher around it must remain self-contained."""
+    plugin = MockPlugin(state_port=_free_port(), cmd_port=_free_port())
+    bus = InProcessFeedbackBus()
+    host = RobotPluginHost(plugin, node=None, bus=bus)
+    host.open()
+    assert host._active
+    host.close()
+    assert not host._active
+
+
+# ---------------------------------------------------------------------------
+# plugin identity
+# ---------------------------------------------------------------------------
+
+
+def test_unattached_plugin_keeps_the_bare_channel_form():
+    """A plugin that was never attached has no id, and its channels stay in the
+    form a single-plugin recipe has always used."""
+    plugin = MockPlugin(state_port=_free_port(), cmd_port=_free_port())
+    assert plugin.feedbacks["Int32"].channel == "robot/feedback/Int32"
+    assert plugin.commands["Int32"].channel == "robot/command/Int32"
+
+
+def test_binding_identity_namespaces_every_channel():
+    plugin = MockPlugin(state_port=_free_port(), cmd_port=_free_port(), id="front_cam")
+    plugin._bind_identity()
+
+    assert plugin.id == "front_cam"
+    assert plugin.feedbacks["Int32"].channel == "plugin/front_cam/feedback/Int32"
+    assert plugin.commands["Int32"].channel == "plugin/front_cam/command/Int32"
+
+
+def test_two_plugins_of_the_same_class_do_not_collide():
+    """The whole point: several plugins share one bus, so identical feedback
+    keys must resolve to different channels."""
+    a = MockPlugin(state_port=_free_port(), cmd_port=_free_port(), id="cam_a")
+    b = MockPlugin(state_port=_free_port(), cmd_port=_free_port(), id="cam_b")
+    a._bind_identity()
+    b._bind_identity()
+
+    assert a.feedbacks["Int32"].channel != b.feedbacks["Int32"].channel
+    assert a.commands["Int32"].channel != b.commands["Int32"].channel
+
+
+def test_namespaced_channel_is_a_valid_ros_topic_name():
+    """Channels become ROS topic names for events, and an invalid one fails at
+    activation rather than when the recipe runs."""
+    from rclpy.validate_topic_name import validate_topic_name
+
+    plugin = MockPlugin(state_port=_free_port(), cmd_port=_free_port(), id="front_cam")
+    plugin._bind_identity()
+    validate_topic_name(f"/{plugin.feedbacks['Int32'].channel}")
+
+
+@pytest.mark.parametrize("bad_id", ["front-cam", "office.cam", "2nd_cam", ""])
+def test_ids_that_are_not_valid_ros_tokens_are_rejected(bad_id):
+    with pytest.raises(ValueError, match="not a usable plugin id"):
+        MockPlugin(state_port=_free_port(), cmd_port=_free_port(), id=bad_id)
+
+
+def test_rebinding_after_a_topic_was_handed_out_raises():
+    """Silent-failure guard: an event built before attaching embeds the old
+    channel name, and the Monitor blackboard is keyed by topic name -- so a
+    later rename would leave the event listening to nothing, with no error."""
+    plugin = MockPlugin(state_port=_free_port(), cmd_port=_free_port(), id="front_cam")
+    plugin.feedbacks["Int32"].as_topic()  # what building an event does
+
+    with pytest.raises(ValueError, match="has already been referenced"):
+        plugin._bind_identity()
+
+
+def test_binding_the_same_identity_twice_is_allowed():
+    plugin = MockPlugin(state_port=_free_port(), cmd_port=_free_port(), id="front_cam")
+    plugin._bind_identity()
+    plugin.feedbacks["Int32"].as_topic()
+    plugin._bind_identity()  # no-op, must not raise
+
+
+def test_identity_survives_the_spec_round_trip():
+    """The component subprocess must subscribe to the same channels the host
+    publishes on."""
+    from ros_sugar.robot import Plugin
+
+    plugin = MockPlugin(state_port=_free_port(), cmd_port=_free_port(), id="front_cam")
+    plugin._bind_identity()
+
+    rebuilt = Plugin.from_spec(plugin.to_spec())
+    assert rebuilt.id == "front_cam"
+    assert rebuilt.feedbacks["Int32"].channel == plugin.feedbacks["Int32"].channel
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        ("Lite3", "lite3"),
+        ("HikVision PTZ-2", "hikvision_ptz_2"),
+        ("  spaced  name  ", "spaced_name"),
+        ("2nd camera", "_2nd_camera"),
+    ],
+)
+def test_display_names_become_usable_ids(name, expected):
+    from ros_sugar.robot.plugin import _slug
+
+    assert _slug(name) == expected
+
+
+# ---------------------------------------------------------------------------
+# component holds several plugins
+# ---------------------------------------------------------------------------
+
+
+def _sensor_plugin(name: str) -> "MockSensor":
+    return MockSensor(cam_name=name)
+
+
+def test_component_keeps_plugins_in_a_dict(rclpy_context):
+    from ros_sugar.core.component import BaseComponent
+
+    component = BaseComponent(component_name="multi_plugin_component")
+    component.rclpy_init_node()
+    try:
+        robot = MockPlugin(state_port=_free_port(), cmd_port=_free_port())
+        camera = _sensor_plugin("front_cam")
+        component.add_plugin(robot)
+        component.add_plugin(camera)
+
+        assert set(component._plugins) == {"mockplugin", "front_cam"}
+    finally:
+        component.destroy_node()
+
+
+def test_robot_plugin_property_reads_and_writes_through(rclpy_context):
+    """Existing code and tests assign ``component._robot_plugin`` directly, and
+    the out-of-tree Lite3 republisher reads it."""
+    from ros_sugar.core.component import BaseComponent
+
+    component = BaseComponent(component_name="robot_plugin_property_component")
+    component.rclpy_init_node()
+    try:
+        assert component._robot_plugin is None
+
+        robot = MockPlugin(state_port=_free_port(), cmd_port=_free_port())
+        component._robot_plugin = robot
+        assert component._robot_plugin is robot
+
+        component._robot_plugin = None
+        assert component._robot_plugin is None
+        assert component._plugins == {}
+    finally:
+        component.destroy_node()
+
+
+def test_setting_the_robot_plugin_leaves_sensors_attached(rclpy_context):
+    from ros_sugar.core.component import BaseComponent
+
+    component = BaseComponent(component_name="mixed_plugin_component")
+    component.rclpy_init_node()
+    try:
+        camera = _sensor_plugin("front_cam")
+        component.add_plugin(camera)
+        component._robot_plugin = MockPlugin(
+            state_port=_free_port(), cmd_port=_free_port()
+        )
+        component._robot_plugin = None  # clearing the robot must not drop the camera
+
+        assert component._plugins == {"front_cam": camera}
+    finally:
+        component.destroy_node()
+
+
+def test_a_sensor_only_component_still_binds_its_plugins(rclpy_context):
+    """The plugin gates used to key on the *robot* plugin, so a recipe with
+    only sensors would have skipped plugin wiring entirely."""
+    from ros_sugar.core.component import BaseComponent
+
+    component = BaseComponent(component_name="sensor_only_component")
+    component.rclpy_init_node()
+    try:
+        component.add_plugin(_sensor_plugin("front_cam"))
+        assert component._robot_plugin is None
+        assert component._plugins, "gates must key on _plugins, not the robot plugin"
+        assert component._plugins_json != "{}"
+    finally:
+        component.destroy_node()
+
+
+def test_plugins_round_trip_across_the_process_boundary(rclpy_context):
+    """Multiprocess launch serializes plugins into argv and rebuilds them in
+    the component subprocess."""
+    from ros_sugar.core.component import BaseComponent
+
+    sender = BaseComponent(component_name="plugins_json_sender")
+    sender.rclpy_init_node()
+    receiver = BaseComponent(component_name="plugins_json_receiver")
+    receiver.rclpy_init_node()
+    try:
+        robot = MockPlugin(
+            state_port=_free_port(), cmd_port=_free_port(), id="lite3"
+        )
+        robot._bind_identity()
+        sender.add_plugin(robot)
+        sender.add_plugin(MockSensor(cam_name="HikVision", id="front_cam"))
+
+        receiver._plugins_json = sender._plugins_json
+
+        assert set(receiver._plugins) == {"lite3", "front_cam"}
+        assert receiver._robot_plugin is not None
+        # the identity has to come back, or the subprocess subscribes to
+        # channels the host never publishes on
+        assert receiver._robot_plugin.id == "lite3"
+        assert (
+            receiver._robot_plugin.feedbacks["Int32"].channel
+            == "plugin/lite3/feedback/Int32"
+        )
+    finally:
+        sender.destroy_node()
+        receiver.destroy_node()
+
+
+# ---------------------------------------------------------------------------
+# launcher holds several plugins
+# ---------------------------------------------------------------------------
+
+
+def _launcher_with(components):
+    from ros_sugar import Launcher
+
+    launcher = Launcher()
+    launcher._components = components
+    return launcher
+
+
+def test_add_plugin_order_does_not_matter(rclpy_context):
+    """Regression: plugins used to be handed out inside add_pkg, so a recipe
+    that called add_pkg first left those components with nothing."""
+    from ros_sugar.core.component import BaseComponent
+
+    component = BaseComponent(component_name="ordering_component")
+    component.rclpy_init_node()
+    try:
+        # components registered BEFORE any plugin is attached
+        launcher = _launcher_with([component])
+        launcher.add_plugin(MockPlugin(state_port=_free_port(), cmd_port=_free_port()))
+        launcher.add_plugin(MockSensor(cam_name="front_cam"))
+
+        assert component._plugins == {}, "distribution happens at bringup"
+        launcher._distribute_plugins()
+        assert set(component._plugins) == {"mockplugin", "front_cam"}
+    finally:
+        component.destroy_node()
+
+
+def test_only_one_robot_plugin_per_recipe(rclpy_context):
+    launcher = _launcher_with([])
+    launcher.add_plugin(MockPlugin(state_port=_free_port(), cmd_port=_free_port()))
+
+    with pytest.raises(ValueError, match="a recipe describes one robot"):
+        launcher.add_plugin(
+            MockPlugin(state_port=_free_port(), cmd_port=_free_port(), id="second")
+        )
+
+
+def test_several_sensor_plugins_are_allowed(rclpy_context):
+    launcher = _launcher_with([])
+    launcher.add_plugin(MockSensor(cam_name="cam_a"))
+    launcher.add_plugin(MockSensor(cam_name="cam_b"))
+
+    assert set(launcher._plugins) == {"cam_a", "cam_b"}
+
+
+def test_duplicate_names_are_rejected(rclpy_context):
+    launcher = _launcher_with([])
+    launcher.add_plugin(MockSensor(cam_name="cam"))
+
+    with pytest.raises(ValueError, match="already taken"):
+        launcher.add_plugin(MockSensor(cam_name="cam"))
+
+
+def test_two_plugins_of_one_kind_need_distinct_names(rclpy_context):
+    """Two identical cameras default to the same slug, so the recipe names
+    them -- and that name is what namespaces their channels."""
+    launcher = _launcher_with([])
+    launcher.add_plugin(MockSensor(cam_name="HikVision PTZ", id="front_cam"))
+    launcher.add_plugin(MockSensor(cam_name="HikVision PTZ", id="rear_cam"))
+
+    assert set(launcher._plugins) == {"front_cam", "rear_cam"}
+    assert launcher._plugins["front_cam"].id == "front_cam"
+    assert launcher._plugins["rear_cam"].id == "rear_cam"
+
+
+def test_attaching_binds_identity_immediately(rclpy_context):
+    """Identity must be final when add_plugin returns: events built from the
+    plugin freeze their topic names before plugin setup runs."""
+    launcher = _launcher_with([])
+    plugin = MockPlugin(state_port=_free_port(), cmd_port=_free_port())
+    launcher.add_plugin(plugin)
+
+    assert plugin.id == "mockplugin"
+    assert plugin.feedbacks["Int32"].channel == "plugin/mockplugin/feedback/Int32"
+
+
+def test_launcher_robot_plugin_property_round_trips(rclpy_context):
+    """ros-agents reads and writes ``launcher._robot_plugin`` directly."""
+    from ros_sugar import Launcher
+
+    plugin = MockPlugin(state_port=_free_port(), cmd_port=_free_port())
+    launcher = Launcher(robot_plugin=plugin)
+    assert launcher._robot_plugin is plugin
+
+    launcher._robot_plugin = None
+    assert launcher._robot_plugin is None
+
+
+# ---------------------------------------------------------------------------
+# addressing a specific plugin from a topic
+# ---------------------------------------------------------------------------
+
+
+def test_topic_rejects_an_empty_plugin_id():
+    """`use_plugin` is tested for truthiness, so "" would silently mean off."""
+    with pytest.raises(ValueError, match="cannot be an empty string"):
+        Topic(name="x", msg_type="Int32", use_plugin="")
+
+
+def test_use_plugin_survives_the_topic_round_trip():
+    """Topics are rebuilt from JSON in every component subprocess."""
+    original = Topic(name="x", msg_type="Int32", use_plugin="front_cam")
+    rebuilt = Topic(**{
+        **json.loads(original.to_json()),
+        "qos_profile": original.qos_profile,
+        "additional_types": [],
+    })
+    assert rebuilt.use_plugin == "front_cam"
+
+    plain = Topic(name="y", msg_type="Int32", use_plugin=True)
+    assert json.loads(plain.to_json())["use_plugin"] is True
+
+
+def test_component_binds_each_topic_to_the_named_plugin(rclpy_context):
+    """The point of step 8: two plugins attached, each topic reaching the one
+    it names."""
+    from ros_sugar.core.component import BaseComponent
+
+    robot_port, cam_port = _free_port(), _free_port()
+    robot = MockPlugin(state_port=robot_port, cmd_port=_free_port(), id="lite3")
+    camera = MockPlugin(state_port=cam_port, cmd_port=_free_port(), id="front_cam")
+
+    # what Launcher.add_plugin does: namespace each plugin's channels so two
+    # plugins exposing the same feedback key cannot collide on the shared bus
+    robot._bind_identity()
+    camera._bind_identity()
+
+    bus = InProcessFeedbackBus()
+    bus.start()
+    hosts = [
+        RobotPluginHost(p, node=None, bus=bus, owns_bus=False) for p in (robot, camera)
+    ]
+    for host in hosts:
+        host.open()
+
+    component = BaseComponent(
+        component_name="two_plugin_component",
+        inputs=[
+            Topic(name="robot_state", msg_type="Int32", use_plugin=True),
+            Topic(name="cam_state", msg_type="Int32", use_plugin=camera.id),
+        ],
+    )
+    component.rclpy_init_node()
+    component.add_plugin(robot)
+    component.add_plugin(camera)
+    try:
+        component._use_robot_plugin()
+        assert component._external_topics == {"robot_state", "cam_state"}
+
+        # each input receives only its own plugin's telemetry
+        tx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        tx.sendto(b"11", ("127.0.0.1", robot_port))
+        tx.sendto(b"22", ("127.0.0.1", cam_port))
+        deadline = time.time() + 2.0
+        while (
+            component.callbacks["robot_state"].msg is None
+            or component.callbacks["cam_state"].msg is None
+        ) and time.time() < deadline:
+            time.sleep(0.02)
+        tx.close()
+
+        assert component.callbacks["robot_state"].get_output() == 11
+        assert component.callbacks["cam_state"].get_output() == 22
+    finally:
+        for host in hosts:
+            host.close()
+        bus.close()
+        component.destroy_node()
+
+
+def test_topic_naming_an_unattached_plugin_is_caught_at_bringup(rclpy_context):
+    """Falling back to a ROS topic nothing publishes leaves the component
+    looking healthy while receiving nothing, so fail in the recipe instead."""
+    from ros_sugar.core.component import BaseComponent
+
+    component = BaseComponent(
+        component_name="typo_component",
+        inputs=[Topic(name="Image", msg_type="Int32", use_plugin="front_cm")],
+    )
+    component.rclpy_init_node()
+    try:
+        launcher = _launcher_with([component])
+        launcher.add_plugin(MockSensor(cam_name="HikVision", id="front_cam"))
+
+        with pytest.raises(ValueError, match="not attached to this recipe"):
+            launcher._validate_plugin_references()
+    finally:
+        component.destroy_node()
+
+
+def test_use_plugin_true_without_a_robot_plugin_is_caught_at_bringup(rclpy_context):
+    from ros_sugar.core.component import BaseComponent
+
+    component = BaseComponent(
+        component_name="no_robot_component",
+        inputs=[Topic(name="Image", msg_type="Int32", use_plugin=True)],
+    )
+    component.rclpy_init_node()
+    try:
+        launcher = _launcher_with([component])
+        launcher.add_plugin(MockSensor(cam_name="HikVision", id="front_cam"))
+
+        with pytest.raises(ValueError, match="no robot plugin is attached"):
+            launcher._validate_plugin_references()
+    finally:
+        component.destroy_node()
+
+
+# ---------------------------------------------------------------------------
+# sensor frames and mounts
+# ---------------------------------------------------------------------------
+
+
+def test_sensor_frame_defaults_to_its_id():
+    """Two instances of one sensor get distinct frames with no author effort."""
+    a = MockSensor(cam_name="HikVision", id="front_cam")
+    b = MockSensor(cam_name="HikVision", id="rear_cam")
+    assert a.frame_id == "front_cam_frame"
+    assert b.frame_id == "rear_cam_frame"
+
+
+def test_sensor_frame_can_be_named_by_the_recipe():
+    cam = MockSensor(cam_name="HikVision", id="front_cam", frame_id="front_optical")
+    assert cam.frame_id == "front_optical"
+
+
+def test_sensor_frame_survives_the_spec_round_trip():
+    from ros_sugar.robot import Plugin
+
+    cam = MockSensor(cam_name="HikVision", id="front_cam", frame_id="front_optical")
+    rebuilt = Plugin.from_spec(cam.to_spec())
+    assert rebuilt.frame_id == "front_optical"
+
+
+def test_unstamped_feedback_is_stamped_with_the_plugin_frame(rclpy_context):
+    """Regression: an unstamped message is silently never transformed -- the
+    component's frame resolver returns None on an empty frame_id."""
+    from std_msgs.msg import Header
+    from sensor_msgs.msg import Imu
+
+    port = _free_port()
+
+    def _decode_imu(raw: bytes):
+        msg = Imu()
+        msg.header = Header()  # deliberately unstamped, as a decoder often is
+        msg.linear_acceleration.x = float(raw.decode())
+        return msg
+
+    RobotImu = create_supported_type(Imu)
+
+    class ImuSensor(SensorPlugin):
+        def __init__(self, imu_port: int):
+            self.metadata = PluginMetadata(name="IMU")
+            transport = UdpTransport(
+                "imu", send_to=("127.0.0.1", imu_port), bind=("127.0.0.1", imu_port)
+            )
+            self.transports = {"imu": transport}
+            self.feedbacks = {
+                "Imu": Feedback(
+                    key="Imu",
+                    msg_type=RobotImu,
+                    transport=transport,
+                    decoder=_decode_imu,
+                )
+            }
+
+    sensor = ImuSensor(imu_port=port, id="waist_imu")
+    sensor._bind_identity()
+    bus = InProcessFeedbackBus()
+    bus.start()
+    host = RobotPluginHost(sensor, node=None, bus=bus, owns_bus=False)
+    host.open()
+
+    received = []
+    handle = bus.subscribe(sensor.feedbacks["Imu"].channel, received.append)
+    try:
+        tx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        tx.sendto(b"9", ("127.0.0.1", port))
+        deadline = time.time() + 2.0
+        while not received and time.time() < deadline:
+            time.sleep(0.02)
+        tx.close()
+        assert received, "no feedback arrived"
+
+        from rclpy.serialization import deserialize_message
+
+        msg = deserialize_message(received[0], Imu)
+        assert msg.header.frame_id == "waist_imu_frame"
+    finally:
+        handle.unsubscribe()
+        host.close()
+        bus.close()
+
+
+def test_a_decoder_that_stamps_its_own_frame_is_never_overridden(rclpy_context):
+    """A robot's odometry is in the localization frame, not a body frame --
+    only the decoder knows that, so the framework must not overwrite it."""
+    from sensor_msgs.msg import Imu
+
+    RobotImu2 = create_supported_type(Imu, module=__name__)
+
+    feedback = Feedback(
+        key="Imu",
+        msg_type=RobotImu2,
+        transport=UdpTransport("x", send_to=("127.0.0.1", 1)),
+        decoder=lambda _: None,
+        frame_id="declared_frame",
+    )
+    host = RobotPluginHost(
+        MockSensor(cam_name="s", id="s"), node=None, bus=InProcessFeedbackBus()
+    )
+
+    msg = Imu()
+    msg.header.frame_id = "author_stamped"
+    host._stamp_frame(feedback, msg)
+    assert msg.header.frame_id == "author_stamped"
+
+    fresh = Imu()
+    host._stamp_frame(feedback, fresh)
+    assert fresh.header.frame_id == "declared_frame", "per-feedback frame wins"
+
+
+# ---- Mount ----------------------------------------------------------------
+
+
+def test_mount_resolves_frames_from_plugins():
+    from ros_sugar.robot import Mount
+
+    robot = MockPlugin(state_port=_free_port(), cmd_port=_free_port(), id="lite3")
+    robot.base_frame = "base_link"
+    cam = MockSensor(cam_name="HikVision", id="front_cam")
+
+    mount = Mount(parent=robot, xyz=(0.15, 0.0, 0.35))
+    mount.child = cam
+    assert mount.parent_frame == "base_link"
+    assert mount.child_frame == "front_cam_frame"
+
+
+def test_mount_accepts_a_plain_frame_for_a_fixed_sensor():
+    """A sensor watching a room is mounted on the world, not on the robot."""
+    from ros_sugar.robot import Mount
+
+    cam = MockSensor(cam_name="Lobby", id="lobby_cam")
+    mount = Mount(parent="map", xyz=(2.0, 3.0, 2.5))
+    mount.child = cam
+    assert mount.parent_frame == "map"
+
+
+def test_mount_rejects_something_with_no_frame():
+    from ros_sugar.robot import Mount
+
+    with pytest.raises(ValueError, match="Cannot mount against"):
+        Mount(parent=object()).parent_frame
+
+
+def test_euler_to_quaternion_matches_known_rotations():
+    from ros_sugar.robot.mount import quaternion_from_euler
+
+    x, y, z, w = quaternion_from_euler(0.0, 0.0, 0.0)
+    assert (x, y, z, w) == (0.0, 0.0, 0.0, 1.0)
+
+    # 90 degrees about Z
+    x, y, z, w = quaternion_from_euler(0.0, 0.0, 3.141592653589793 / 2)
+    assert abs(z - 0.7071067811865476) < 1e-9
+    assert abs(w - 0.7071067811865476) < 1e-9
+
+
+def test_launcher_collects_mounts_from_add_plugin(rclpy_context):
+    from ros_sugar.robot import Mount
+
+    robot = MockPlugin(state_port=_free_port(), cmd_port=_free_port(), id="lite3")
+    robot.base_frame = "base_link"
+    cam = MockSensor(cam_name="HikVision", id="front_cam")
+
+    launcher = _launcher_with([])
+    launcher.add_plugin(robot)
+    launcher.add_plugin(cam, mount=Mount(parent=robot, xyz=(0.15, 0.0, 0.35)))
+
+    assert len(launcher._mounts) == 1
+    mount = launcher._mounts[0]
+    assert mount.parent_frame == "base_link"
+    # the child is filled in from the plugin, so a recipe never repeats it
+    assert mount.child_frame == "front_cam_frame"
+
+
+def test_a_sensor_needs_no_mount_when_tf_already_has_its_frame(rclpy_context):
+    """Mode B: a URDF or the sensor's own driver already publishes the frame,
+    so the recipe declares nothing and Sugarcoat just consumes it."""
+    cam = MockSensor(cam_name="HikVision", id="front_cam")
+    launcher = _launcher_with([])
+    launcher.add_plugin(cam)
+
+    assert launcher._mounts == []
+
+
+# ---------------------------------------------------------------------------
+# launcher-side plugin bring-up
+# ---------------------------------------------------------------------------
+
+
+class _StubMonitor:
+    """Stands in for the Monitor node in ``_setup_plugins``.
+
+    Only the two methods the launcher wires plugin feedback through are
+    needed; building a real Monitor would drag in the whole launch machinery.
+    """
+
+    def __init__(self):
+        self.registered = []
+
+    def register_external_topic(self, topic):
+        self.registered.append(topic.name)
+
+    def feed_external_topic(self, name, msg):
+        pass
+
+
+def test_setup_plugins_hosts_every_plugin_on_one_bus(rclpy_context):
+    """Each plugin needs its own host -- otherwise a sensor plugin's transports
+    are never opened and it is attached in name only."""
+    launcher = _launcher_with([])
+    launcher.monitor_node = _StubMonitor()
+
+    robot = MockPlugin(state_port=_free_port(), cmd_port=_free_port(), id="lite3")
+    camera = MockUdpSensor(state_port=_free_port(), id="front_cam")
+    launcher.add_plugin(robot)
+    launcher.add_plugin(camera)
+
+    try:
+        launcher._setup_plugins()
+
+        assert len(launcher._plugin_hosts) == 2
+        assert all(host._active for host in launcher._plugin_hosts)
+        # one bus, owned by the launcher rather than by any host
+        assert launcher._plugin_bus is not None
+        assert all(not host._owns_bus for host in launcher._plugin_hosts)
+        assert all(
+            host.bus is launcher._plugin_bus for host in launcher._plugin_hosts
+        )
+    finally:
+        for host in launcher._plugin_hosts:
+            host.close()
+        if launcher._plugin_bus:
+            launcher._plugin_bus.close()
+
+
+def test_setup_plugins_registers_each_plugins_feedback_with_the_monitor(rclpy_context):
+    """Events over non-ROS feedback are tracked without a ROS subscription, so
+    every plugin's channels have to reach the Monitor -- namespaced, or two
+    plugins would register the same topic."""
+    launcher = _launcher_with([])
+    launcher.monitor_node = _StubMonitor()
+
+    launcher.add_plugin(
+        MockPlugin(state_port=_free_port(), cmd_port=_free_port(), id="lite3")
+    )
+    launcher.add_plugin(MockUdpSensor(state_port=_free_port(), id="front_cam"))
+
+    try:
+        launcher._setup_plugins()
+        assert set(launcher.monitor_node.registered) == {
+            "plugin/lite3/feedback/Int32",
+            "plugin/front_cam/feedback/Int32",
+        }
+    finally:
+        for host in launcher._plugin_hosts:
+            host.close()
+        if launcher._plugin_bus:
+            launcher._plugin_bus.close()
+
+
+def test_setup_plugins_is_a_noop_without_plugins(rclpy_context):
+    launcher = _launcher_with([])
+    launcher.monitor_node = _StubMonitor()
+
+    launcher._setup_plugins()
+
+    assert launcher._plugin_hosts == []
+    assert launcher._plugin_bus is None
+
+
+def test_mounts_are_published_as_static_transforms(rclpy_context):
+    """The mount only matters if it actually reaches the TF tree."""
+    import math
+
+    from rclpy.node import Node
+    from rclpy.qos import QoSDurabilityPolicy, QoSHistoryPolicy, QoSProfile
+    from tf2_msgs.msg import TFMessage
+
+    from ros_sugar.robot import Mount
+
+    publisher_node = Node("mount_publisher")
+    listener_node = Node("mount_listener")
+    received = []
+    listener_node.create_subscription(
+        TFMessage,
+        "/tf_static",
+        lambda m: received.extend(m.transforms),
+        QoSProfile(
+            depth=1,
+            history=QoSHistoryPolicy.KEEP_LAST,
+            durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+        ),
+    )
+
+    launcher = _launcher_with([])
+    launcher.monitor_node = publisher_node
+
+    robot = MockPlugin(state_port=_free_port(), cmd_port=_free_port(), id="lite3")
+    robot.base_frame = "base_link"
+    camera = MockSensor(cam_name="HikVision", id="front_cam")
+    launcher.add_plugin(robot)
+    launcher.add_plugin(
+        camera,
+        mount=Mount(parent=robot, xyz=(0.15, 0.0, 0.35), rpy=(0.0, 0.0, math.pi / 2)),
+    )
+
+    try:
+        launcher._publish_mounts()
+
+        deadline = time.time() + 3.0
+        while not received and time.time() < deadline:
+            rclpy.spin_once(publisher_node, timeout_sec=0.05)
+            rclpy.spin_once(listener_node, timeout_sec=0.05)
+
+        assert received, "the mount never reached /tf_static"
+        transform = received[0]
+        assert transform.header.frame_id == "base_link"
+        assert transform.child_frame_id == "front_cam_frame"
+        assert abs(transform.transform.translation.x - 0.15) < 1e-6
+        assert abs(transform.transform.translation.z - 0.35) < 1e-6
+        # 90 degrees about Z
+        assert abs(transform.transform.rotation.z - 0.7071067811865476) < 1e-6
+        assert abs(transform.transform.rotation.w - 0.7071067811865476) < 1e-6
+    finally:
+        publisher_node.destroy_node()
+        listener_node.destroy_node()
+
+
+def test_publishing_mounts_is_a_noop_without_any(rclpy_context):
+    from rclpy.node import Node
+
+    node = Node("no_mounts")
+    launcher = _launcher_with([])
+    launcher.monitor_node = node
+    try:
+        launcher._publish_mounts()  # must not create a broadcaster or raise
+        assert not hasattr(launcher, "_static_tf_broadcaster")
+    finally:
+        node.destroy_node()

--- a/test/robot_plugin_test.py
+++ b/test/robot_plugin_test.py
@@ -579,6 +579,62 @@ def test_route_via_host_command_forwarding():
         robot_cmd_sock.close()
 
 
+def test_lifecycle_hooks_fire_around_the_transports(monkeypatch):
+    """`on_detached` has to run while the transports are still open, so a
+    plugin can leave hardware in a safe state -- a spinning motor is not
+    stopped by closing the port."""
+    plugin = MockPlugin(state_port=_free_port(), cmd_port=_free_port())
+    events = []
+
+    monkeypatch.setattr(
+        type(plugin),
+        "on_attached",
+        lambda self, node, bus: events.append("attached"),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        type(plugin),
+        "on_detached",
+        lambda self, node, bus: events.append(
+            # every transport must still be usable at this point
+            f"detached:{all(t._open for t in self.transports.values())}"
+        ),
+        raising=False,
+    )
+
+    host = RobotPluginHost(plugin, node=None, bus=InProcessFeedbackBus())
+    host.open()
+    assert events == ["attached"]
+    host.close()
+    assert events == ["attached", "detached:True"]
+
+    # Both hooks are idempotent, since close() is
+    host.close()
+    assert events == ["attached", "detached:True"]
+
+
+def test_a_raising_detach_hook_does_not_block_teardown():
+    """Teardown must finish even if the device has already gone away."""
+    plugin = MockPlugin(state_port=_free_port(), cmd_port=_free_port())
+
+    def _boom(self, node, bus):
+        raise RuntimeError("device unplugged")
+
+    monkeypatch_target = type(plugin)
+    original = getattr(monkeypatch_target, "on_detached", None)
+    monkeypatch_target.on_detached = _boom
+    try:
+        host = RobotPluginHost(plugin, node=None, bus=InProcessFeedbackBus())
+        host.open()
+        host.close()  # must not raise
+        assert all(not t._open for t in plugin.transports.values())
+    finally:
+        if original is not None:
+            monkeypatch_target.on_detached = original
+        else:
+            del monkeypatch_target.on_detached
+
+
 # ---------------------------------------------------------------------------
 # Component integration
 # ---------------------------------------------------------------------------

--- a/test/robot_plugin_test.py
+++ b/test/robot_plugin_test.py
@@ -946,10 +946,13 @@ def test_use_robot_plugin_mismatch_is_contained(rclpy_context):
 
 
 class _FakeComponentConfig:
-    """Bare component config with a duck-typed ``robot`` slot."""
+    """Bare component config with the two slots the launcher broadcasts into."""
 
     def __init__(self):
+        from ros_sugar.config import RobotFrames
+
         self.robot = None
+        self.frames = RobotFrames()
 
 
 class _FakeComponent:
@@ -1000,13 +1003,13 @@ def test_recipe_override_wins_over_plugin():
     assert comp.config.robot == {"sentinel": "from_recipe"}  # untouched
 
 
-def test_plugin_without_robot_config_attr_is_noop():
-    """A plugin that doesn't expose ``robot_config`` causes no broadcast and
-    no error -- the auto-apply path is fully opt-in."""
+def test_plugin_that_describes_no_robot_is_noop():
+    """Every plugin declares ``robot_config``, but one that describes no robot
+    leaves it None -- the auto-apply path stays opt-in."""
     from ros_sugar import Launcher
 
     plugin = MockPlugin(state_port=_free_port(), cmd_port=_free_port())
-    assert not hasattr(plugin, "robot_config")
+    assert plugin.robot_config is None
 
     launcher = Launcher(robot_plugin=plugin)
     comp = _FakeComponent("d")
@@ -1026,3 +1029,162 @@ def test_no_plugin_attached_is_noop():
 
     launcher._apply_plugin_robot_config()
     assert comp.config.robot is None
+
+
+# ---------------------------------------------------------------------------
+# component events on plugin-fed topics
+# ---------------------------------------------------------------------------
+
+
+def _event_component(plugin, topic, name):
+    """A component whose event watches a topic served by the plugin."""
+    from ros_sugar.core.action import Action
+    from ros_sugar.core.component import BaseComponent
+    from ros_sugar.core.event import Event
+
+    component = BaseComponent(component_name=name, inputs=[topic])
+    component.rclpy_init_node()
+    component._robot_plugin = plugin
+    component._use_robot_plugin()
+    component._add_event_action_pair(
+        Event(topic.msg.data > 10), Action(method=lambda: None)
+    )
+    return component
+
+
+def test_event_on_plugin_topic_creates_no_ros_subscription(rclpy_context):
+    """The data never travels over ROS, so a ROS subscription would sit empty."""
+    plugin = MockPlugin(state_port=_free_port(), cmd_port=_free_port())
+    host = RobotPluginHost(plugin, node=None, bus=InProcessFeedbackBus())
+    host.open()
+
+    topic = Topic(name="robot_state", msg_type="Int32", use_plugin=True)
+    component = _event_component(plugin, topic, "plugin_event_no_sub")
+    try:
+        component._turn_on_events_management()
+        assert component._external_topics == {"robot_state"}
+        assert component._BaseComponent__event_listeners == [], (
+            "a plugin-fed event topic must not get a dead ROS subscription"
+        )
+    finally:
+        host.close()
+        component.destroy_node()
+
+
+def test_event_on_plugin_topic_fires_from_feedback_bus(rclpy_context):
+    """Regression: events on plugin feedback never fired, because the component
+    only ever subscribed to ROS."""
+    state_port = _free_port()
+    plugin = MockPlugin(state_port=state_port, cmd_port=_free_port())
+    host = RobotPluginHost(plugin, node=None, bus=InProcessFeedbackBus())
+    host.open()
+
+    topic = Topic(name="robot_state", msg_type="Int32", use_plugin=True)
+    component = _event_component(plugin, topic, "plugin_event_bus")
+    try:
+        component._turn_on_events_management()
+
+        robot_tx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        robot_tx.sendto(b"55", ("127.0.0.1", state_port))
+        deadline = time.time() + 2.0
+        while (
+            "robot_state" not in component._events_topics_blackboard
+            and time.time() < deadline
+        ):
+            time.sleep(0.02)
+        robot_tx.close()
+
+        entry = component._events_topics_blackboard.get("robot_state")
+        assert entry is not None, "plugin feedback never reached the event handler"
+        assert entry.msg.data == 55
+    finally:
+        host.close()
+        component.destroy_node()
+
+
+# ---------------------------------------------------------------------------
+# plugin-supplied robot description
+# ---------------------------------------------------------------------------
+
+
+class _DescribingPlugin(RobotPlugin):
+    """A plugin that knows the robot it drives."""
+
+    def __init__(self):
+        from ros_sugar.config import (
+            AngularCtrlLimits,
+            LinearCtrlLimits,
+            RobotConfig,
+            RobotGeometryType,
+            RobotType,
+        )
+        import numpy as np
+
+        self.metadata = PluginMetadata(name="DescribingPlugin")
+        self.robot_config = RobotConfig(
+            model_type=RobotType.DIFFERENTIAL_DRIVE,
+            geometry_type=RobotGeometryType.BOX,
+            geometry_params=np.array([0.61, 0.37, 0.4]),
+            ctrl_vx_limits=LinearCtrlLimits(max_vel=1.0, max_acc=2.5, max_decel=7.5),
+            ctrl_omega_limits=AngularCtrlLimits(
+                max_vel=1.5, max_acc=2.5, max_decel=4.0, max_steer=1.57
+            ),
+        )
+        self.base_frame = "lite3_base"
+
+
+def test_plugin_describes_robot_via_declared_fields():
+    """Both are declared members, so a plugin author has something to populate
+    and the launcher has something to type against."""
+    plugin = _DescribingPlugin()
+    assert plugin.robot_config is not None
+    assert plugin.base_frame == "lite3_base"
+
+    bare = MockPlugin(state_port=_free_port(), cmd_port=_free_port())
+    assert bare.robot_config is None and bare.base_frame is None
+
+
+def test_plugin_base_frame_applied_but_not_world_frame():
+    """A robot knows its own body frame; where it has been placed is not its
+    call, so the world frame must be left alone."""
+    from ros_sugar import Launcher
+
+    launcher = Launcher(robot_plugin=_DescribingPlugin())
+    comp = _FakeComponent("base_frame_component")
+    launcher._components = [comp]
+
+    launcher._apply_plugin_robot_config()
+    launcher._apply_plugin_base_frame()
+
+    assert comp.config.robot is not None
+    assert comp.config.frames.robot_base == "lite3_base"
+    assert comp.config.frames.world == "map", "world frame is not the robot's to set"
+
+
+def test_recipe_frames_win_over_plugin_base_frame():
+    from ros_sugar import Launcher
+    from ros_sugar.config import RobotFrames
+
+    launcher = Launcher(robot_plugin=_DescribingPlugin())
+    comp = _FakeComponent("recipe_wins_component")
+    launcher._components = [comp]
+
+    launcher.frames = RobotFrames(robot_base="from_recipe", world="office")
+    launcher._apply_plugin_base_frame()  # would normally fire at bringup
+
+    assert comp.config.frames.robot_base == "from_recipe"
+    assert comp.config.frames.world == "office"
+
+
+def test_plugin_without_base_frame_leaves_frames_untouched():
+    from ros_sugar import Launcher
+
+    launcher = Launcher(robot_plugin=MockPlugin(
+        state_port=_free_port(), cmd_port=_free_port()
+    ))
+    comp = _FakeComponent("no_base_frame_component")
+    launcher._components = [comp]
+
+    launcher._apply_plugin_base_frame()
+
+    assert comp.config.frames.robot_base == "base_link"

--- a/test/robot_plugin_test.py
+++ b/test/robot_plugin_test.py
@@ -1188,19 +1188,94 @@ def test_plugin_base_frame_applied_but_not_world_frame():
     assert comp.config.frames.world == "map", "world frame is not the robot's to set"
 
 
-def test_recipe_frames_win_over_plugin_base_frame():
+def test_plugin_base_frame_wins_over_recipe():
+    """The plugin stamps its telemetry in its own body frame and mounts are
+    parented on it, so a recipe cannot rename it from the outside."""
     from ros_sugar import Launcher
     from ros_sugar.config import RobotFrames
 
     launcher = Launcher(robot_plugin=_DescribingPlugin())
-    comp = _FakeComponent("recipe_wins_component")
+    comp = _FakeComponent("plugin_wins_component")
     launcher._components = [comp]
 
     launcher.frames = RobotFrames(robot_base="from_recipe", world="office")
     launcher._apply_plugin_base_frame()  # would normally fire at bringup
 
-    assert comp.config.frames.robot_base == "from_recipe"
-    assert comp.config.frames.world == "office"
+    assert comp.config.frames.robot_base == "lite3_base"
+    assert comp.config.frames.world == "office", "world is still the recipe's"
+
+
+def test_naming_only_the_world_frame_keeps_the_plugin_base_frame():
+    """The regression this precedence exists for: a recipe that assigns
+    `frames` to choose a world frame used to silently drop the plugin's body
+    frame, leaving mounts parented on a frame nothing looked up."""
+    from ros_sugar import Launcher
+    from ros_sugar.config import RobotFrames
+
+    launcher = Launcher(robot_plugin=_DescribingPlugin())
+    comp = _FakeComponent("world_only_component")
+    launcher._components = [comp]
+
+    launcher.frames = RobotFrames(world="odom")
+    launcher._apply_plugin_base_frame()
+
+    assert comp.config.frames.robot_base == "lite3_base"
+    assert comp.config.frames.world == "odom"
+
+
+def test_renaming_the_frame_on_the_plugin_is_the_way_to_override():
+    """The escape hatch: rename it where telemetry and mounts both read it."""
+    from ros_sugar import Launcher
+
+    plugin = _DescribingPlugin()
+    plugin.base_frame = "base_link"
+    launcher = Launcher(robot_plugin=plugin)
+    comp = _FakeComponent("renamed_frame_component")
+    launcher._components = [comp]
+
+    launcher._apply_plugin_base_frame()
+
+    assert comp.config.frames.robot_base == "base_link"
+
+
+def test_world_frame_setter_leaves_the_robot_frame_alone():
+    from ros_sugar import Launcher
+
+    launcher = Launcher(robot_plugin=_DescribingPlugin())
+    comp = _FakeComponent("world_setter_component")
+    launcher._components = [comp]
+
+    launcher.world_frame = "odom"
+    launcher._apply_plugin_base_frame()
+
+    assert comp.config.frames.world == "odom"
+    assert comp.config.frames.robot_base == "lite3_base"
+    assert launcher.world_frame == {"world_setter_component": "odom"}
+
+
+def test_robot_frame_setter_applies_without_a_plugin():
+    from ros_sugar import Launcher
+
+    launcher = Launcher()
+    comp = _FakeComponent("robot_setter_component")
+    launcher._components = [comp]
+
+    launcher.robot_frame = "chassis"
+    launcher._apply_plugin_base_frame()  # no plugin attached, so a no-op
+
+    assert comp.config.frames.robot_base == "chassis"
+    assert launcher.robot_frame == {"robot_setter_component": "chassis"}
+
+
+@pytest.mark.parametrize("bad", ["", None, 3])
+def test_frame_setters_reject_non_frame_names(bad):
+    from ros_sugar import Launcher
+
+    launcher = Launcher()
+    launcher._components = [_FakeComponent("bad_frame_component")]
+
+    with pytest.raises(ValueError):
+        launcher.world_frame = bad
 
 
 def test_plugin_without_base_frame_leaves_frames_untouched():
@@ -2083,7 +2158,12 @@ def test_mounts_are_published_as_static_transforms(rclpy_context):
     )
 
     launcher = _launcher_with([])
+    # The real Monitor is not rclpy-initialized when mounts are registered, so
+    # it only holds them; a live node stands in for the broadcast half here.
     launcher.monitor_node = publisher_node
+    publisher_node.set_static_transforms = lambda t: setattr(
+        publisher_node, "_pending", t
+    )
 
     robot = MockPlugin(state_port=_free_port(), cmd_port=_free_port(), id="lite3")
     robot.base_frame = "base_link"
@@ -2096,6 +2176,15 @@ def test_mounts_are_published_as_static_transforms(rclpy_context):
 
     try:
         launcher._publish_mounts()
+
+        # what Monitor.activate() does once the node is up
+        from tf2_ros import StaticTransformBroadcaster
+
+        stamp = publisher_node.get_clock().now().to_msg()
+        for transform in publisher_node._pending:
+            transform.header.stamp = stamp
+        broadcaster = StaticTransformBroadcaster(publisher_node)
+        broadcaster.sendTransform(publisher_node._pending)
 
         deadline = time.time() + 3.0
         while not received and time.time() < deadline:
@@ -2122,8 +2211,9 @@ def test_publishing_mounts_is_a_noop_without_any(rclpy_context):
     node = Node("no_mounts")
     launcher = _launcher_with([])
     launcher.monitor_node = node
+    node.set_static_transforms = lambda t: setattr(node, "_pending", t)
     try:
-        launcher._publish_mounts()  # must not create a broadcaster or raise
-        assert not hasattr(launcher, "_static_tf_broadcaster")
+        launcher._publish_mounts()  # must not register anything or raise
+        assert not hasattr(node, "_pending")
     finally:
         node.destroy_node()

--- a/test/robot_plugin_test.py
+++ b/test/robot_plugin_test.py
@@ -1185,6 +1185,115 @@ def test_event_on_plugin_topic_fires_from_feedback_bus(rclpy_context):
         component.destroy_node()
 
 
+def test_event_on_a_sensor_topic_binds_to_that_sensor(rclpy_context):
+    """Regression: the event path resolved against the robot plugin whatever
+    the topic named, so a sensor's event fired on the robot's telemetry."""
+    from ros_sugar.core.action import Action
+    from ros_sugar.core.component import BaseComponent
+    from ros_sugar.core.event import Event
+
+    robot_port, cam_port = _free_port(), _free_port()
+    robot = MockPlugin(state_port=robot_port, cmd_port=_free_port(), id="lite3")
+    camera = MockUdpSensor(state_port=cam_port, id="front_cam")
+    robot._bind_identity()
+    camera._bind_identity()
+
+    bus = InProcessFeedbackBus()
+    bus.start()
+    hosts = [
+        RobotPluginHost(p, node=None, bus=bus, owns_bus=False) for p in (robot, camera)
+    ]
+    for host in hosts:
+        host.open()
+
+    topic = Topic(name="cam_state", msg_type="Int32", use_plugin=camera.id)
+    component = BaseComponent(component_name="sensor_event", inputs=[topic])
+    component.rclpy_init_node()
+    component.add_plugin(robot)
+    component.add_plugin(camera)
+    try:
+        component._use_robot_plugin()
+        component._add_event_action_pair(
+            Event(topic.msg.data > 10), Action(method=lambda: None)
+        )
+        component._turn_on_events_management()
+
+        # Only the robot transmits. Resolving against the robot plugin would
+        # deliver its telemetry to the camera's event.
+        tx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        tx.sendto(b"55", ("127.0.0.1", robot_port))
+        time.sleep(0.5)
+        assert component._events_topics_blackboard.get("cam_state") is None, (
+            "the camera's event received the robot's telemetry"
+        )
+
+        # The camera's own data does reach it
+        tx.sendto(b"22", ("127.0.0.1", cam_port))
+        deadline = time.time() + 2.0
+        while (
+            "cam_state" not in component._events_topics_blackboard
+            and time.time() < deadline
+        ):
+            time.sleep(0.02)
+        tx.close()
+
+        entry = component._events_topics_blackboard.get("cam_state")
+        assert entry is not None, "the camera's feedback never reached its event"
+        assert entry.msg.data == 22
+    finally:
+        for host in hosts:
+            host.close()
+        bus.close()
+        component.destroy_node()
+
+
+def test_event_on_a_sensor_topic_binds_with_no_robot_plugin(rclpy_context):
+    """A sensor-only recipe has no robot plugin, which used to mean the event
+    path returned early and wired up nothing at all -- silently."""
+    from ros_sugar.core.action import Action
+    from ros_sugar.core.component import BaseComponent
+    from ros_sugar.core.event import Event
+
+    cam_port = _free_port()
+    camera = MockUdpSensor(state_port=cam_port, id="front_cam")
+    camera._bind_identity()
+
+    bus = InProcessFeedbackBus()
+    bus.start()
+    host = RobotPluginHost(camera, node=None, bus=bus, owns_bus=False)
+    host.open()
+
+    topic = Topic(name="cam_state", msg_type="Int32", use_plugin=camera.id)
+    component = BaseComponent(component_name="sensor_only_event", inputs=[topic])
+    component.rclpy_init_node()
+    component.add_plugin(camera)
+    try:
+        assert component._robot_plugin is None, "no robot plugin in this recipe"
+        component._use_robot_plugin()
+        component._add_event_action_pair(
+            Event(topic.msg.data > 10), Action(method=lambda: None)
+        )
+        component._turn_on_events_management()
+
+        tx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        tx.sendto(b"22", ("127.0.0.1", cam_port))
+        deadline = time.time() + 2.0
+        while (
+            "cam_state" not in component._events_topics_blackboard
+            and time.time() < deadline
+        ):
+            time.sleep(0.02)
+        tx.close()
+
+        entry = component._events_topics_blackboard.get("cam_state")
+        assert entry is not None, "sensor event got no listeners at all"
+        assert entry.msg.data == 22
+    finally:
+        host.close()
+        bus.close()
+        component.destroy_node()
+
+
 # ---------------------------------------------------------------------------
 # plugin-supplied robot description
 # ---------------------------------------------------------------------------

--- a/test/tf_lifecycle_test.py
+++ b/test/tf_lifecycle_test.py
@@ -131,6 +131,41 @@ def test_resolved_transforms_survive_a_restart(component):
     assert dynamic.transform.transform.translation.x == 5.0
 
 
+def test_same_frame_lookup_resolves_to_identity_without_polling(component):
+    """Source and goal being the same frame is a normal configuration -- data
+    that already arrives where it is wanted -- not a missing transform. It must
+    not spin a timer or leave callers waiting on a lookup that could only ever
+    return the identity."""
+    listener = component.get_transform_listener("map", "map")
+
+    assert listener.is_identity
+    assert listener.got_transform, "callers poll this and would wait forever"
+    assert listener.timer is None, "nothing to look up, so nothing to poll"
+    assert listener.transform.header.frame_id == "map"
+    assert listener.translation == pytest.approx([0.0, 0.0, 0.0])
+    assert listener.rotation == pytest.approx([0.0, 0.0, 0.0, 1.0])
+
+
+def test_same_frame_listener_survives_the_lifecycle(component):
+    """It has no timer, so pause/resume must step over it rather than trip."""
+    listener = component.get_transform_listener("map", "map")
+
+    component.deactivate()
+    component.activate()
+
+    assert listener.got_transform
+    assert component.get_transform_listener("map", "map") is listener
+
+
+def test_distinct_frames_still_poll(component):
+    """The identity shortcut must not swallow a real lookup."""
+    listener = component.get_transform_listener("odom", "map")
+
+    assert not listener.is_identity
+    assert not listener.got_transform
+    assert listener.timer is not None
+
+
 def test_no_tf_machinery_is_created_when_unused(component):
     """A component that never asks for a transform should not pay for a buffer
     or the /tf and /tf_static subscriptions that come with it."""


### PR DESCRIPTION
## Why

Deployments are not always one-robot-shaped. A mobile robot gets an inspection camera bolted on after the fact, for example. These additional sensors can have not just feedback but also a control surface, telemetry, actions and events (exactly what a plugin already models), but today only one could attach, so the rest fell back to hand-wired ROS topics.

This PR lifts the singleton. A recipe now attaches any number of plugins, each addressable by id, sharing one feedback bus, and each able to say where it sits on the robot.

## Multi-plugin

- **Taxonomy** — generic `Plugin` base, with `RobotPlugin` / `SensorPlugin`. Role is intrinsic (`_role`), never passed by a recipe.
- **Identity** — `Plugin.id` addresses a plugin and namespaces its channels as `plugin/<id>/feedback/<key>`; the bare form is kept when the id is empty, so single-plugin setups are untouched. `owner_id` is a declared attrs field —
  `Feedback`/`RobotCommand` are slotted and could not be stamped on.
- **Shared bus** — owned by the launcher, not the hosts. 
- **`Topic.use_plugin: Union[bool, str]`** — `True` means the robot plugin, a string names one by id. Unknown ids fail at bringup.
- **`Mount`** — recipe-level static TF, broadcast by the Monitor as one batched `TransformStamped[]` on latched `/tf_static`.
- **Frames** — the plugin's `base_frame` now wins, and `launcher.world_frame` /  `launcher.robot_frame` set one field each.
- **`on_detached`** — teardown hook called before transports close, so a plugin can quiesce hardware. A lidar keeps spinning when its port closes.
- **Events on plugin-fed topics** now route through the bus instead of creating a dead ROS subscription that never fires.

## Sensor data paths

- **Fixes #59** — `PointCloudCallback` discarded its filtering kwargs through a permissive `**_` and never applied its `transformation`, so components asking for body-frame data silently got sensor-frame clouds. `min_z`, `max_z`,
  `discard_underground` and `get_2d` are implemented, the transform is applied, and `**_` is gone from both cloud and scan callbacks. Both rebuild the **raw buffer**, not just the decoded `xyz` — the safety-critical consumers read
  `data`/offsets directly and never touch `xyz`.
- **Transformations for `Path` and `OccupancyGrid`**, so every spatial input honors the frame its component asked for.
- **Zero-copy contract** — float32 and C-contiguity pinned by tests for every array crossing into kompass-core. 
- **`Range`** added as a supported type.

## Also here

`BaseAttrs.explicit_fields` (tuned algorithm params no longer revert to defaults across the multiprocess boundary), no TF listener when source and goal frames match, plus fixes for event action logging and two UI video rendering bugs.

## Breaking

- A robot plugin's `base_frame` overrides `launcher.frames.robot_base` (warns).
- Channels gain a `plugin/<id>/` prefix once a plugin has a non-empty id.
- `component._robot_plugin` is a property over `_plugins`.
- The cloud and scan `get_output` reject unknown kwargs instead of ignoring them.
